### PR TITLE
Add environment tags and filtering

### DIFF
--- a/analytics/test_from_redis.py
+++ b/analytics/test_from_redis.py
@@ -1,5 +1,8 @@
 import numpy as np
+import pytest
 from analytics.redis_retrain import prepare_sequences
+
+pytestmark = pytest.mark.env("local")
 
 def test_prepare_sequences_returns_correct_shapes():
     spreads = np.linspace(-1, 1, 15, dtype=np.float32)

--- a/analytics/test_predict.py
+++ b/analytics/test_predict.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytestmark = pytest.mark.env("local")
+
+
 def test_predict_returns_valid_shape(analytics_app):
     client = analytics_app.app.test_client()
     payload = {"features": [1.23, 4.56]}

--- a/analytics/test_stats.py
+++ b/analytics/test_stats.py
@@ -1,4 +1,7 @@
+import pytest
 from pytest import approx
+
+pytestmark = pytest.mark.env("local")
 
 def test_stats_endpoint_returns_metrics(analytics_app):
     analytics_app.trades.clear()

--- a/api/__tests__/api.test.js
+++ b/api/__tests__/api.test.js
@@ -1,4 +1,6 @@
 import request from 'supertest';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 process.env.NODE_ENV = 'test';
 process.env.ADMIN_TOKEN = 'testadmintoken';
 process.env.SANDBOX_MODE = 'true';
@@ -11,7 +13,7 @@ beforeAll(async () => {
   await app.listen({ port: 8080 });
 });
 
-describe('API authentication', () => {
+describeLocal('API authentication', () => {
   test('/login returns a cookie', async () => {
     const res = await request(app.server)
       .post('/api/login')

--- a/api/__tests__/panicResume.test.js
+++ b/api/__tests__/panicResume.test.js
@@ -1,4 +1,6 @@
 import request from 'supertest';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 process.env.NODE_ENV = 'test';
 let buildApp;
 let testState;
@@ -14,19 +16,21 @@ afterAll(async () => {
   await app.close();
 });
 
-test('panic and resume cycle updates metrics', async () => {
-  const panicRes = await request(app.server).post('/api/test/panic');
-  expect(panicRes.statusCode).toBe(200);
-  expect(testState.panic).toBe(true);
+describeLocal('panic resume cycle', () => {
+  test('panic and resume cycle updates metrics', async () => {
+    const panicRes = await request(app.server).post('/api/test/panic');
+    expect(panicRes.statusCode).toBe(200);
+    expect(testState.panic).toBe(true);
 
-  const metrics1 = await request(app.server).get('/api/metrics');
-  expect(metrics1.body.panicActive).toBe(true);
+    const metrics1 = await request(app.server).get('/api/metrics');
+    expect(metrics1.body.panicActive).toBe(true);
 
-  const resumeRes = await request(app.server).post('/api/resume');
-  expect(resumeRes.statusCode).toBe(200);
-  expect(testState.panic).toBe(false);
+    const resumeRes = await request(app.server).post('/api/resume');
+    expect(resumeRes.statusCode).toBe(200);
+    expect(testState.panic).toBe(false);
 
-  const metrics2 = await request(app.server).get('/api/metrics');
-  expect(metrics2.body.panicActive).toBe(false);
+    const metrics2 = await request(app.server).get('/api/metrics');
+    expect(metrics2.body.panicActive).toBe(false);
+  });
 });
 

--- a/api/__tests__/settings.validation.test.js
+++ b/api/__tests__/settings.validation.test.js
@@ -1,4 +1,6 @@
 import request from 'supertest';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 process.env.NODE_ENV = 'test';
 process.env.SANDBOX_MODE = 'true';
 let buildApp;
@@ -19,7 +21,7 @@ afterAll(async () => {
   await app.close();
 });
 
-describe('settings validation', () => {
+describeLocal('settings validation', () => {
   test('rejects unknown properties', async () => {
     const res = await request(app.server)
       .patch('/api/settings')

--- a/dashboard/__tests__/Dashboard.test.jsx
+++ b/dashboard/__tests__/Dashboard.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 import '@testing-library/jest-dom';
 import Dashboard from '../src/pages/Dashboard.jsx';
 
@@ -11,11 +13,13 @@ jest.mock('recharts', () => {
   };
 });
 
-test('renders trading mode buttons and wallet info', () => {
-  render(<Dashboard />);
-  expect(screen.getByText(/wallet balance/i)).toBeInTheDocument();
-  expect(screen.getByTestId('system-status')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /auto/i })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /realistic/i })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /aggressive/i })).toBeInTheDocument();
+describeLocal('dashboard basics', () => {
+  test('renders trading mode buttons and wallet info', () => {
+    render(<Dashboard />);
+    expect(screen.getByText(/wallet balance/i)).toBeInTheDocument();
+    expect(screen.getByTestId('system-status')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /auto/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /realistic/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /aggressive/i })).toBeInTheDocument();
+  });
 });

--- a/dashboard/__tests__/Infrastructure.test.jsx
+++ b/dashboard/__tests__/Infrastructure.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 import { act } from 'react';
 import '@testing-library/jest-dom';
 import Infrastructure from '../src/pages/Infrastructure.jsx';
@@ -23,10 +25,12 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
-test('shows infrastructure status table', async () => {
-  await act(async () => {
-    render(<Infrastructure />);
-  });
+describeLocal('infrastructure page', () => {
+  test('shows infrastructure status table', async () => {
+    await act(async () => {
+      render(<Infrastructure />);
+    });
 
-  expect(await screen.findByText('app')).toBeInTheDocument();
+    expect(await screen.findByText('app')).toBeInTheDocument();
+  });
 });

--- a/dashboard/__tests__/LiveMetric.test.jsx
+++ b/dashboard/__tests__/LiveMetric.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 import '@testing-library/jest-dom';
 import LiveMetrics from '../components/LiveMetrics.jsx';
 
@@ -18,8 +20,10 @@ jest.mock('recharts', () => ({
   ResponsiveContainer: ({ children }) => <div>{children}</div>,
 }));
 
-test('renders chart container and uses mocked data', () => {
-  render(<LiveMetrics />);
-  expect(screen.getByTestId('line-chart')).toBeInTheDocument();
-  expect(received).toHaveLength(10);
+describeLocal('live metrics', () => {
+  test('renders chart container and uses mocked data', () => {
+    render(<LiveMetrics />);
+    expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+    expect(received).toHaveLength(10);
+  });
 });

--- a/dashboard/__tests__/Settings.test.jsx
+++ b/dashboard/__tests__/Settings.test.jsx
@@ -1,20 +1,24 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 import '@testing-library/jest-dom';
 import Settings from '../src/pages/Settings.jsx';
 
 jest.mock('axios');
 
-test('toggle buttons update mode state', () => {
-  render(<Settings />);
-  const autoBtn = screen.getByRole('button', { name: /auto/i });
-  const aggBtn = screen.getByRole('button', { name: /aggressive/i });
-  const realBtn = screen.getByRole('button', { name: /realistic/i });
+describeLocal('settings page', () => {
+  test('toggle buttons update mode state', () => {
+    render(<Settings />);
+    const autoBtn = screen.getByRole('button', { name: /auto/i });
+    const aggBtn = screen.getByRole('button', { name: /aggressive/i });
+    const realBtn = screen.getByRole('button', { name: /realistic/i });
 
-  expect(autoBtn).toBeInTheDocument();
-  expect(aggBtn).toBeInTheDocument();
-  expect(realBtn).toBeInTheDocument();
+    expect(autoBtn).toBeInTheDocument();
+    expect(aggBtn).toBeInTheDocument();
+    expect(realBtn).toBeInTheDocument();
 
-  fireEvent.click(aggBtn);
-  expect(aggBtn).toHaveClass('bg-blue-600');
+    fireEvent.click(aggBtn);
+    expect(aggBtn).toHaveClass('bg-blue-600');
+  });
 });

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,9 @@
+# Test Environment Tags
+
+This project separates tests into **local** and **live** environments. Use the environment variable or build property to run the desired set:
+
+- **Python**: each test file defines `pytestmark = pytest.mark.env("local"|"live")`. Pytest is configured via `pytest.ini` to recognize the `env` marker. Run with `pytest -m env("local")` or `env("live")`.
+- **Node.js / React**: test suites call `describeLocal` or `describe('LIVE: ...')`. Tests wrapped with `describeLocal` run only when `process.env.TEST_ENV` is `local`. Live blocks are skipped unless `TEST_ENV` is `live`.
+- **Java**: JUnit tests use `@Tag("local")` or `@Tag("live")`. Gradle's `testEnv` property controls which tagged tests execute: `./gradlew test -PtestEnv=local` or `-PtestEnv=live`.
+
+Use these tags to avoid hitting external services when running the default local test suite.

--- a/executor/build.gradle
+++ b/executor/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
+    def env = project.hasProperty('testEnv') ? project.property('testEnv') : 'local'
+    useJUnitPlatform {
+        includeTags env
+    }
 }
 

--- a/executor/src/test/java/CGTPoolTest.java
+++ b/executor/src/test/java/CGTPoolTest.java
@@ -3,7 +3,9 @@ package executor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
+@Tag("local")
 public class CGTPoolTest {
     @Test
     void calculatesAverageCost() {

--- a/executor/src/test/java/CircuitBreakerTest.java
+++ b/executor/src/test/java/CircuitBreakerTest.java
@@ -1,9 +1,11 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Unit tests for {@link CircuitBreaker}. */
+@Tag("local")
 public class CircuitBreakerTest {
     static class DummyRedisClient extends RedisClient {
         String channel;

--- a/executor/src/test/java/ColdSweepSchedulerTest.java
+++ b/executor/src/test/java/ColdSweepSchedulerTest.java
@@ -1,11 +1,13 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+@Tag("local")
 public class ColdSweepSchedulerTest {
     static class TestWalletClient implements WalletClient {
         boolean called = false;

--- a/executor/src/test/java/ColdSweeperTest.java
+++ b/executor/src/test/java/ColdSweeperTest.java
@@ -1,8 +1,10 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
+@Tag("local")
 public class ColdSweeperTest {
 
     @Test

--- a/executor/src/test/java/ConfigValidatorTest.java
+++ b/executor/src/test/java/ConfigValidatorTest.java
@@ -1,8 +1,10 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
+@Tag("local")
 public class ConfigValidatorTest {
 
     @Test

--- a/executor/src/test/java/ExecutorCanaryModeTest.java
+++ b/executor/src/test/java/ExecutorCanaryModeTest.java
@@ -1,9 +1,11 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Tests that Executor bypasses trades when canary mode is enabled. */
+@Tag("local")
 public class ExecutorCanaryModeTest {
     static class DummyRedisClient extends RedisClient {
         DummyRedisClient() {

--- a/executor/src/test/java/ExecutorGhostModeTest.java
+++ b/executor/src/test/java/ExecutorGhostModeTest.java
@@ -1,9 +1,11 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Tests that Executor publishes opportunities instead of executing when ghost mode is enabled. */
+@Tag("local")
 public class ExecutorGhostModeTest {
     static class DummyRedisClient extends RedisClient {
         String publishedChannel;

--- a/executor/src/test/java/ExecutorRedisRecoveryTest.java
+++ b/executor/src/test/java/ExecutorRedisRecoveryTest.java
@@ -1,10 +1,12 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Ensures Executor continues processing after Redis reconnects. */
+@Tag("local")
 public class ExecutorRedisRecoveryTest {
     /** Redis client stub emitting a message, a disconnect, then another message. */
     static class FlakyRedisClient extends RedisClient {

--- a/executor/src/test/java/ExecutorSandboxModeTest.java
+++ b/executor/src/test/java/ExecutorSandboxModeTest.java
@@ -3,10 +3,12 @@ package executor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Tests sandbox mode behaviour. */
+@Tag("local")
 public class ExecutorSandboxModeTest {
     static class DummyRedisClient extends RedisClient {
         String channel;

--- a/executor/src/test/java/FraudDetectionTest.java
+++ b/executor/src/test/java/FraudDetectionTest.java
@@ -1,9 +1,11 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Simulates fraudulent order book data to ensure it is ignored. */
+@Tag("local")
 public class FraudDetectionTest {
     static class DummyRedisClient extends RedisClient {
         DummyRedisClient() { super("localhost", 6379, "chan", (c,m) -> {}); }

--- a/executor/src/test/java/MockExchangeAdapterTest.java
+++ b/executor/src/test/java/MockExchangeAdapterTest.java
@@ -1,11 +1,13 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
 // For using ExchangeAdapter interface in tests
 import executor.ExchangeAdapter;
 
+@Tag("local")
 public class MockExchangeAdapterTest {
     @Test
     void feeRateCanBeOverridden() {

--- a/executor/src/test/java/PanicBrakeTest.java
+++ b/executor/src/test/java/PanicBrakeTest.java
@@ -1,9 +1,11 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 import executor.PanicBrake;
 
+@Tag("local")
 public class PanicBrakeTest {
     @Test
     void triggersOnHighLoss() {

--- a/executor/src/test/java/RebalanceSchedulerTest.java
+++ b/executor/src/test/java/RebalanceSchedulerTest.java
@@ -1,11 +1,13 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Tag("local")
 public class RebalanceSchedulerTest {
     static class TestRebalancer extends Rebalancer {
         boolean called = false;

--- a/executor/src/test/java/RebalancerTest.java
+++ b/executor/src/test/java/RebalancerTest.java
@@ -1,11 +1,13 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Tag("local")
 public class RebalancerTest {
     @Test
     void handlesImbalancedExchanges() {

--- a/executor/src/test/java/ResumeHandlerTest.java
+++ b/executor/src/test/java/ResumeHandlerTest.java
@@ -1,6 +1,7 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Unit tests for {@link ResumeHandler}.
  */
+@Tag("local")
 public class ResumeHandlerTest {
 
     /** Simple stub of the Redis client that immediately sends a resume message. */

--- a/executor/src/test/java/RiskFilterTest.java
+++ b/executor/src/test/java/RiskFilterTest.java
@@ -2,8 +2,10 @@ package executor;
 
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
+@Tag("local")
 public class RiskFilterTest {
     @Test
     void rejectsWhenEdgeBelowThreshold() {

--- a/executor/src/test/java/RiskSettingsTest.java
+++ b/executor/src/test/java/RiskSettingsTest.java
@@ -1,9 +1,11 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Verifies trade size respects order book depth limit. */
+@Tag("local")
 public class RiskSettingsTest {
     @Test
     void tradeSizeCappedByOrderBookDepth() {

--- a/executor/src/test/java/SandboxExchangeAdapterTest.java
+++ b/executor/src/test/java/SandboxExchangeAdapterTest.java
@@ -3,10 +3,12 @@ package executor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Tests for SandboxExchangeAdapter. */
+@Tag("local")
 public class SandboxExchangeAdapterTest {
     /** Dummy redis client capturing publishes. */
     static class DummyRedis extends RedisClient {

--- a/executor/src/test/java/ScoringEngineTest.java
+++ b/executor/src/test/java/ScoringEngineTest.java
@@ -1,8 +1,10 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
+@Tag("local")
 public class ScoringEngineTest {
     static class FixedPredictor implements ModelPredictor {
         private final double value;

--- a/executor/src/test/java/SimulatedPublisherTest.java
+++ b/executor/src/test/java/SimulatedPublisherTest.java
@@ -3,10 +3,12 @@ package executor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Unit tests for {@link SimulatedPublisher}. */
+@Tag("local")
 public class SimulatedPublisherTest {
     /** Simple Redis client capturing the last published message. */
     static class DummyRedisClient extends RedisClient {

--- a/executor/src/test/java/TriangularArbDetectorTest.java
+++ b/executor/src/test/java/TriangularArbDetectorTest.java
@@ -1,9 +1,11 @@
 package executor;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Unit tests for {@link TriangularArbDetector}. */
+@Tag("local")
 public class TriangularArbDetectorTest {
     static class DummyRedisClient extends RedisClient {
         DummyRedisClient() { super("localhost", 6379, "chan", (c,m) -> {}); }

--- a/feed-aggregator/tests/test_agents_json.py
+++ b/feed-aggregator/tests/test_agents_json.py
@@ -1,5 +1,8 @@
 import json
 from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.env("local")
 
 def test_agents_json_valid():
     data_path = Path(__file__).resolve().parents[1] / 'docs/agents.json'

--- a/feed-aggregator/tests/test_health.py
+++ b/feed-aggregator/tests/test_health.py
@@ -6,6 +6,8 @@ import os
 import shutil
 import pytest
 
+pytestmark = pytest.mark.env("local")
+
 if not shutil.which("node"):
     pytest.skip("node not installed", allow_module_level=True)
 

--- a/feed-aggregator/tests/test_normalize.py
+++ b/feed-aggregator/tests/test_normalize.py
@@ -3,6 +3,8 @@ import subprocess
 from pathlib import Path
 import pytest
 
+pytestmark = pytest.mark.env("local")
+
 if not subprocess.run(['which', 'node'], capture_output=True).stdout.strip():
     pytest.skip('node not installed', allow_module_level=True)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    env(name): mark test with environment name


### PR DESCRIPTION
## Summary
- tag Python tests with pytest markers
- skip Node tests unless `TEST_ENV` matches
- tag Java tests with JUnit `@Tag` and allow filtering via Gradle
- document how environment tags work

## Testing
- `npm test`
- `pytest`
- `./gradlew test -PtestEnv=local`

------
https://chatgpt.com/codex/tasks/task_b_6873df2720c4832c9f66148a6663bce7