### PR TITLE
Update run-local to invoke jest with configs

### DIFF
--- a/test/run-local.sh
+++ b/test/run-local.sh
@@ -2,6 +2,7 @@
 # @dev-note: runs mocked tests only
 set -euo pipefail
 export TEST_ENV=local
-npx jest --runInBand
+npx jest --runInBand --config dashboard/jest.config.js
+npx jest --runInBand --config api/jest.config.js
 pytest -m "env('local')"
 ./gradlew test -PtestEnv=local


### PR DESCRIPTION
## Summary
- run dashboard and api Jest tests separately in `run-local.sh`

## Testing
- `bash test/run-local.sh` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_b_6874455f10e0832c9b12059228bff4a3