### PR TITLE
Update build script security option

### DIFF
--- a/scripts/builds.sh
+++ b/scripts/builds.sh
@@ -15,5 +15,5 @@ for svc in "${SERVICES[@]}"; do
     IMAGE="arb-$svc"
     CONTEXT="$ROOT_DIR/$svc"
     echo "Building $IMAGE from $CONTEXT"
-    podman build -t "$IMAGE" "$CONTEXT"
+    podman build --security-opt systempaths=unconfined -t "$IMAGE" "$CONTEXT"
 done


### PR DESCRIPTION
## Summary
- add `systempaths=unconfined` to podman build command in `scripts/builds.sh`

## Testing
- `./test/run-local.sh` *(fails: Wrong expression passed to '-m': env('local'))*
- `bash ./test/run-live.sh` *(hangs: waiting for npm to install Jest)*

------
https://chatgpt.com/codex/tasks/task_b_687bd6d142c0832c8383fc780dc076a0