### PR TITLE
Improve scheduler configurability and throttling

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -33,6 +33,10 @@ Lists environment variables used across services.
 | `CANARY_MODE` / `GHOST_MODE` | Feature toggles |
 | `USE_ENSEMBLE` | Enable ensemble model |
 | `sweep_cadence` | Daily, Monthly, or None for automatic sweeps |
+| `REBALANCE_INTERVAL_MINUTES` | Minutes between balance scans |
+| `SWEEP_INTERVAL_DAYS` | Days between cold sweep evaluations |
+| `ARB_SCAN_MS` | Minimum milliseconds between triangular scans |
+| `REDIS_BASE_DELAY_MS` / `REDIS_MAX_DELAY_MS` | Redis reconnect backoff settings |
 | `TEST_COLD_WALLET_ADDRESS` | Address used in sweep tests |
 | `GHOST_FEED_CHANNEL` | Redis channel for ghost trades |
 | `SANDBOX_SLIPPAGE` / `SANDBOX_FEE` / `SANDBOX_LATENCY_MS` | Sandbox exchange settings |

--- a/executor/src/main/java/ColdSweepScheduler.java
+++ b/executor/src/main/java/ColdSweepScheduler.java
@@ -38,9 +38,24 @@ public class ColdSweepScheduler {
         this.capitalSupplier = capitalSupplier;
     }
 
-    /** Start the daily evaluation job. */
+    /** Start the evaluation job with a configurable interval. */
     public void start() {
-        scheduler.scheduleAtFixedRate(this::runOnce, 0, 1, TimeUnit.DAYS);
+        scheduler.scheduleAtFixedRate(this::runOnce, 0,
+                getIntervalDays(), TimeUnit.DAYS);
+    }
+
+    /**
+     * Determine sweep evaluation interval in days using
+     * {@code SWEEP_INTERVAL_DAYS} environment variable or system property.
+     */
+    static long getIntervalDays() {
+        String val = System.getProperty("SWEEP_INTERVAL_DAYS",
+                System.getenv().getOrDefault("SWEEP_INTERVAL_DAYS", "1"));
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return 1L;
+        }
     }
 
     /** Evaluate thresholds and sweep if eligible. */

--- a/executor/src/main/java/RebalanceScheduler.java
+++ b/executor/src/main/java/RebalanceScheduler.java
@@ -31,9 +31,25 @@ public class RebalanceScheduler {
     }
 
     
-    /** Start the 15 minute rebalance job. */
+    /** Start the rebalance job with a configurable interval. */
     public void start() {
-        scheduler.scheduleAtFixedRate(this::runOnce, 0, 15, TimeUnit.MINUTES);
+        scheduler.scheduleAtFixedRate(this::runOnce, 0,
+                getIntervalMinutes(), TimeUnit.MINUTES);
+    }
+
+    /**
+     * Determine the rebalance interval in minutes.
+     * Uses system property or environment variable
+     * {@code REBALANCE_INTERVAL_MINUTES}.
+     */
+    static long getIntervalMinutes() {
+        String val = System.getProperty("REBALANCE_INTERVAL_MINUTES",
+                System.getenv().getOrDefault("REBALANCE_INTERVAL_MINUTES", "15"));
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return 15L;
+        }
     }
 
     /** Collect balances and invoke {@link Rebalancer#rebalance(Map, double)}. */

--- a/executor/src/main/java/RedisClient.java
+++ b/executor/src/main/java/RedisClient.java
@@ -22,6 +22,8 @@ public class RedisClient extends Thread {
     private final int port;
     private final String channel;
     private final MessageHandler handler;
+    private final long baseDelayMs;
+    private final long maxDelayMs;
     private volatile boolean running = true;
 
     /**
@@ -33,11 +35,38 @@ public class RedisClient extends Thread {
      * @param handler callback for incoming messages
      */
     public RedisClient(String host, int port, String channel, MessageHandler handler) {
+        this(host, port, channel, handler, getBaseDelayMs(), getMaxDelayMs());
+    }
+
+    public RedisClient(String host, int port, String channel, MessageHandler handler,
+                       long baseDelayMs, long maxDelayMs) {
         this.host = host;
         this.port = port;
         this.channel = channel;
         this.handler = handler;
+        this.baseDelayMs = baseDelayMs;
+        this.maxDelayMs = maxDelayMs;
         setName("RedisClientSubscriber");
+    }
+
+    static long getBaseDelayMs() {
+        String val = System.getProperty("REDIS_BASE_DELAY_MS",
+                System.getenv().getOrDefault("REDIS_BASE_DELAY_MS", "1000"));
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return 1000L;
+        }
+    }
+
+    static long getMaxDelayMs() {
+        String val = System.getProperty("REDIS_MAX_DELAY_MS",
+                System.getenv().getOrDefault("REDIS_MAX_DELAY_MS", "30000"));
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return 30000L;
+        }
     }
 
     /**
@@ -118,7 +147,7 @@ public class RedisClient extends Thread {
                 }, channel);
                 attempt = 0;
             } catch (Exception e) {
-                long delay = Math.min(30000, (1 << attempt) * 1000L);
+                long delay = Math.min(maxDelayMs, (1L << attempt) * baseDelayMs);
                 logger.error("Redis connection failed: {}", e.getMessage());
                 AlertManager.sendAlert("Redis connection lost: " + e.getMessage());
                 try {

--- a/executor/src/main/java/ResumeHandler.java
+++ b/executor/src/main/java/ResumeHandler.java
@@ -14,16 +14,25 @@ public class ResumeHandler {
      private static final Logger logger = LoggerFactory.getLogger(ResumeHandler.class);
 
     private final Object redis;
-     private final Executor executor;
-     private Thread thread;
+    private final Executor executor;
+    private final long baseDelayMs;
+    private final long maxDelayMs;
+    private Thread thread;
 
     /**
      * @param redis     redis connection or client
      * @param executor  executor to be resumed
      */
      public ResumeHandler(Object redis, Executor executor) {
+         this(redis, executor, getBaseDelayMs(), getMaxDelayMs());
+     }
+
+     public ResumeHandler(Object redis, Executor executor,
+                          long baseDelayMs, long maxDelayMs) {
          this.redis = redis;
          this.executor = executor;
+         this.baseDelayMs = baseDelayMs;
+         this.maxDelayMs = maxDelayMs;
      }
 
     /**
@@ -57,7 +66,7 @@ public class ResumeHandler {
                     }
                     attempt = 0;
                 } catch (Exception e) {
-                    long delay = Math.min(30000L, (1L << attempt) * 1000L);
+                    long delay = Math.min(maxDelayMs, (1L << attempt) * baseDelayMs);
                     logger.error("Redis subscription failed: {}", e.getMessage());
                     try {
                         Thread.sleep(delay);
@@ -78,5 +87,25 @@ public class ResumeHandler {
     public interface ResumeCapable {
         /** Trigger resumption of normal trading. */
         void resumeFromPanic();
+    }
+
+    static long getBaseDelayMs() {
+        String val = System.getProperty("REDIS_BASE_DELAY_MS",
+                System.getenv().getOrDefault("REDIS_BASE_DELAY_MS", "1000"));
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return 1000L;
+        }
+    }
+
+    static long getMaxDelayMs() {
+        String val = System.getProperty("REDIS_MAX_DELAY_MS",
+                System.getenv().getOrDefault("REDIS_MAX_DELAY_MS", "30000"));
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return 30000L;
+        }
     }
 }

--- a/executor/src/main/java/TriangularArbDetector.java
+++ b/executor/src/main/java/TriangularArbDetector.java
@@ -9,6 +9,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Detects triangular arbitrage opportunities from order books and
@@ -34,12 +38,41 @@ public class TriangularArbDetector {
     private final Executor executor;
     private final ObjectMapper mapper = new ObjectMapper();
     private final double feeRate = 0.001;
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private final long intervalMs;
+    private final AtomicBoolean dirty = new AtomicBoolean(false);
 
     /**
      * @param executor executor to notify when opportunities arise
      */
     public TriangularArbDetector(Executor executor) {
+        this(executor, getIntervalMs());
+    }
+
+    /**
+     * @param executor    executor to notify
+     * @param intervalMs  minimum milliseconds between scans (0 for immediate)
+     */
+    public TriangularArbDetector(Executor executor, long intervalMs) {
         this.executor = executor;
+        this.intervalMs = intervalMs > 0 ? intervalMs : 0;
+        if (this.intervalMs > 0) {
+            scheduler.scheduleAtFixedRate(() -> {
+                if (dirty.getAndSet(false)) {
+                    scan();
+                }
+            }, this.intervalMs, this.intervalMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    static long getIntervalMs() {
+        String val = System.getProperty("ARB_SCAN_MS",
+                System.getenv().getOrDefault("ARB_SCAN_MS", "100"));
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return 100L;
+        }
     }
 
     /**
@@ -74,7 +107,11 @@ public class TriangularArbDetector {
         if (parts != null) {
             adjacency.computeIfAbsent(parts[0], k -> new HashSet<>()).add(pair);
         }
-        scan();
+        dirty.set(true);
+        if (intervalMs == 0) {
+            scan();
+            dirty.set(false);
+        }
     }
 
     private void scan() {
@@ -130,5 +167,10 @@ public class TriangularArbDetector {
         if (pair == null) return null;
         String[] parts = pair.split("/");
         return parts.length == 2 ? parts : null;
+    }
+
+    /** Stop the scheduled scans. */
+    public void stop() {
+        scheduler.shutdownNow();
     }
 }

--- a/executor/src/test/java/ColdSweepSchedulerTest.java
+++ b/executor/src/test/java/ColdSweepSchedulerTest.java
@@ -57,4 +57,11 @@ public class ColdSweepSchedulerTest {
         scheduler.runOnce(LocalDate.of(2025,1,1));
         assertTrue(wallet.called);
     }
+
+    @Test
+    void parsesIntervalProperty() {
+        System.setProperty("SWEEP_INTERVAL_DAYS", "2");
+        assertEquals(2, ColdSweepScheduler.getIntervalDays());
+        System.clearProperty("SWEEP_INTERVAL_DAYS");
+    }
 }

--- a/executor/src/test/java/ExecutorRedisRecoveryTest.java
+++ b/executor/src/test/java/ExecutorRedisRecoveryTest.java
@@ -12,7 +12,7 @@ public class ExecutorRedisRecoveryTest {
     static class FlakyRedisClient extends RedisClient {
         MessageHandler handler;
         FlakyRedisClient() {
-            super("localhost", 6379, "chan", (c, m) -> {});
+            super("localhost", 6379, "chan", (c, m) -> {}, 1L, 2L);
         }
         void setHandler(MessageHandler h) { this.handler = h; }
         @Override public void start() { run(); }

--- a/executor/src/test/java/RebalanceSchedulerTest.java
+++ b/executor/src/test/java/RebalanceSchedulerTest.java
@@ -42,4 +42,11 @@ public class RebalanceSchedulerTest {
         assertEquals(2, rebalancer.lastBalances.size());
         assertEquals(5000.0, rebalancer.lastTarget, 0.001);
     }
+
+    @Test
+    void parsesIntervalFromProperty() {
+        System.setProperty("REBALANCE_INTERVAL_MINUTES", "3");
+        assertEquals(3, RebalanceScheduler.getIntervalMinutes());
+        System.clearProperty("REBALANCE_INTERVAL_MINUTES");
+    }
 }

--- a/executor/src/test/java/ResumeHandlerTest.java
+++ b/executor/src/test/java/ResumeHandlerTest.java
@@ -16,7 +16,7 @@ public class ResumeHandlerTest {
     /** Simple stub of the Redis client that immediately sends a resume message. */
     static class StubRedisClient extends RedisClient {
         StubRedisClient() {
-            super("localhost", 6379, "chan", (c, m) -> {});
+            super("localhost", 6379, "chan", (c, m) -> {}, 1L, 2L);
         }
 
         @Override
@@ -31,7 +31,7 @@ public class ResumeHandlerTest {
         final AtomicBoolean resumed = new AtomicBoolean(false);
 
         DummyExecutor() {
-            super(new executor.RedisClient("localhost", 6379, "chan", (c, m) -> {}),
+            super(new executor.RedisClient("localhost", 6379, "chan", (c, m) -> {}, 1L, 2L),
                     "localhost", 6379, new executor.RiskFilter(), new executor.NearMissLogger(null));
         }
 
@@ -44,7 +44,7 @@ public class ResumeHandlerTest {
     @Test
     void invokesResumeOnMessage() throws Exception {
         DummyExecutor exec = new DummyExecutor();
-        ResumeHandler handler = new ResumeHandler(new StubRedisClient(), exec);
+        ResumeHandler handler = new ResumeHandler(new StubRedisClient(), exec, 1L, 2L);
         handler.start();
         // Wait briefly to allow the handler thread to process the message
         Thread.sleep(50);

--- a/executor/src/test/java/TriangularArbDetectorTest.java
+++ b/executor/src/test/java/TriangularArbDetectorTest.java
@@ -21,11 +21,17 @@ public class TriangularArbDetectorTest {
         @Override public void handleMessage(String msg) { lastMessage = msg; }
     }
 
+    static class CountingExecutor extends DummyExecutor {
+        int count = 0;
+        CountingExecutor(DummyRedisClient c) { super(c); }
+        @Override public void handleMessage(String msg) { count++; super.handleMessage(msg); }
+    }
+
     @Test
     void detectsArbitrageLoop() {
         DummyRedisClient client = new DummyRedisClient();
         DummyExecutor exec = new DummyExecutor(client);
-        TriangularArbDetector detector = new TriangularArbDetector(exec);
+        TriangularArbDetector detector = new TriangularArbDetector(exec, 0);
 
         detector.update("A/B", 0.5, 0.6);
         detector.update("B/C", 0.5, 0.6);
@@ -44,7 +50,7 @@ public class TriangularArbDetectorTest {
     void ignoresNonProfitableLoop() {
         DummyRedisClient client = new DummyRedisClient();
         DummyExecutor exec = new DummyExecutor(client);
-        TriangularArbDetector detector = new TriangularArbDetector(exec);
+        TriangularArbDetector detector = new TriangularArbDetector(exec, 0);
 
         detector.update("A/B", 1.0, 1.01);
         detector.update("B/C", 1.0, 1.01);
@@ -57,7 +63,7 @@ public class TriangularArbDetectorTest {
     void selectsHighestNetEdge() {
         DummyRedisClient client = new DummyRedisClient();
         DummyExecutor exec = new DummyExecutor(client);
-        TriangularArbDetector detector = new TriangularArbDetector(exec);
+        TriangularArbDetector detector = new TriangularArbDetector(exec, 0);
 
         detector.update("A/B", 0.5, 0.6);
         detector.update("B/C", 0.5, 0.6);
@@ -68,6 +74,22 @@ public class TriangularArbDetectorTest {
         assertNotNull(exec.lastMessage);
         SpreadOpportunity opp = SpreadOpportunity.fromJson(exec.lastMessage);
         assertEquals("A-B-C", opp.getPair());
+    }
+
+    @Test
+    void throttlesScanFrequency() throws Exception {
+        DummyRedisClient client = new DummyRedisClient();
+        CountingExecutor exec = new CountingExecutor(client);
+        TriangularArbDetector detector = new TriangularArbDetector(exec, 50);
+
+        detector.update("A/B", 0.5, 0.6);
+        detector.update("B/C", 0.5, 0.6);
+        detector.update("C/A", 4.2, 4.3);
+        detector.update("A/B", 0.6, 0.7);
+
+        Thread.sleep(60);
+        detector.stop();
+        assertEquals(1, exec.count);
     }
 }
 

--- a/scripts/mock-ghost-feed.js
+++ b/scripts/mock-ghost-feed.js
@@ -46,5 +46,13 @@ console.log(
   `Publishing mock trades to redis://${args.host}:${args.port}/${args.channel} every ${args.interval}ms`,
 );
 
-publish();
-setInterval(publish, Number(args.interval));
+let running = false;
+async function loop() {
+  if (running) return;
+  running = true;
+  publish();
+  running = false;
+  setTimeout(loop, Number(args.interval));
+}
+
+loop();

--- a/scripts/personality-scheduler.js
+++ b/scripts/personality-scheduler.js
@@ -23,5 +23,13 @@ async function checkAndUpdate() {
   }
 }
 
-checkAndUpdate();
-setInterval(checkAndUpdate, INTERVAL_MS);
+let running = false;
+async function loop() {
+  if (running) return;
+  running = true;
+  await checkAndUpdate();
+  running = false;
+  setTimeout(loop, INTERVAL_MS);
+}
+
+loop();


### PR DESCRIPTION
## Summary
- add env var docs for new scheduler config options
- make rebalance and sweep scheduler intervals configurable
- throttle triangular arb scanning and add stop method
- expose Redis retry delays and update resume handler
- prevent overlapping node script executions
- update unit tests

## Testing
- `pip install flask==3.1.1 python-dotenv==1.1.1 prometheus_client==0.22.1 numpy==2.1.3 pytest==8.4.1 joblib==1.5.1 psycopg2-binary==2.9.10 redis==6.2.0`
- `pytest` *(fails: ModuleNotFoundError: No module named 'tensorflow')*
- `cd executor && ./gradlew test -PtestEnv=local`
- `cd ../api && npm install && npm test`
- `cd ../dashboard && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_b_687bfc93aefc832c966f251e9bcf033c