### PR TITLE
Add max open trades enforcement

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -31,6 +31,7 @@ Lists environment variables used across services.
 | `ANALYTICS_URL` | Trade logging service endpoint |
 | `CB_WIN_RATE_THRESHOLD` | Circuit breaker win-rate limit |
 | `CB_MAX_DRAWDOWN_PCT` | Maximum drawdown before panic |
+| `MAX_OPEN_TRADES` | Maximum number of simultaneous trades |
 | `CANARY_MODE` / `GHOST_MODE` | Feature toggles |
 | `USE_ENSEMBLE` | Enable ensemble model |
 | `sweep_cadence` | Daily, Monthly, or None for automatic sweeps |

--- a/docs/risk-controls.md
+++ b/docs/risk-controls.md
@@ -18,4 +18,8 @@ Operators can trigger Panic mode manually from the dashboard or via the API. Thi
 
 `COIN_CAP_PCT` limits the maximum allocation per asset, while `STARTING_BALANCE` defines total capital at risk. Adjust these settings in the executor `.env` file.
 
+### Max Open Trades
+
+`MAX_OPEN_TRADES` restricts how many positions may be active at once. When the limit is reached, new opportunities are ignored until other trades close.
+
 All risk events are logged to Postgres and surfaced through Prometheus metrics for alerting.

--- a/executor/.env.example
+++ b/executor/.env.example
@@ -18,6 +18,7 @@ PREDICT_URL=
 # Circuit breaker thresholds
 CB_WIN_RATE_THRESHOLD=0.35
 CB_MAX_DRAWDOWN_PCT=5.0
+MAX_OPEN_TRADES=5
 
 # Feature flags
 CANARY_MODE=false

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -58,6 +58,10 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     private boolean sandboxMode;
     private CircuitBreaker circuitBreaker;
 
+    // Track open trades
+    private final int maxOpenTrades;
+    private int currentOpenTrades = 0;
+
     /**
      * Create a new executor instance.
      *
@@ -85,6 +89,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         this.canaryMode = Boolean.parseBoolean(System.getenv().getOrDefault("CANARY_MODE", "false"));
         this.ghostMode = Boolean.parseBoolean(System.getenv().getOrDefault("GHOST_MODE", "false"));
         this.sandboxMode = Boolean.parseBoolean(System.getenv().getOrDefault("SANDBOX_MODE", "false"));
+        this.maxOpenTrades = Integer.parseInt(System.getenv().getOrDefault("MAX_OPEN_TRADES", "5"));
     }
 
     /**
@@ -174,6 +179,11 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             return;
         }
 
+        if (currentOpenTrades >= maxOpenTrades) {
+            logger.warn("Max open trades ({}) reached; skipping opportunity", maxOpenTrades);
+            return;
+        }
+
         logger.debug("Received message: {}", message);
         SpreadOpportunity opp = SpreadOpportunity.fromJson(message);
         logger.debug("Parsed opportunity: {}", opp);
@@ -228,13 +238,18 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
 
         double tradeSize = riskSettings.computeTradeSize();
         TradeResult result;
-        if (sandboxMode) {
-            SandboxExchangeAdapter adapter = new SandboxExchangeAdapter(
-                    redisClient,
-                    o -> scoringEngine.predictProbability(o));
-            result = adapter.execute(opp, tradeSize, 1.0);
-        } else {
-            result = opp.execute(tradeSize, 1.0);
+        currentOpenTrades++;
+        try {
+            if (sandboxMode) {
+                SandboxExchangeAdapter adapter = new SandboxExchangeAdapter(
+                        redisClient,
+                        o -> scoringEngine.predictProbability(o));
+                result = adapter.execute(opp, tradeSize, 1.0);
+            } else {
+                result = opp.execute(tradeSize, 1.0);
+            }
+        } finally {
+            currentOpenTrades--;
         }
 
         updatePerformanceMetrics(result);

--- a/executor/src/test/java/ExecutorMaxOpenTradesTest.java
+++ b/executor/src/test/java/ExecutorMaxOpenTradesTest.java
@@ -1,0 +1,34 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Tests that Executor enforces the MAX_OPEN_TRADES limit. */
+@Tag("local")
+public class ExecutorMaxOpenTradesTest {
+    static class DummyRedisClient extends RedisClient {
+        DummyRedisClient() { super("localhost", 6379, "chan", (c,m) -> {}); }
+        @Override public void start() {}
+        @Override public void publish(String channel, String message) {}
+    }
+
+    static class DummyExecutor extends Executor {
+        DummyExecutor() {
+            super(new DummyRedisClient(), "localhost", 6379, new RiskFilter(), new NearMissLogger(null));
+        }
+        @Override public void start() {}
+    }
+
+    @Test
+    void skipsTradesWhenLimitReached() {
+        ProfitTracker.init(10000, "http://localhost");
+        System.setProperty("MAX_OPEN_TRADES", "0");
+        DummyExecutor exec = new DummyExecutor();
+        String msg = "{\"pair\":\"BTC/USDT\",\"buyExchange\":\"A\",\"sellExchange\":\"B\",\"grossEdge\":2.0,\"netEdge\":2.0}";
+        exec.handleMessage(msg); // should be skipped due to limit 0
+        assertEquals(0.0, ProfitTracker.getGlobalTotal(), 1e-9);
+    }
+}
+

--- a/executor/src/test/java/TriangularArbDetectorTest.java
+++ b/executor/src/test/java/TriangularArbDetectorTest.java
@@ -87,7 +87,7 @@ public class TriangularArbDetectorTest {
         detector.update("C/A", 4.2, 4.3);
         detector.update("A/B", 0.6, 0.7);
 
-        Thread.sleep(60);
+        Thread.sleep(80);
         detector.stop();
         assertEquals(1, exec.count);
     }


### PR DESCRIPTION
## Summary
- add `MAX_OPEN_TRADES` setting to docs and example env
- enforce max open trades in Executor
- stabilize `TriangularArbDetectorTest` timing
- add `ExecutorMaxOpenTradesTest`

## Testing
- `./test/run-local.sh`

------
https://chatgpt.com/codex/tasks/task_b_687c14d9a4d8832c9cd9ebecbc3015ab