### PR TITLE
Fix multiple prod scripts and validation

### DIFF
--- a/analytics/app.py
+++ b/analytics/app.py
@@ -161,6 +161,15 @@ def predict():
         if len(features.shape) == 1:
             features = features.reshape(1, -1)
 
+        expected_shape = None
+        if hasattr(model, "input_shape"):
+            expected_shape = tuple(model.input_shape[1:])
+        elif hasattr(model, "n_features_in_"):
+            expected_shape = (int(model.n_features_in_),)
+        if expected_shape and tuple(features.shape[1:]) != expected_shape:
+            logger.warning("Invalid input shape: expected %s, got %s", expected_shape, features.shape)
+            return jsonify({'error': 'invalid input shape'}), 400
+
         logger.info("Input shape: %s", features.shape)
         preds = model.predict(features)
         logger.info("Output shape: %s", np.array(preds).shape)

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -63,7 +63,7 @@ log "Deploying flannel CNI"
 kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 
 log "Applying NVIDIA GPU plugin"
-kubectl apply -f "$ROOT_DIR/infra/k8s/gpu-plugin.yaml"
+kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.12.3/nvidia-device-plugin.yml
 
 log "Deploying Kubernetes manifests"
 for manifest in "$ROOT_DIR/infra/k8s"/*.yaml; do
@@ -72,5 +72,5 @@ for manifest in "$ROOT_DIR/infra/k8s"/*.yaml; do
 done
 
 log "Deploying Helm chart"
-helm upgrade --install crypto-arbitrage "$ROOT_DIR/infra/helm" \
+helm install prism-arbitrage "$ROOT_DIR/infra/helm" \
   --namespace arbitrage --create-namespace

--- a/scripts/ops-tools.sh
+++ b/scripts/ops-tools.sh
@@ -47,7 +47,8 @@ case "$cmd" in
     ;;
   backup)
     pod=$(kubectl get pods -n "$NAMESPACE" -l app=postgres -o jsonpath='{.items[0].metadata.name}')
-    kubectl exec -n "$NAMESPACE" "$pod" -- pg_dump -U postgres -d arbdb > "$ROOT_DIR/postgres-backup.sql"
+    ts=$(date +%Y%m%d%H%M%S)
+    kubectl exec -n "$NAMESPACE" "$pod" -- pg_dump -U postgres -d arbdb > "$ROOT_DIR/postgres-backup-$ts.sql"
     ;;
   *)
     usage

--- a/test/verify-env.sh
+++ b/test/verify-env.sh
@@ -1,40 +1,26 @@
 #!/bin/bash
-# verify-env.sh - Check if key toolchains are installed
-#
-# Usage: bash test/verify-env.sh
-#
-# This script checks versions of Jest, PyTest, and Maven. If any check
-# fails, the script exits with a non-zero status. Maven is required only
-# if a `pom.xml` file exists in the project.
+# verify-env.sh - Ensure Jest, PyTest and Maven are available
 
-set -e
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-
-# Check Jest via npx
-npx -y jest --version >/dev/null 2>&1 || {
-  echo "Error: Jest is not installed or not accessible via npx" >&2
+# Check Jest
+if ! npx -y jest --version >/dev/null 2>&1; then
+  echo "Error: Jest not found" >&2
   exit 1
-}
+fi
 
 # Check PyTest
-pytest --version >/dev/null 2>&1 || {
-  echo "Error: PyTest is not installed" >&2
+if ! pytest --version >/dev/null 2>&1; then
+  echo "Error: PyTest not found" >&2
   exit 1
-}
+fi
 
-# Check Maven only if the project uses it (presence of pom.xml)
-if find "${REPO_ROOT}" -name pom.xml | grep -q pom.xml; then
-  if mvn -v >/dev/null 2>&1; then
-    echo "Maven found"
-  else
-    echo "Error: Maven is required but not installed" >&2
+# Check Maven if project uses pom.xml
+if find "$(dirname "$0")/.." -name pom.xml | grep -q pom.xml; then
+  if ! mvn -v >/dev/null 2>&1; then
+    echo "Error: Maven not installed" >&2
     exit 1
   fi
-else
-  echo "Maven not required"
 fi
 
 echo "Environment verified"
-


### PR DESCRIPTION
## Summary
- add shape validation to `/predict` endpoint
- timestamp Postgres backups via ops-tools CLI
- deploy NVIDIA device plugin from remote YAML
- helm install `prism-arbitrage`
- check Jest, PyTest and Maven with `verify-env.sh`
- pre-push hook executes npm, PyTest and Maven suites

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError)*
- `mvn test` *(fails: no POM found)*

------
https://chatgpt.com/codex/tasks/task_b_6872e96624e0832ca822e25f40bc6ede