### PR TITLE
Fix panic brake test mode operations

### DIFF
--- a/api/__tests__/panicResume.test.js
+++ b/api/__tests__/panicResume.test.js
@@ -25,7 +25,7 @@ describeLocal('panic resume cycle', () => {
     const metrics1 = await request(app.server).get('/api/metrics');
     expect(metrics1.body.panicActive).toBe(true);
 
-    const resumeRes = await request(app.server).post('/api/resume');
+    const resumeRes = await request(app.server).post('/api/test/resume');
     expect(resumeRes.statusCode).toBe(200);
     expect(testState.panic).toBe(false);
 

--- a/api/index.js
+++ b/api/index.js
@@ -152,11 +152,14 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
     if (isTest) {
       api.post('/test/panic', async () => {
         testState.panic = true;
+        await redis.publish('control-feed', 'halt');
+        await sendAlert('email', 'Panic brake triggered (test mode)');
         return { triggered: true };
       });
 
       api.post('/test/resume', async () => {
         testState.panic = false;
+        await redis.publish('control-feed', 'resume');
         return { resumed: true };
       });
 

--- a/executor/src/main/java/PanicBrake.java
+++ b/executor/src/main/java/PanicBrake.java
@@ -20,17 +20,51 @@ public class PanicBrake {
      * @return {@code true} if trading should halt
      */
 
+    private static double getLossCapPct() {
+        String val = System.getProperty("LOSS_CAP_PCT",
+                System.getenv().getOrDefault("LOSS_CAP_PCT", "3.0"));
+        try {
+            return Double.parseDouble(val);
+        } catch (NumberFormatException e) {
+            return 3.0;
+        }
+    }
+
+    private static double getLatencyMaxMs() {
+        String val = System.getProperty("LATENCY_MAX_MS",
+                System.getenv().getOrDefault("LATENCY_MAX_MS", "500.0"));
+        try {
+            return Double.parseDouble(val);
+        } catch (NumberFormatException e) {
+            return 500.0;
+        }
+    }
+
+    private static double getWinRateThreshold() {
+        String val = System.getProperty("WIN_RATE_THRESHOLD",
+                System.getenv().getOrDefault("WIN_RATE_THRESHOLD", "0.4"));
+        try {
+            return Double.parseDouble(val);
+        } catch (NumberFormatException e) {
+            return 0.4;
+        }
+    }
+
     public static boolean shouldHalt(double dailyLossPct, double avgLatencyMs, double winRate) {
-        if (dailyLossPct > 3.0) {
-            logger.warn("PANIC BRAKE TRIGGERED: loss {}% > 3.0%", dailyLossPct);
+        double lossCap = getLossCapPct();
+        double latencyCap = getLatencyMaxMs();
+        double winRateThresh = getWinRateThreshold();
+
+        if (dailyLossPct > lossCap) {
+            logger.warn("PANIC BRAKE TRIGGERED: loss {}% > {}%", dailyLossPct, lossCap);
             return true;
         }
-        if (avgLatencyMs > 500.0) {
-            logger.warn("PANIC BRAKE TRIGGERED: latency {}ms > 500ms", avgLatencyMs);
+        if (avgLatencyMs > latencyCap) {
+            logger.warn("PANIC BRAKE TRIGGERED: latency {}ms > {}ms", avgLatencyMs, latencyCap);
             return true;
         }
-        if (winRate < 0.4) {
-            logger.warn("PANIC BRAKE TRIGGERED: winRate {} < 0.4", winRate);
+        if (winRate < winRateThresh) {
+            logger.warn("PANIC BRAKE TRIGGERED: winRate {} < {}", winRate, winRateThresh);
             return true;
         }
         return false;

--- a/executor/src/test/java/PanicBrakeTest.java
+++ b/executor/src/test/java/PanicBrakeTest.java
@@ -26,4 +26,18 @@ public class PanicBrakeTest {
     void passesIfAllWithinLimits() {
         assertFalse(PanicBrake.shouldHalt(1.0, 100.0, 0.8));
     }
+
+    @Test
+    void readsThresholdsFromProperties() {
+        System.setProperty("LOSS_CAP_PCT", "1.5");
+        System.setProperty("LATENCY_MAX_MS", "200.0");
+        System.setProperty("WIN_RATE_THRESHOLD", "0.9");
+        try {
+            assertTrue(PanicBrake.shouldHalt(2.0, 300.0, 0.5));
+        } finally {
+            System.clearProperty("LOSS_CAP_PCT");
+            System.clearProperty("LATENCY_MAX_MS");
+            System.clearProperty("WIN_RATE_THRESHOLD");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- publish control-feed signals from test panic/resume routes
- alert on panic activation in test mode
- read panic brake thresholds from environment
- add property-based PanicBrake test
- update panic/resume integration test

## Testing
- `npm --prefix dashboard test -- --runInBand`
- `npm --prefix api test -- --runInBand`
- `pytest`
- `executor/gradlew test -p executor -PtestEnv=local --no-daemon`


------
https://chatgpt.com/codex/tasks/task_b_687c03b45d90832c9f264006b88f853f