### PR TITLE
Fix pytest command in run-local script

### DIFF
--- a/test/run-local.sh
+++ b/test/run-local.sh
@@ -8,5 +8,5 @@ source "$(dirname "$0")/verify-env.sh"
 export TEST_ENV=local
 npm --prefix dashboard test -- --runInBand
 npm --prefix api test -- --runInBand
-pytest -m "env('local')"
+pytest
 executor/gradlew test -p executor -PtestEnv=local


### PR DESCRIPTION
## Summary
- update test `run-local.sh` script to run all tests without env filter

## Testing
- `bash githooks/pre-push`

------
https://chatgpt.com/codex/tasks/task_b_687bd9a54abc832ca2b1e87e24a30662