### PR TITLE
Downgrade numpy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+- Downgrade numpy to 2.1.3 to resolve TensorFlow install conflict.
+
 ## [Batch 1] - 2025-07-02
 ### Added
 - Local environment setup

--- a/analytics/requirements.txt
+++ b/analytics/requirements.txt
@@ -2,7 +2,7 @@ flask==3.1.1
 python-dotenv==1.1.1
 tensorflow==2.19.0
 prometheus_client==0.22.1
-numpy==2.3.1
+numpy==2.1.3
 pytest==8.4.0
 joblib==1.5.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask==3.1.1
 python-dotenv==1.1.1
 tensorflow==2.19.0
 prometheus_client==0.22.1
-numpy==2.3.1
+numpy==2.1.3
 pytest==8.4.0
 joblib==1.5.1
 


### PR DESCRIPTION
## Summary
- lock numpy version to `2.1.3`
- document the numpy downgrade in the changelog

## Testing
- `pip install --break-system-packages --upgrade --ignore-installed -r analytics/requirements.txt`
- `pytest analytics/`

------
https://chatgpt.com/codex/tasks/task_b_687aa095b5f8832ca024aef4d4b3aea6