### PR TITLE
Improve scoring and ranking logic

### DIFF
--- a/executor/src/main/java/ScoringEngine.java
+++ b/executor/src/main/java/ScoringEngine.java
@@ -6,9 +6,12 @@ package executor;
  */
 public class ScoringEngine {
     private static final double EDGE_THRESHOLD = 0.002; // 0.2%
-    
+
     private final ModelPredictor predictor;
     private final boolean useEnsemble;
+    private final double ruleWeight;
+    private final double modelWeight;
+    private final double threshold;
  
     /**
      * Construct using default model and configuration flags.
@@ -23,8 +26,22 @@ public class ScoringEngine {
      * @param useEnsemble whether to blend rule and model scores
      */
     public ScoringEngine(ModelPredictor predictor, boolean useEnsemble) {
+        this(
+            predictor,
+            useEnsemble,
+            Double.parseDouble(System.getenv().getOrDefault("RULE_WEIGHT", "0.6")),
+            Double.parseDouble(System.getenv().getOrDefault("MODEL_WEIGHT", "0.4")),
+            Double.parseDouble(System.getenv().getOrDefault("SCORE_THRESHOLD", "0.5"))
+        );
+    }
+
+    public ScoringEngine(ModelPredictor predictor, boolean useEnsemble,
+                         double ruleWeight, double modelWeight, double threshold) {
         this.predictor = predictor;
         this.useEnsemble = useEnsemble;
+        this.ruleWeight = ruleWeight;
+        this.modelWeight = modelWeight;
+        this.threshold = threshold;
     }
 
     /**
@@ -43,9 +60,9 @@ public class ScoringEngine {
         }
         double ruleEdge = opp.getNetEdge();
         double modelPrediction = predictor.predict(opp);
-        double blendedScore = useEnsemble ? 0.6 * ruleEdge + 0.4 * modelPrediction
-        : ruleEdge;
-        return blendedScore > 0.5 && ruleEdge > EDGE_THRESHOLD;
+        double blendedScore = useEnsemble ?
+                ruleWeight * ruleEdge + modelWeight * modelPrediction : ruleEdge;
+        return blendedScore > threshold && ruleEdge > EDGE_THRESHOLD;
     }
     
     /**

--- a/executor/src/main/java/TriangularArbDetector.java
+++ b/executor/src/main/java/TriangularArbDetector.java
@@ -78,6 +78,9 @@ public class TriangularArbDetector {
     }
 
     private void scan() {
+        double bestEdge = 0.0;
+        String bestMessage = null;
+
         for (Map.Entry<String, OrderBook> entry1 : books.entrySet()) {
             String pair1 = entry1.getKey();
             OrderBook first = entry1.getValue();
@@ -102,18 +105,24 @@ public class TriangularArbDetector {
                 double grossEdge = product - 1.0;
                 if (grossEdge > 0) {
                     double netEdge = grossEdge - (3 * feeRate);
-                    String path = t1[0] + "-" + t1[1] + "-" + t2[1];
-                    ObjectNode node = mapper.createObjectNode();
-                    node.put("pair", path);
-                    node.put("buyExchange", "triangular");
-                    node.put("sellExchange", "triangular");
-                    node.put("grossEdge", grossEdge);
-                    node.put("netEdge", netEdge);
-                    String msg = node.toString();
-                    logger.debug("Triangular arbitrage detected: {}", msg);
-                    executor.handleMessage(msg);
+                    if (netEdge > bestEdge) {
+                        bestEdge = netEdge;
+                        String path = t1[0] + "-" + t1[1] + "-" + t2[1];
+                        ObjectNode node = mapper.createObjectNode();
+                        node.put("pair", path);
+                        node.put("buyExchange", "triangular");
+                        node.put("sellExchange", "triangular");
+                        node.put("grossEdge", grossEdge);
+                        node.put("netEdge", netEdge);
+                        bestMessage = node.toString();
+                    }
                 }
             }
+        }
+
+        if (bestMessage != null) {
+            logger.debug("Triangular arbitrage detected: {}", bestMessage);
+            executor.handleMessage(bestMessage);
         }
     }
 

--- a/executor/src/test/java/ScoringEngineTest.java
+++ b/executor/src/test/java/ScoringEngineTest.java
@@ -26,4 +26,12 @@ public class ScoringEngineTest {
         SpreadOpportunity opp = new SpreadOpportunity("BTC/USDT", "A", "B", 0.1, 0.1, 0L);
         assertFalse(engine.scoreSpread(opp));
     }
+
+    @Test
+    void customWeightsViaConstructor() {
+        ScoringEngine engine = new ScoringEngine(new FixedPredictor(0.9), true,
+                0.2, 0.8, 0.5);
+        SpreadOpportunity opp = new SpreadOpportunity("ETH/USDT", "X", "Y", 0.3, 0.3, 0L);
+        assertTrue(engine.scoreSpread(opp));
+    }
 }

--- a/executor/src/test/java/TriangularArbDetectorTest.java
+++ b/executor/src/test/java/TriangularArbDetectorTest.java
@@ -52,5 +52,22 @@ public class TriangularArbDetectorTest {
 
         assertNull(exec.lastMessage);
     }
+
+    @Test
+    void selectsHighestNetEdge() {
+        DummyRedisClient client = new DummyRedisClient();
+        DummyExecutor exec = new DummyExecutor(client);
+        TriangularArbDetector detector = new TriangularArbDetector(exec);
+
+        detector.update("A/B", 0.5, 0.6);
+        detector.update("B/C", 0.5, 0.6);
+        detector.update("C/A", 4.2, 4.3);
+        detector.update("B/D", 0.5, 0.6);
+        detector.update("D/A", 2.0, 2.1);
+
+        assertNotNull(exec.lastMessage);
+        SpreadOpportunity opp = SpreadOpportunity.fromJson(exec.lastMessage);
+        assertEquals("A-B-C", opp.getPair());
+    }
 }
 


### PR DESCRIPTION
## Summary
- make scoring weights configurable via constructor parameters
- pick best triangular arbitrage candidate during scan
- extend tests for new scoring and ranking logic

## Testing
- `./test/run-local.sh`

------
https://chatgpt.com/codex/tasks/task_b_687bf761b570832c9860a655063fffc5