### PR TITLE
batch-1-fix-3

### DIFF
--- a/api/services/alertManager.js
+++ b/api/services/alertManager.js
@@ -16,36 +16,46 @@ function hasWebhookConfig() {
 }
 
 async function sendAlert(type, message) {
-  try {
-    switch (type) {
-      case 'email':
-        if (!hasEmailConfig()) {
-          logger.warn('Email alert skipped: missing SMTP config');
-          return;
-        }
-        await sendEmail('Crypto Alert', message);
-        break;
-      case 'telegram':
-        if (!hasTelegramConfig()) {
-          logger.warn('Telegram alert skipped: missing Telegram config');
-          return;
-        }
-        await sendTelegram(message);
-        break;
-      case 'webhook':
-        if (!hasWebhookConfig()) {
-          logger.warn('Webhook alert skipped: missing WEBHOOK_URL');
-          return;
-        }
-        await sendWebhook(message);
-        break;
-      default:
-        logger.warn(`Unknown alert type: ${type}`);
+  switch (type) {
+    case 'email':
+      if (!hasEmailConfig()) {
+        logger.warn('Email alert skipped: missing SMTP config');
         return;
-    }
-    logger.info(`Alert dispatched via ${type}`);
-  } catch (err) {
-    logger.error(`Failed to send ${type} alert: ${err.message}`);
+      }
+      try {
+        await sendEmail('Crypto Alert', message);
+        logger.info('Email alert sent');
+      } catch (err) {
+        logger.error(`Email alert failed: ${err.message}`);
+      }
+      break;
+    case 'telegram':
+      if (!hasTelegramConfig()) {
+        logger.warn('Telegram alert skipped: missing Telegram config');
+        return;
+      }
+      try {
+        await sendTelegram(message);
+        logger.info('Telegram alert sent');
+      } catch (err) {
+        logger.error(`Telegram alert failed: ${err.message}`);
+      }
+      break;
+    case 'webhook':
+      if (!hasWebhookConfig()) {
+        logger.warn('Webhook alert skipped: missing WEBHOOK_URL');
+        return;
+      }
+      try {
+        await sendWebhook(message);
+        logger.info('Webhook alert sent');
+      } catch (err) {
+        logger.error(`Webhook alert failed: ${err.message}`);
+      }
+      break;
+    default:
+      logger.warn(`Unknown alert type: ${type}`);
+      return;
   }
 }
 

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -160,12 +160,12 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
      * @param message JSON encoded opportunity
      */
     public void handleMessage(String message) {
-        if (circuitBreaker.isTripped()) {
-            logger.warn("Trading halted due to circuit breaker.");
-            return;
-        }
         if (isPanic) {
             logger.warn("Trading halted due to panic brake.");
+            return;
+        }
+        if (circuitBreaker.isTripped()) {
+            logger.warn("Trading halted due to circuit breaker.");
             return;
         }
 
@@ -204,6 +204,11 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
 
         if (canaryMode) {
             logger.info("CANARY MODE — trade bypassed");
+            return;
+        }
+
+        if (isPanic) {
+            logger.warn("Panic brake active; skipping execution.");
             return;
         }
 

--- a/infra/helm/templates/sealed-secret.yaml
+++ b/infra/helm/templates/sealed-secret.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: default
 spec:
   encryptedData:
-    binanceKey: AgBINANCEKEYPLACEHOLDER
-    gmailPassword: AgGMAILPASSWORDPLACEHOLDER
-    telegramToken: AgTELEGRAMTOKENPLACEHOLDER
+    binanceKey: AgFAKEENCRYPTEDBINANCEKEY
+    gmailPassword: AgFAKEENCRYPTEDGMAILPASS
+    telegramToken: AgFAKEENCRYPTEDTELEGRAMTOKEN

--- a/infra/k8s/sealed-secret.yaml
+++ b/infra/k8s/sealed-secret.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: default
 spec:
   encryptedData:
-    binanceKey: AgBINANCEKEYPLACEHOLDER
-    gmailPassword: AgGMAILPASSWORDPLACEHOLDER
-    telegramToken: AgTELEGRAMTOKENPLACEHOLDER
+    binanceKey: AgFAKEENCRYPTEDBINANCEKEY
+    gmailPassword: AgFAKEENCRYPTEDGMAILPASS
+    telegramToken: AgFAKEENCRYPTEDTELEGRAMTOKEN


### PR DESCRIPTION
## Summary
- add per-channel success/fail logging for alerts
- reconnect ResumeHandler on Redis failure
- skip trades when panic brake active
- export inference latency metric and guard model load with logging
- provide placeholder encrypted values for sealed secrets

## Testing
- `npx jest --runInBand --passWithNoTests` *(fails: Test suite failed to run)*
- `npx jest --runInBand --passWithNoTests` in dashboard *(fails: jest-environment-jsdom missing)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `./gradlew test --quiet` *(fails: compilation failed)*

------
https://chatgpt.com/codex/tasks/task_b_6872f0fecd10832ca429cb4eb4b72e24