### PR TITLE
Pin Containerfile base image versions

### DIFF
--- a/analytics/Containerfile
+++ b/analytics/Containerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10.18-bullseye
 WORKDIR /app
 COPY . /app
 RUN pip install --no-cache-dir -r requirements.txt

--- a/api/Containerfile
+++ b/api/Containerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18.20.8-bullseye
 
 WORKDIR /app
 

--- a/dashboard/Containerfile
+++ b/dashboard/Containerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18.20.8-bullseye
 WORKDIR /app
 COPY . .
 RUN yarn install --frozen-lockfile && yarn build

--- a/executor/Containerfile
+++ b/executor/Containerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:17.0.10-jdk-slim
 WORKDIR /app
 COPY . /app
 RUN ./gradlew build

--- a/feed-aggregator/Containerfile
+++ b/feed-aggregator/Containerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18.20.8-bullseye
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --production


### PR DESCRIPTION
## Summary
- pin patch versions for base images across services

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: analytics.redis_retrain)*
- `yarn test --runInBand` in dashboard *(fails: cannot find module '@testing-library/dom')*
- `npm test` in api *(fails: SyntaxError: Cannot use import statement outside a module)*
- `./gradlew test` *(passes)*

------
https://chatgpt.com/codex/tasks/task_b_6874332ab578832c8fcc35de9a479f72