### PR TITLE
Add system status route

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -28,7 +28,7 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 const isTest = process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID;
-const testState = { panic: false };
+const testState = { panic: false, reason: '' };
 
 let redis;
 let pool;
@@ -138,6 +138,11 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
     await redis.publish('control-feed', 'resume');
     return { resumed: true };
   });
+
+  api.get('/system/status', async () => ({
+    panic: testState.panic,
+    reason: testState.reason,
+  }));
 
     if (isTest) {
       api.post('/test/panic', async () => {


### PR DESCRIPTION
## Summary
- expose system status route to show panic state and reason
- extend `testState` object to include `reason`

## Testing
- `npm test` *(fails: panic resume cycle and auth tests due to unauthorized responses)*

------
https://chatgpt.com/codex/tasks/task_b_6877c6cd07a4832cb1c0727af75f29e5