### PR TITLE
Add manual cold sweep handler and explicit amount

### DIFF
--- a/executor/src/main/java/ColdSweepScheduler.java
+++ b/executor/src/main/java/ColdSweepScheduler.java
@@ -79,7 +79,7 @@ public class ColdSweepScheduler {
         double capital = capitalSupplier.get();
         if (sweeper.shouldSweep(profit, capital)) {
             logger.info("Cold sweep triggered");
-            sweeper.sweepToColdWallet();
+            sweeper.sweepToColdWallet(profit);
         }
     }
 

--- a/executor/src/main/java/ColdSweeper.java
+++ b/executor/src/main/java/ColdSweeper.java
@@ -75,21 +75,22 @@ public class ColdSweeper {
      * Logs the sweep action. Stub for actual wallet transfer.
      * Uses the address from {@link ColdSweeperConfig}.
      */
-    public void sweepToColdWallet() {
+    public void sweepToColdWallet(double amountUsd) {
         String address = config.getTestColdWalletAddress();
-        logger.info("Cold wallet sweep triggered for: {}", address);
-        logger.info("Sweeping to cold wallet: {}", address);
-        walletClient.withdraw(address);
+        logger.info("Cold wallet sweep triggered for: {} amount {}", address, amountUsd);
+        walletClient.withdraw(address, amountUsd);
+        ProfitTracker.resetCumulativeProfit();
     }
 
     /**
      * Logs the sweep action to a custom address.
      *
      * @param address destination cold wallet address
+     * @param amountUsd amount to sweep
      */
-    public void sweepToColdWallet(String address) {
-        logger.info("Cold wallet sweep triggered for: {}", address);
-        logger.info("Sweeping to cold wallet: {}", address);
-        walletClient.withdraw(address);
+    public void sweepToColdWallet(String address, double amountUsd) {
+        logger.info("Cold wallet sweep triggered for: {} amount {}", address, amountUsd);
+        walletClient.withdraw(address, amountUsd);
+        ProfitTracker.resetCumulativeProfit();
     }
 }

--- a/executor/src/main/java/Main.java
+++ b/executor/src/main/java/Main.java
@@ -12,6 +12,8 @@ import executor.RebalanceScheduler;
 import executor.Rebalancer;
 import executor.ExchangeAdapter;
 import executor.ProfitTracker;
+import executor.SweepHandler;
+import redis.clients.jedis.Jedis;
 
 /**
  * Entry point for launching the executor from the command line.
@@ -62,11 +64,16 @@ public class Main {
         ColdSweeper sweeper = new ColdSweeper();
         ColdSweepScheduler sweepScheduler = new ColdSweepScheduler(
                 sweeper,
-                () -> System.getenv().getOrDefault("SWEEP_CADENCE", "None"),
+                () -> System.getProperty("sweep_cadence",
+                        System.getenv().getOrDefault("sweep_cadence", "None")),
                 ProfitTracker::getCumulativeProfit,
                 () -> ProfitTracker.getStartingBalance() + ProfitTracker.getCumulativeProfit()
         );
         sweepScheduler.start();
+
+        // start handler for manual sweeps
+        SweepHandler sweepHandler = new SweepHandler(new Jedis(redisHost, redisPort), sweeper);
+        sweepHandler.start();
 
         Rebalancer rebalancer = new Rebalancer(250.0);
         Map<String, ExchangeAdapter> adapters = new HashMap<>();

--- a/executor/src/main/java/MockWalletClient.java
+++ b/executor/src/main/java/MockWalletClient.java
@@ -11,7 +11,7 @@ public class MockWalletClient implements WalletClient {
 
     /** {@inheritDoc} */
     @Override
-    public void withdraw(String address) {
-        logger.info("Withdrawing funds to cold wallet: {}", address);
+    public void withdraw(String address, double amountUsd) {
+        logger.info("Withdrawing {} USD to cold wallet: {}", amountUsd, address);
     }
 }

--- a/executor/src/main/java/ProfitTracker.java
+++ b/executor/src/main/java/ProfitTracker.java
@@ -111,6 +111,11 @@ public class ProfitTracker {
     public static double getCumulativeProfit() {
         return cumulativeProfit;
     }
+
+    /** Reset the cumulative profit after a cold sweep. */
+    public static void resetCumulativeProfit() {
+        cumulativeProfit = 0.0;
+    }
     
     /**
      * Get the initial starting balance used for drawdown calculations.

--- a/executor/src/main/java/SweepHandler.java
+++ b/executor/src/main/java/SweepHandler.java
@@ -1,0 +1,80 @@
+package executor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Listens for "sweep" commands on a Redis channel and triggers the cold wallet sweep.
+ */
+public class SweepHandler {
+    private static final String CHANNEL = "control-feed";
+    private static final Logger logger = LoggerFactory.getLogger(SweepHandler.class);
+
+    private final Object redis;
+    private final ColdSweeper sweeper;
+    private final long baseDelayMs;
+    private final long maxDelayMs;
+    private Thread thread;
+
+    /**
+     * @param redis   redis connection or client
+     * @param sweeper cold sweeper instance
+     */
+    public SweepHandler(Object redis, ColdSweeper sweeper) {
+        this(redis, sweeper, ResumeHandler.getBaseDelayMs(), ResumeHandler.getMaxDelayMs());
+    }
+
+    public SweepHandler(Object redis, ColdSweeper sweeper, long baseDelayMs, long maxDelayMs) {
+        this.redis = redis;
+        this.sweeper = sweeper;
+        this.baseDelayMs = baseDelayMs;
+        this.maxDelayMs = maxDelayMs;
+    }
+
+    /** Begin listening for sweep messages. */
+    public void start() {
+        thread = new Thread(() -> {
+            int attempt = 0;
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    if (redis instanceof redis.clients.jedis.Jedis jedis) {
+                        jedis.subscribe(new redis.clients.jedis.JedisPubSub() {
+                            @Override
+                            public void onMessage(String channel, String message) {
+                                if ("sweep".equalsIgnoreCase(message)) {
+                                    logger.info("Received 'sweep' command from Redis");
+                                    double amount = ProfitTracker.getCumulativeProfit();
+                                    sweeper.sweepToColdWallet(amount);
+                                }
+                            }
+                        }, CHANNEL);
+                        break;
+                    } else if (redis instanceof RedisClient client) {
+                        client.subscribe(new redis.clients.jedis.JedisPubSub() {
+                            @Override
+                            public void onMessage(String channel, String message) {
+                                if ("sweep".equalsIgnoreCase(message)) {
+                                    logger.info("Received 'sweep' command from Redis");
+                                    double amount = ProfitTracker.getCumulativeProfit();
+                                    sweeper.sweepToColdWallet(amount);
+                                }
+                            }
+                        }, CHANNEL);
+                        break;
+                    }
+                    attempt = 0;
+                } catch (Exception e) {
+                    long delay = Math.min(maxDelayMs, (1L << attempt) * baseDelayMs);
+                    logger.error("Redis subscription failed: {}", e.getMessage());
+                    try {
+                        Thread.sleep(delay);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    }
+                    attempt++;
+                }
+            }
+        });
+        thread.start();
+    }
+}

--- a/executor/src/main/java/WalletClient.java
+++ b/executor/src/main/java/WalletClient.java
@@ -9,5 +9,5 @@ public interface WalletClient {
      *
      * @param address destination address
      */
-    void withdraw(String address);
+    void withdraw(String address, double amountUsd);
 }

--- a/executor/src/test/java/ColdSweepSchedulerTest.java
+++ b/executor/src/test/java/ColdSweepSchedulerTest.java
@@ -11,9 +11,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ColdSweepSchedulerTest {
     static class TestWalletClient implements WalletClient {
         boolean called = false;
+        double lastAmount = 0.0;
         @Override
-        public void withdraw(String address) {
+        public void withdraw(String address, double amountUsd) {
             called = true;
+            lastAmount = amountUsd;
         }
     }
 
@@ -41,6 +43,7 @@ public class ColdSweepSchedulerTest {
                 () -> 10.0);
         scheduler.runOnce(LocalDate.of(2025,1,2));
         assertTrue(wallet.called);
+        assertEquals(10.0, wallet.lastAmount, 0.0001);
     }
 
     @Test
@@ -56,6 +59,7 @@ public class ColdSweepSchedulerTest {
         assertFalse(wallet.called);
         scheduler.runOnce(LocalDate.of(2025,1,1));
         assertTrue(wallet.called);
+        assertEquals(10.0, wallet.lastAmount, 0.0001);
     }
 
     @Test
@@ -63,5 +67,21 @@ public class ColdSweepSchedulerTest {
         System.setProperty("SWEEP_INTERVAL_DAYS", "2");
         assertEquals(2, ColdSweepScheduler.getIntervalDays());
         System.clearProperty("SWEEP_INTERVAL_DAYS");
+    }
+
+    @Test
+    void respectsSweepCadenceProperty() {
+        System.setProperty("sweep_cadence", "Daily");
+        TestWalletClient wallet = new TestWalletClient();
+        ColdSweeper sweeper = new ColdSweeper(0, 0, wallet);
+        ColdSweepScheduler scheduler = new ColdSweepScheduler(
+                sweeper,
+                () -> System.getProperty("sweep_cadence",
+                        System.getenv().getOrDefault("sweep_cadence", "None")),
+                () -> 5.0,
+                () -> 5.0);
+        scheduler.runOnce(LocalDate.of(2025,1,2));
+        assertTrue(wallet.called);
+        System.clearProperty("sweep_cadence");
     }
 }

--- a/executor/src/test/java/SweepHandlerTest.java
+++ b/executor/src/test/java/SweepHandlerTest.java
@@ -1,0 +1,48 @@
+package executor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class SweepHandlerTest {
+
+    /** Redis stub that immediately emits a sweep message. */
+    static class StubRedisClient extends RedisClient {
+        StubRedisClient() {
+            super("localhost", 6379, "chan", (c, m) -> {}, 1L, 2L);
+        }
+
+        @Override
+        public void subscribe(redis.clients.jedis.JedisPubSub listener, String... channels) {
+            listener.onMessage(channels[0], "sweep");
+        }
+    }
+
+    /** Wallet stub capturing withdrawal requests. */
+    static class CaptureWallet implements WalletClient {
+        boolean called = false;
+        double amount = 0.0;
+
+        @Override
+        public void withdraw(String address, double amountUsd) {
+            if (!called) {
+                called = true;
+                amount = amountUsd;
+            }
+        }
+    }
+
+    @Test
+    void invokesSweepOnMessage() throws Exception {
+        CaptureWallet wallet = new CaptureWallet();
+        ColdSweeper sweeper = new ColdSweeper(0, 0, wallet);
+        ProfitTracker.resetCumulativeProfit();
+        ProfitTracker.record(12.0);
+        SweepHandler handler = new SweepHandler(new StubRedisClient(), sweeper, 1L, 2L);
+        handler.start();
+        Thread.sleep(50);  // allow handler thread to process
+        assertTrue(wallet.called);
+        assertEquals(12.0, wallet.amount, 0.0001);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `WalletClient` to specify withdrawal amount
- implement `SweepHandler` for manual sweep commands
- record and clear cumulative profit on sweeps
- include sweep amount in `ColdSweeper` and scheduler
- instantiate sweep handler in `Main`
- update scheduler tests and add new sweep handler test

## Testing
- `./executor/gradlew test -p executor -PtestEnv=local`
- `bash test/run-local.sh` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687c09813b00832c8a867921fe52b207