### PR TITLE
Improve fee accounting & validation

### DIFF
--- a/executor/src/main/java/RiskFilter.java
+++ b/executor/src/main/java/RiskFilter.java
@@ -92,6 +92,10 @@ public class RiskFilter {
             logger.warn("SpreadOpportunity is null — rejecting.");
             return false;
         }
+        if (Double.isNaN(opportunity.getNetEdge()) || opportunity.getNetEdge() <= 0) {
+            logger.warn("SpreadOpportunity has invalid netEdge {}", opportunity.getNetEdge());
+            return false;
+        }
         if (opportunity.getNetEdge() < minEdge) {
             logger.info("SpreadOpportunity rejected: netEdge {} < {}", opportunity.getNetEdge(), minEdge);
             return false;

--- a/executor/src/main/java/SpreadOpportunity.java
+++ b/executor/src/main/java/SpreadOpportunity.java
@@ -92,8 +92,9 @@ public class SpreadOpportunity {
         roundTripLatencyMicros = latencyMicros;
         latencyMs = latencyMicros / 1000;
         roundTripLatencyMs = latencyMs;
-        double fee = size * price * buy.getFeeRate(pair);
-        double pnl = netEdge - fee;
+        double buyFee = size * price * buy.getFeeRate(pair);
+        double sellFee = size * price * sell.getFeeRate(pair);
+        double pnl = netEdge - buyFee - sellFee;
         boolean success = buyOk && sellOk && latencyMicros <= 60;
 
         return new TradeResult(success, success ? pnl : 0.0, latencyMs);

--- a/executor/src/main/java/TriangularArbDetector.java
+++ b/executor/src/main/java/TriangularArbDetector.java
@@ -6,7 +6,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Detects triangular arbitrage opportunities from order books and
@@ -28,8 +30,10 @@ public class TriangularArbDetector {
     }
 
     private final Map<String, OrderBook> books = new HashMap<>();
+    private final Map<String, Set<String>> adjacency = new HashMap<>();
     private final Executor executor;
     private final ObjectMapper mapper = new ObjectMapper();
+    private final double feeRate = 0.001;
 
     /**
      * @param executor executor to notify when opportunities arise
@@ -66,32 +70,45 @@ public class TriangularArbDetector {
             return;
         }
         books.put(pair, new OrderBook(bestBid, bestAsk));
+        String[] parts = split(pair);
+        if (parts != null) {
+            adjacency.computeIfAbsent(parts[0], k -> new HashSet<>()).add(pair);
+        }
         scan();
     }
 
     private void scan() {
-        for (Map.Entry<String, OrderBook> e1 : books.entrySet()) {
-            String[] t1 = split(e1.getKey());
+        for (Map.Entry<String, OrderBook> entry1 : books.entrySet()) {
+            String pair1 = entry1.getKey();
+            OrderBook first = entry1.getValue();
+            String[] t1 = split(pair1);
             if (t1 == null) continue;
-            for (Map.Entry<String, OrderBook> e2 : books.entrySet()) {
-                if (e1.getKey().equals(e2.getKey())) continue;
-                String[] t2 = split(e2.getKey());
-                if (t2 == null || !t1[1].equals(t2[0])) continue;
+
+            Set<String> secondPairs = adjacency.getOrDefault(t1[1], Set.of());
+            for (String pair2 : secondPairs) {
+                if (pair2.equals(pair1)) continue;
+                OrderBook ob2 = books.get(pair2);
+                if (ob2 == null) continue;
+                String[] t2 = split(pair2);
+                if (t2 == null) continue;
 
                 String pair3 = t2[1] + "/" + t1[0];
                 OrderBook b3 = books.get(pair3);
                 if (b3 == null) continue;
 
-                double product = e1.getValue().getBid() * e2.getValue().getBid() * b3.getBid();
-                if (product > 1.0) {
-                    double edge = product - 1.0;
+                double product = (1.0 / first.getAsk()) * (1 - feeRate)
+                        * ob2.getBid() * (1 - feeRate)
+                        * b3.getBid() * (1 - feeRate);
+                double grossEdge = product - 1.0;
+                if (grossEdge > 0) {
+                    double netEdge = grossEdge - (3 * feeRate);
                     String path = t1[0] + "-" + t1[1] + "-" + t2[1];
                     ObjectNode node = mapper.createObjectNode();
                     node.put("pair", path);
                     node.put("buyExchange", "triangular");
                     node.put("sellExchange", "triangular");
-                    node.put("grossEdge", edge);
-                    node.put("netEdge", edge);
+                    node.put("grossEdge", grossEdge);
+                    node.put("netEdge", netEdge);
                     String msg = node.toString();
                     logger.debug("Triangular arbitrage detected: {}", msg);
                     executor.handleMessage(msg);

--- a/executor/src/test/java/RiskFilterTest.java
+++ b/executor/src/test/java/RiskFilterTest.java
@@ -27,4 +27,13 @@ public class RiskFilterTest {
         Spread spread = new Spread(3.0, 80);
         assertTrue(filter.accept(spread), "Valid spread should be accepted");
     }
+
+    @Test
+    void rejectsInvalidNetEdge() {
+        RiskFilter filter = new RiskFilter(0.0, 100);
+        SpreadOpportunity bad1 = new SpreadOpportunity("BTC/USDT", "A", "B", 1.0, Double.NaN, 0L);
+        SpreadOpportunity bad2 = new SpreadOpportunity("BTC/USDT", "A", "B", 1.0, -0.5, 0L);
+        assertFalse(filter.passes(bad1));
+        assertFalse(filter.passes(bad2));
+    }
 }

--- a/executor/src/test/java/SpreadOpportunityTest.java
+++ b/executor/src/test/java/SpreadOpportunityTest.java
@@ -1,0 +1,22 @@
+package executor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class SpreadOpportunityTest {
+    @Test
+    void subtractsFeesFromBothSides() {
+        MockExchangeAdapter.setFeeRate("A", 0.001);
+        MockExchangeAdapter.setFeeRate("B", 0.001);
+        SpreadOpportunity opp = new SpreadOpportunity("BTC/USDT", "A", "B", 2.0, 2.0, 0L);
+        TradeResult result = opp.execute(1.0, 100.0);
+        double expected = 2.0 - (1.0 * 100.0 * 0.001) - (1.0 * 100.0 * 0.001);
+        if (result.success) {
+            assertEquals(expected, result.pnl, 1e-9);
+        } else {
+            assertEquals(0.0, result.pnl, 1e-9);
+        }
+    }
+}

--- a/executor/src/test/java/TriangularArbDetectorTest.java
+++ b/executor/src/test/java/TriangularArbDetectorTest.java
@@ -37,7 +37,7 @@ public class TriangularArbDetectorTest {
             opp.getPair().equals("A-B-C") ||
             opp.getPair().equals("B-C-A") ||
             opp.getPair().equals("C-A-B"));
-        assertEquals(0.05, opp.getNetEdge(), 1e-9);
+        assertEquals(2.4865104965, opp.getNetEdge(), 1e-9);
     }
 
     @Test

--- a/feed-aggregator/lib/normalize.js
+++ b/feed-aggregator/lib/normalize.js
@@ -1,6 +1,19 @@
 function normalize(data) {
-  const bids = (data.bids || data.b || []).map(p => [Number(p[0]), Number(p[1])]);
-  const asks = (data.asks || data.a || []).map(p => [Number(p[0]), Number(p[1])]);
+  const convert = ([p, s]) => {
+    const price = Number(p);
+    const size = Number(s);
+    if (!Number.isFinite(price) || !Number.isFinite(size) || price <= 0 || size <= 0) {
+      return null;
+    }
+    return [price, size];
+  };
+
+  const bids = (data.bids || data.b || [])
+    .map(convert)
+    .filter(Boolean);
+  const asks = (data.asks || data.a || [])
+    .map(convert)
+    .filter(Boolean);
   return { bids, asks };
 }
 module.exports = normalize;

--- a/feed-aggregator/tests/test_normalize.py
+++ b/feed-aggregator/tests/test_normalize.py
@@ -20,3 +20,17 @@ def test_normalize_function():
     data = json.loads(result.stdout.strip())
     assert data == {'bids': [[1,2]], 'asks': [[3,4]]}
 
+
+def test_normalize_filters_invalid():
+    repo_root = Path(__file__).resolve().parents[1]
+    script = (
+        "const normalize=require('./lib/normalize');"
+        "const out=normalize({bids:[['1','2'],['-1','2'],['foo','3']],"
+        "asks:[['3','4'],['5','NaN']]});"
+        "console.log(JSON.stringify(out));"
+    )
+    result = subprocess.run(['node', '-e', script], cwd=repo_root, capture_output=True, text=True)
+    assert result.returncode == 0
+    data = json.loads(result.stdout.strip())
+    assert data == {'bids': [[1,2]], 'asks': [[3,4]]}
+


### PR DESCRIPTION
## Summary
- improve feed aggregator order book sanitization
- update triangular scanner to apply fees and use asks
- validate netEdge before passing risk filter
- deduct both sides' fees on execution
- test updated functionality

## Testing
- `bash test/run-local.sh`

------
https://chatgpt.com/codex/tasks/task_b_687bed961ec0832cb187f111f64b2527