### PR TITLE
Pin GitHub Actions with SHA references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,29 @@ jobs:
         shell: bash -eo pipefail {0}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        # actions/checkout@v3 SHA f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Prepare test results directory
         run: mkdir -p test-results
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        # actions/setup-node@v3 SHA 3235b876344d2a9aa001b8d1453c930bba69e610
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: 18
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        # actions/setup-python@v4 SHA 7f4fc3e22c37d6ff65e88745f38bd3157c663f7c
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c
         with:
           python-version: '3.10'
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        # actions/setup-java@v3 SHA 17f84c3641ba7b8f6deff6309fc4c864478f5d62
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -65,7 +69,8 @@ jobs:
 
       - name: Upload API test report
         if: failure()
-        uses: actions/upload-artifact@v3
+        # actions/upload-artifact@v3 SHA ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
         with:
           name: api-jest-report
           path: test-results/api-jest.json
@@ -78,7 +83,8 @@ jobs:
         run: podman build -t api ./api
 
       - name: Run Trivy scan on api
-        uses: aquasecurity/trivy-action@v0.32.0
+        # aquasecurity/trivy-action@0.32.0 SHA dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
         with:
           image-ref: api
           format: table
@@ -94,7 +100,8 @@ jobs:
 
       - name: Upload Dashboard test report
         if: failure()
-        uses: actions/upload-artifact@v3
+        # actions/upload-artifact@v3 SHA ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
         with:
           name: dashboard-jest-report
           path: test-results/dashboard-jest.json
@@ -107,7 +114,8 @@ jobs:
         run: podman build -t dashboard ./dashboard
 
       - name: Run Trivy scan on dashboard
-        uses: aquasecurity/trivy-action@v0.32.0
+        # aquasecurity/trivy-action@0.32.0 SHA dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
         with:
           image-ref: dashboard
           format: table
@@ -131,7 +139,8 @@ jobs:
 
       - name: Upload feed-aggregator test report
         if: failure()
-        uses: actions/upload-artifact@v3
+        # actions/upload-artifact@v3 SHA ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
         with:
           name: feed-aggregator-pytest-report
           path: test-results/feed-aggregator-pytest.xml
@@ -140,7 +149,8 @@ jobs:
         run: podman build -t feed-aggregator ./feed-aggregator
 
       - name: Run Trivy scan on feed-aggregator
-        uses: aquasecurity/trivy-action@v0.32.0
+        # aquasecurity/trivy-action@0.32.0 SHA dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
         with:
           image-ref: feed-aggregator
           format: table
@@ -159,7 +169,8 @@ jobs:
         
       - name: Upload analytics test report
         if: failure()
-        uses: actions/upload-artifact@v3
+        # actions/upload-artifact@v3 SHA ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
         with:
           name: analytics-pytest-report
           path: test-results/analytics-pytest.xml
@@ -174,7 +185,8 @@ jobs:
         run: podman run --rm analytics python --version
 
       - name: Run Trivy scan on analytics
-        uses: aquasecurity/trivy-action@v0.32.0
+        # aquasecurity/trivy-action@0.32.0 SHA dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
         with:
           image-ref: analytics
           format: table
@@ -191,7 +203,8 @@ jobs:
 
       - name: Upload Executor test report
         if: failure()
-        uses: actions/upload-artifact@v3
+        # actions/upload-artifact@v3 SHA ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
         with:
           name: executor-gradle-report
           path: test-results/executor
@@ -207,7 +220,8 @@ jobs:
         run: podman run --rm executor java -version
 
       - name: Run Trivy scan on executor
-        uses: aquasecurity/trivy-action@v0.32.0
+        # aquasecurity/trivy-action@0.32.0 SHA dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
         with:
           image-ref: executor
           format: table
@@ -223,7 +237,8 @@ jobs:
         shell: bash -eo pipefail {0}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        # actions/checkout@v3 SHA f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Install kubectl and jq
         run: |
           sudo apt-get update
@@ -236,7 +251,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run live tests on Xeon server
-        uses: appleboy/ssh-action@v0.1.7
+        # appleboy/ssh-action@v0.1.7 SHA d91a1af6f57cd4478ceee14d7705601dafabaa19
+        uses: appleboy/ssh-action@d91a1af6f57cd4478ceee14d7705601dafabaa19
         with:
           host: ${{ secrets.XEON_HOST }}
           username: ${{ secrets.XEON_USER }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,20 +8,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        # actions/checkout@v3 SHA f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        # actions/setup-node@v3 SHA 3235b876344d2a9aa001b8d1453c930bba69e610
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: 18
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        # actions/setup-python@v4 SHA 7f4fc3e22c37d6ff65e88745f38bd3157c663f7c
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c
         with:
           python-version: '3.10'
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        # actions/setup-java@v3 SHA 17f84c3641ba7b8f6deff6309fc4c864478f5d62
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -53,7 +57,8 @@ jobs:
           syft feed-aggregator:latest -o json > sbom-feed-aggregator.json
 
       - name: Upload SBOMs and CHANGELOG to GitHub Release
-        uses: softprops/action-gh-release@v1
+        # softprops/action-gh-release@v1 SHA 26994186c0ac3ef5cae75ac16aa32e8153525f77
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77
         with:
           files: |
             sbom-*.json


### PR DESCRIPTION
## Summary
- pin GitHub Action versions to specific commit SHAs
- annotate pinned SHAs in workflow files for easy updates

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_687ab47a35dc832ca46a6a8d9f306ab4