### PR TITLE
Parameterize configs

### DIFF
--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -20,6 +20,8 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     private final RiskFilter riskFilter;
     private final NearMissLogger nearMissLogger;
     private final ResumeHandler resumeHandler;
+    private final String redisHost;
+    private final int redisPort;
     private Connection dbConnection;
     private TradeLogger tradeLogger;
 
@@ -31,9 +33,11 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     private long cumulativeLatencyMs;
     private boolean isPanic;
 
-    public Executor(RedisClient redisClient, RiskFilter riskFilter, NearMissLogger nearMissLogger) {
+    public Executor(RedisClient redisClient, String redisHost, int redisPort, RiskFilter riskFilter, NearMissLogger nearMissLogger) {
         this.redisClient = redisClient;
-        this.resumeHandler = new ResumeHandler(new redis.clients.jedis.Jedis("localhost", 6379), this);
+        this.redisHost = redisHost;
+        this.redisPort = redisPort;
+        this.resumeHandler = new ResumeHandler(new redis.clients.jedis.Jedis(redisHost, redisPort), this);
         this.riskFilter = riskFilter;
         this.nearMissLogger = nearMissLogger;
     }

--- a/executor/src/main/java/Main.java
+++ b/executor/src/main/java/Main.java
@@ -10,6 +10,11 @@ public class Main {
         int redisPort = Integer.parseInt(System.getenv().getOrDefault("REDIS_PORT", "6379"));
         String redisChannel = System.getenv().getOrDefault("REDIS_CHANNEL", "spreads");
 
+        double startingBalance = Double.parseDouble(System.getenv().getOrDefault("STARTING_BALANCE", "10000"));
+        String analyticsUrl = System.getenv().getOrDefault("ANALYTICS_URL", "http://localhost:5000/trade");
+
+        ProfitTracker.init(startingBalance, analyticsUrl);
+
         Connection conn = null;
         try {
             String host = System.getenv().getOrDefault("PGHOST", "localhost");
@@ -31,7 +36,7 @@ public class Main {
         RedisClient redisClient = new RedisClient(redisHost, redisPort, redisChannel,
                 (ch, msg) -> holder[0].handleMessage(msg));
 
-        holder[0] = new Executor(redisClient, riskFilter, nearMissLogger);
+        holder[0] = new Executor(redisClient, redisHost, redisPort, riskFilter, nearMissLogger);
         holder[0].start();
     }
 }

--- a/executor/src/main/java/ProfitTracker.java
+++ b/executor/src/main/java/ProfitTracker.java
@@ -11,6 +11,21 @@ public class ProfitTracker {
     private static double globalTotal = 0.0;
     private static double dailyTotal = 0.0;
 
+    private static double startingBalance = 10_000.0;
+    private static String analyticsUrl = "http://localhost:5000/trade";
+
+    /**
+     * Initialize the tracker with starting capital and analytics endpoint.
+     *
+     * @param startBalance initial account balance used for loss calculations
+     * @param url analytics endpoint to send trade PnL data
+     */
+    public static void init(double startBalance, String url) {
+        startingBalance = startBalance;
+        analyticsUrl = url;
+        logger.info("ProfitTracker initialized: startingBalance={}, analyticsUrl={}", startBalance, url);
+    }
+
     /**
      * Record profit or loss from a trade.
      * Updates both the daily total and the global total.
@@ -21,7 +36,7 @@ public class ProfitTracker {
         dailyTotal += pnl;
         globalTotal += pnl;
         try {
-            URL url = new URL("http://localhost:5000/trade");
+            URL url = new URL(analyticsUrl);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
@@ -41,13 +56,11 @@ public class ProfitTracker {
     }
 
     /**
-     * Get today's loss as a percentage of starting capital.
-     * For simplicity we assume a fixed starting balance of $10,000.
+     * Get today's loss as a percentage of the configured starting capital.
      *
      * @param pnl profit (positive) or loss (negative)
      */
     public static double getDailyLossPct() {
-        double startingBalance = 10_000.0;
         if (dailyTotal >= 0) {
             return 0.0;
         }


### PR DESCRIPTION
## Summary
- read ProfitTracker analytics URL and starting balance from env
- initialize ProfitTracker in Main
- read Redis host/port for ResumeHandler from env

## Testing
- `npx jest` *(fails: Need to install packages)*
- `pytest` *(fails: ModuleNotFoundError: numpy)*
- `./executor/gradlew test` *(fails: Invalid or corrupt jarfile)*

------
https://chatgpt.com/codex/tasks/task_b_6869402f3624832c8a6c9ac39732eb3b