### PR TITLE
Improve adapter determinism and env handling

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -9,6 +9,7 @@ Lists environment variables used across services.
 |------|-------------|
 | `PGHOST` / `PGPORT` / `PGUSER` / `PGPASSWORD` / `PGDATABASE` | Postgres connection settings |
 | `REDIS_HOST` / `REDIS_PORT` / `REDIS_CHANNEL` | Redis host, port and pub/sub channel |
+| `ORDERBOOK_CHANNEL` / `ALERT_CHANNEL` | Feed and alert Redis channels |
 | `JWT_SECRET` | Token signing key for the API |
 | `ADMIN_TOKEN` | Required for admin-only API endpoints |
 | `SENTRY_DSN` | Error reporting endpoint |

--- a/executor/src/main/java/MockExchangeAdapter.java
+++ b/executor/src/main/java/MockExchangeAdapter.java
@@ -20,7 +20,7 @@ public class MockExchangeAdapter implements ExchangeAdapter {
         FEE_RATES.put("Mock", 0.001);
     }
 
-    private final Random random = new Random();
+    private final Random random;
     private final String name;
     private final double cancelFeeRate;
     private double lastFillSize = 0.0;
@@ -44,8 +44,18 @@ public class MockExchangeAdapter implements ExchangeAdapter {
      * @param cancelFeeRate  fee charged when an order is cancelled or partially filled
      */
     public MockExchangeAdapter(String name, double cancelFeeRate) {
+        this(name, cancelFeeRate, new Random());
+    }
+
+    /**
+     * @param name          identifier used when logging activity
+     * @param cancelFeeRate fee charged when an order is cancelled or partially filled
+     * @param random        random number generator for deterministic tests
+     */
+    public MockExchangeAdapter(String name, double cancelFeeRate, Random random) {
         this.name = name;
         this.cancelFeeRate = cancelFeeRate;
+        this.random = random;
     }
 
     /**

--- a/executor/src/main/java/SandboxExchangeAdapter.java
+++ b/executor/src/main/java/SandboxExchangeAdapter.java
@@ -19,21 +19,51 @@ public class SandboxExchangeAdapter extends MockExchangeAdapter {
     private static final String CHANNEL =
             System.getenv().getOrDefault("GHOST_FEED_CHANNEL", "ghost_feed");
 
-    private final Random random = new Random();
+    private final Random random;
     private final double slippagePct;
     private final long latencyMs;
     private final RedisClient redisClient;
     private final ModelPredictor predictor;
+
+    private static double parseDoubleEnv(String key, double def) {
+        String val = System.getProperty(key,
+                System.getenv().getOrDefault(key, Double.toString(def)));
+        try {
+            return Double.parseDouble(val);
+        } catch (NumberFormatException e) {
+            return def;
+        }
+    }
+
+    private static long parseLongEnv(String key, long def) {
+        String val = System.getProperty(key,
+                System.getenv().getOrDefault(key, Long.toString(def)));
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return def;
+        }
+    }
 
     /**
      * Construct using environment configured parameters.
      */
     public SandboxExchangeAdapter(RedisClient redisClient,
                                   ModelPredictor predictor) {
+        this(redisClient, predictor, new Random());
+    }
+
+    /**
+     * Construct using environment configured parameters and explicit RNG.
+     */
+    public SandboxExchangeAdapter(RedisClient redisClient,
+                                  ModelPredictor predictor,
+                                  Random random) {
         this("Sandbox", redisClient, predictor,
-             Double.parseDouble(System.getenv().getOrDefault("SANDBOX_SLIPPAGE", "0.0005")),
-             Double.parseDouble(System.getenv().getOrDefault("SANDBOX_FEE", "0.001")),
-             Long.parseLong(System.getenv().getOrDefault("SANDBOX_LATENCY_MS", "50")));
+             parseDoubleEnv("SANDBOX_SLIPPAGE", 0.0005),
+             parseDoubleEnv("SANDBOX_FEE", 0.001),
+             parseLongEnv("SANDBOX_LATENCY_MS", 50),
+             random);
     }
 
     /**
@@ -45,7 +75,21 @@ public class SandboxExchangeAdapter extends MockExchangeAdapter {
                                   double slippagePct,
                                   double feeRate,
                                   long latencyMs) {
-        super(name);
+        this(name, redisClient, predictor, slippagePct, feeRate, latencyMs, new Random());
+    }
+
+    /**
+     * Create a sandbox adapter with explicit settings and random source.
+     */
+    public SandboxExchangeAdapter(String name,
+                                  RedisClient redisClient,
+                                  ModelPredictor predictor,
+                                  double slippagePct,
+                                  double feeRate,
+                                  long latencyMs,
+                                  Random random) {
+        super(name, 0.0002, random);
+        this.random = random;
         this.redisClient = redisClient;
         this.predictor = predictor;
         this.slippagePct = slippagePct;

--- a/executor/src/test/java/MockExchangeAdapterTest.java
+++ b/executor/src/test/java/MockExchangeAdapterTest.java
@@ -2,6 +2,7 @@ package executor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import java.util.Random;
 import static org.junit.jupiter.api.Assertions.*;
 
 // For using ExchangeAdapter interface in tests
@@ -11,7 +12,7 @@ import executor.ExchangeAdapter;
 public class MockExchangeAdapterTest {
     @Test
     void feeRateCanBeOverridden() {
-        MockExchangeAdapter adapter = new MockExchangeAdapter("Test");
+        MockExchangeAdapter adapter = new MockExchangeAdapter("Test", 0.0002, new Random(42));
         assertEquals(0.001, adapter.getFeeRate("BTC/USDT"), 1e-9);
         MockExchangeAdapter.setFeeRate("Test", 0.002);
         assertEquals(0.002, adapter.getFeeRate("BTC/USDT"), 1e-9);
@@ -20,13 +21,13 @@ public class MockExchangeAdapterTest {
 
     @Test
     void balanceAlwaysTenThousand() {
-        MockExchangeAdapter adapter = new MockExchangeAdapter("Test");
+        MockExchangeAdapter adapter = new MockExchangeAdapter("Test", 0.0002, new Random(42));
         assertEquals(10000.0, adapter.getBalance("BTC"), 1e-9);
     }
 
     @Test
     void placeOrderSucceedsRoughlyEightyPercent() {
-        MockExchangeAdapter adapter = new MockExchangeAdapter("Test");
+        MockExchangeAdapter adapter = new MockExchangeAdapter("Test", 0.0002, new Random(42));
         int success = 0;
         int total = 1000;
         for (int i = 0; i < total; i++) {
@@ -40,7 +41,7 @@ public class MockExchangeAdapterTest {
 
     @Test
     void partialFillSetsFeeAndSize() {
-        MockExchangeAdapter adapter = new MockExchangeAdapter("Test");
+        MockExchangeAdapter adapter = new MockExchangeAdapter("Test", 0.0002, new Random(42));
         boolean observed = false;
         for (int i = 0; i < 1000 && !observed; i++) {
             boolean filled = adapter.placeOrder("BTC/USDT", "BUY", 1.0, 50000.0);
@@ -55,7 +56,7 @@ public class MockExchangeAdapterTest {
 
     @Test
     void transferDoesNotThrow() {
-        ExchangeAdapter adapter = new MockExchangeAdapter("Test");
+        ExchangeAdapter adapter = new MockExchangeAdapter("Test", 0.0002, new Random(42));
         assertDoesNotThrow(() -> adapter.transfer("USDT", 1.5, "wallet"));
     }
 }

--- a/executor/src/test/java/RebalanceSchedulerTest.java
+++ b/executor/src/test/java/RebalanceSchedulerTest.java
@@ -2,6 +2,7 @@ package executor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import java.util.Random;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
@@ -25,11 +26,11 @@ public class RebalanceSchedulerTest {
     @Test
     void runOnceCollectsBalances() {
         Map<String, ExchangeAdapter> adapters = new HashMap<>();
-        adapters.put("Binance", new MockExchangeAdapter("Binance") {
+        adapters.put("Binance", new MockExchangeAdapter("Binance", 0.0002, new Random(42)) {
             @Override
             public double getBalance(String asset) { return 6000.0; }
         });
-        adapters.put("Kraken", new MockExchangeAdapter("Kraken") {
+        adapters.put("Kraken", new MockExchangeAdapter("Kraken", 0.0002, new Random(42)) {
             @Override
             public double getBalance(String asset) { return 4000.0; }
         });

--- a/executor/src/test/java/SandboxExchangeAdapterTest.java
+++ b/executor/src/test/java/SandboxExchangeAdapterTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -22,7 +23,7 @@ public class SandboxExchangeAdapterTest {
     @Test
     void publishesAndReturnsResult() throws Exception {
         DummyRedis redis = new DummyRedis();
-        SandboxExchangeAdapter adapter = new SandboxExchangeAdapter(redis, opp -> 0.7);
+        SandboxExchangeAdapter adapter = new SandboxExchangeAdapter(redis, opp -> 0.7, new Random(42));
         SpreadOpportunity opp = new SpreadOpportunity("BTC/USDT", "A", "B", 0.1, 0.1, 0L);
         TradeResult result = adapter.execute(opp, 1.0, 1.0);
         assertNotNull(result);
@@ -35,5 +36,22 @@ public class SandboxExchangeAdapterTest {
         assertEquals(result.latencyMs, node.get("latency_ms").asLong());
         assertEquals(result.pnl, node.get("simulated_pnl").asDouble(), 1e-9);
         assertTrue(result.pnl <= 0.1);
+    }
+
+    @Test
+    void invalidEnvValuesFallbackToDefaults() {
+        System.setProperty("SANDBOX_SLIPPAGE", "bad");
+        System.setProperty("SANDBOX_FEE", "oops");
+        System.setProperty("SANDBOX_LATENCY_MS", "wrong");
+
+        DummyRedis redis = new DummyRedis();
+        SandboxExchangeAdapter adapter = new SandboxExchangeAdapter(redis, o -> 0.5, new Random(1));
+
+        assertEquals(0.001, adapter.getFeeRate("BTC/USDT"), 1e-9);
+        assertDoesNotThrow(() -> adapter.placeOrder("BTC/USDT", "BUY", 1.0, 1.0));
+
+        System.clearProperty("SANDBOX_SLIPPAGE");
+        System.clearProperty("SANDBOX_FEE");
+        System.clearProperty("SANDBOX_LATENCY_MS");
     }
 }

--- a/feed-aggregator/.env.example
+++ b/feed-aggregator/.env.example
@@ -3,6 +3,9 @@ FEED_URL=wss://example.com/feed
 # Redis connection
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
+# Pub/sub channels
+ORDERBOOK_CHANNEL=orderbook
+ALERT_CHANNEL=alerts
 # Liveness probe port
 HEALTH_PORT=8090
 # Maximum reconnect attempts

--- a/feed-aggregator/README.md
+++ b/feed-aggregator/README.md
@@ -13,8 +13,9 @@ npm install
 node index.js
 ```
 
-The service publishes books to the `orderbook` Redis channel and exposes a
-health check on `http://localhost:8090/health`.
+The service publishes books to the Redis channel specified by `ORDERBOOK_CHANNEL` (default `orderbook`)
+and sends alerts to `ALERT_CHANNEL` (default `alerts`). A health check is available at
+`http://localhost:8090/health`.
 
 ## Tests
 

--- a/feed-aggregator/index.js
+++ b/feed-aggregator/index.js
@@ -5,7 +5,7 @@ const winston = require("winston");
 const normalize = require("./lib/normalize");
 
 const FEED_URL = process.env.FEED_URL || "wss://example.com/feed";
-const CHANNEL = "orderbook";
+const CHANNEL = process.env.ORDERBOOK_CHANNEL || "orderbook";
 const REDIS_HOST = process.env.REDIS_HOST || "127.0.0.1";
 const REDIS_PORT = process.env.REDIS_PORT || 6379;
 const HEALTH_PORT = process.env.HEALTH_PORT || 8090;
@@ -23,7 +23,7 @@ const logger = winston.createLogger({
 });
 
 const redis = new Redis({ host: REDIS_HOST, port: REDIS_PORT });
-const ALERT_CHANNEL = "alerts";
+const ALERT_CHANNEL = process.env.ALERT_CHANNEL || "alerts";
 
 function sendAlert(type, message) {
   const payload = JSON.stringify({


### PR DESCRIPTION
## Summary
- make exchange feed channels configurable via env vars
- add RNG injection for MockExchangeAdapter and SandboxExchangeAdapter
- parse SandboxExchangeAdapter env vars safely
- update docs and sample env files
- seed randoms in unit tests

## Testing
- `./gradlew test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687c119a2ae8832c801ecd6211339b3f