### PR TITLE
Update Gradle wrapper guide

### DIFF
--- a/docs/gradle-wrapper-guide.MD
+++ b/docs/gradle-wrapper-guide.MD
@@ -11,19 +11,16 @@ This guide explains how to regenerate the Gradle wrapper inside the `executor` m
    gradle wrapper --gradle-version 8.14
    ```
    This updates `gradlew`, `gradlew.bat`, and the files under `gradle/wrapper/`.
-3. **Ignore the wrapper JAR** so you don't commit the binary:
-   ```bash
-   echo "executor/gradle/wrapper/gradle-wrapper.jar" >> ../.gitignore
-   git rm --cached gradle/wrapper/gradle-wrapper.jar 2>/dev/null || true
-   ```
+3. **Include the wrapper JAR** so builds remain reproducible. The file should
+   stay under version control.
 4. **Run the unit tests** to confirm everything works:
    ```bash
    ./gradlew test
    ```
-5. **Commit the changes** without the JAR:
+5. **Commit the changes**, including the wrapper JAR:
    ```bash
-   git add gradlew gradlew.bat gradle/wrapper/gradle-wrapper.properties ../.gitignore
-   git commit -m "Regenerate Gradle wrapper and ignore jar"
+   git add gradlew gradlew.bat gradle/wrapper/gradle-wrapper.properties gradle/wrapper/gradle-wrapper.jar
+   git commit -m "Regenerate Gradle wrapper"
    ```
 
 After committing, push your branch and open a pull request.


### PR DESCRIPTION
## Summary
- edit Gradle wrapper guide to keep the wrapper JAR in version control

## Testing
- `npm test`
- `npm test` in `api` *(fails: Cannot find module 'jest')*
- `npm test` in `dashboard` *(fails: jest: not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `./gradlew test` in executor *(fails: invalid or corrupt jarfile)*

------
https://chatgpt.com/codex/tasks/task_b_686bc92fcbe0832cb0ea5889c584ed79