### PR TITLE
Improve sandbox trade realism

### DIFF
--- a/executor/src/main/java/MockExchangeAdapter.java
+++ b/executor/src/main/java/MockExchangeAdapter.java
@@ -25,6 +25,7 @@ public class MockExchangeAdapter implements ExchangeAdapter {
     private final double cancelFeeRate;
     private double lastFillSize = 0.0;
     private double lastCancelFee = 0.0;
+    private double lastExecPrice = 0.0;
 
     /** Create an adapter with the default exchange name. */
     public MockExchangeAdapter() {
@@ -69,6 +70,7 @@ public class MockExchangeAdapter implements ExchangeAdapter {
     public boolean placeOrder(String pair, String side, double size, double price) {
         lastFillSize = 0.0;
         lastCancelFee = 0.0;
+        lastExecPrice = price;
         double r = random.nextDouble();
         if (r < 0.8) {
             lastFillSize = size;
@@ -126,6 +128,13 @@ public class MockExchangeAdapter implements ExchangeAdapter {
      */
     public double getLastCancelFee() {
         return lastCancelFee;
+    }
+
+    /**
+     * @return execution price used for the last order
+     */
+    public double getLastExecPrice() {
+        return lastExecPrice;
     }
 
     /**

--- a/executor/src/main/java/SandboxExchangeAdapter.java
+++ b/executor/src/main/java/SandboxExchangeAdapter.java
@@ -82,12 +82,46 @@ public class SandboxExchangeAdapter extends MockExchangeAdapter {
     public TradeResult execute(SpreadOpportunity opp, double size, double price) {
         double predicted = predictor.predict(opp);
         long start = System.currentTimeMillis();
-        boolean buyOk = placeOrder(opp.getPair(), "BUY", size, price);
-        boolean sellOk = placeOrder(opp.getPair(), "SELL", size, price);
+
+        double buyCancel = 0.0;
+        double sellCancel = 0.0;
+        boolean buyOk = false;
+        boolean sellOk = false;
+        double buyPrice = price;
+        double sellPrice = price;
+        int attempts = 0;
+        final int maxRetries = 3;
+
+        while (attempts < maxRetries && !buyOk) {
+            buyOk = placeOrder(opp.getPair(), "BUY", size, price);
+            buyCancel += getLastCancelFee();
+            buyPrice = getLastExecPrice();
+            attempts++;
+        }
+
+        if (buyOk) {
+            attempts = 0;
+            while (attempts < maxRetries && !sellOk) {
+                sellOk = placeOrder(opp.getPair(), "SELL", size, price);
+                sellCancel += getLastCancelFee();
+                sellPrice = getLastExecPrice();
+                attempts++;
+            }
+        }
+
         long end = System.currentTimeMillis();
         long latency = end - start;
 
-        double pnl = opp.getNetEdge();
+        double buyFee = size * buyPrice * getFeeRate(opp.getPair());
+        double sellFee = size * sellPrice * getFeeRate(opp.getPair());
+
+        double slippageLoss = (buyPrice - price) * size + (price - sellPrice) * size;
+        double pnl = opp.getNetEdge() - buyFee - sellFee - buyCancel - sellCancel - slippageLoss;
+
+        boolean success = buyOk && sellOk;
+        if (!success) {
+            pnl = 0.0;
+        }
 
         if (redisClient != null) {
             try {
@@ -104,6 +138,6 @@ public class SandboxExchangeAdapter extends MockExchangeAdapter {
             }
         }
 
-        return new TradeResult(buyOk && sellOk, pnl, latency);
+        return new TradeResult(success, pnl, latency);
     }
 }

--- a/executor/src/main/java/SpreadOpportunity.java
+++ b/executor/src/main/java/SpreadOpportunity.java
@@ -84,17 +84,39 @@ public class SpreadOpportunity {
         MockExchangeAdapter sell = new MockExchangeAdapter(sellExchange);
 
         long start = System.nanoTime();
-        boolean buyOk = buy.placeIocOrder(pair, "BUY", size, price);
-        boolean sellOk = sell.placeIocOrder(pair, "SELL", size, price);
+
+        double buyCancel = 0.0;
+        double sellCancel = 0.0;
+        boolean buyOk = false;
+        boolean sellOk = false;
+        int attempts = 0;
+        final int maxRetries = 3;
+
+        while (attempts < maxRetries && !buyOk) {
+            buyOk = buy.placeIocOrder(pair, "BUY", size, price);
+            buyCancel += buy.getLastCancelFee();
+            attempts++;
+        }
+
+        if (buyOk) {
+            attempts = 0;
+            while (attempts < maxRetries && !sellOk) {
+                sellOk = sell.placeIocOrder(pair, "SELL", size, price);
+                sellCancel += sell.getLastCancelFee();
+                attempts++;
+            }
+        }
+
         long end = System.nanoTime();
 
         latencyMicros = (end - start) / 1000;
         roundTripLatencyMicros = latencyMicros;
         latencyMs = latencyMicros / 1000;
         roundTripLatencyMs = latencyMs;
+
         double buyFee = size * price * buy.getFeeRate(pair);
         double sellFee = size * price * sell.getFeeRate(pair);
-        double pnl = netEdge - buyFee - sellFee;
+        double pnl = netEdge - buyFee - sellFee - buyCancel - sellCancel;
         boolean success = buyOk && sellOk && latencyMicros <= 60;
 
         return new TradeResult(success, success ? pnl : 0.0, latencyMs);

--- a/executor/src/test/java/SandboxExchangeAdapterTest.java
+++ b/executor/src/test/java/SandboxExchangeAdapterTest.java
@@ -33,5 +33,7 @@ public class SandboxExchangeAdapterTest {
         assertEquals(0.1, node.get("net_edge").asDouble(), 1e-9);
         assertEquals(0.7, node.get("predicted_prob").asDouble(), 1e-9);
         assertEquals(result.latencyMs, node.get("latency_ms").asLong());
+        assertEquals(result.pnl, node.get("simulated_pnl").asDouble(), 1e-9);
+        assertTrue(result.pnl <= 0.1);
     }
 }


### PR DESCRIPTION
## Summary
- track execution price in `MockExchangeAdapter`
- simulate fees and slippage in `SandboxExchangeAdapter`
- add retry logic and cancel-fee accounting in `SpreadOpportunity`
- test updated sandbox adapter behaviour

## Testing
- `./gradlew test --no-daemon`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687bf4455044832c9fc70aad8f14a16a