### PR TITLE
Improve logging consistency and alert robustness

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,7 +1,7 @@
 import Fastify from 'fastify';
 import fastifyJwt from '@fastify/jwt';
 import fastifyCookie from '@fastify/cookie';
-import winston from 'winston';
+import logger from './services/logger.js';
 import * as Sentry from '@sentry/node';
 import Redis from 'ioredis';
 import pg from 'pg';
@@ -73,11 +73,6 @@ function buildApp() {
 
 const app = buildApp();
 
-const logger = winston.createLogger({
-  level: process.env.LOG_LEVEL || 'info',
-  format: winston.format.simple(),
-  transports: [new winston.transports.Console()],
-});
 logger.info('API initialized');
 
 const alertSettings = {
@@ -164,7 +159,7 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
       });
 
       api.post('/test/sweep', async () => {
-        app.log.info('[DRY-RUN MODE] Cold wallet sweep logic verified. No assets moved.');
+        logger.info('[DRY-RUN MODE] Cold wallet sweep logic verified. No assets moved.');
         await redis.publish('control-feed', 'sweep');
         return { swept: true };
       });

--- a/api/services/logger.js
+++ b/api/services/logger.js
@@ -1,8 +1,16 @@
 import winston from 'winston';
 
+const service = process.env.SERVICE_NAME || 'api';
+
 const logger = winston.createLogger({
-  level: 'info',
-  transports: [new winston.transports.Console()]
+  level: process.env.LOG_LEVEL || 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.printf(({ level, message, timestamp }) =>
+      `${timestamp} ${level} [${service}] ${message}`
+    )
+  ),
+  transports: [new winston.transports.Console()],
 });
 
 export default logger;

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -268,7 +268,12 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             ProfitTracker.record(result.pnl);
             dailyLossPct = ProfitTracker.getDailyLossPct();
         } else {
-            logger.warn("Trade execution failed for {}", opp.getPair());
+            logger.warn(
+                "Trade execution failed for {}: pnl={}, latencyMs={}",
+                opp.getPair(),
+                result.pnl,
+                result.latencyMs
+            );
         }
 
         if (featureLogger != null) {

--- a/executor/src/main/java/TriangularArbDetector.java
+++ b/executor/src/main/java/TriangularArbDetector.java
@@ -158,7 +158,7 @@ public class TriangularArbDetector {
         }
 
         if (bestMessage != null) {
-            logger.debug("Triangular arbitrage detected: {}", bestMessage);
+            logger.info("Triangular arbitrage detected: {}", bestMessage);
             executor.handleMessage(bestMessage);
         }
     }

--- a/feed-aggregator/README.md
+++ b/feed-aggregator/README.md
@@ -17,6 +17,10 @@ The service publishes books to the Redis channel specified by `ORDERBOOK_CHANNEL
 and sends alerts to `ALERT_CHANNEL` (default `alerts`). A health check is available at
 `http://localhost:8090/health`.
 
+Alerts are throttled so repeated errors with the same message within 60 seconds
+are suppressed. If Redis is unavailable, alert payloads are written to
+`alerts-fallback.log`.
+
 ## Tests
 
 Run the Python-based test suite after installing dependencies:

--- a/feed-aggregator/index.js
+++ b/feed-aggregator/index.js
@@ -2,6 +2,7 @@ const WebSocket = require("ws");
 const Redis = require("ioredis");
 const Fastify = require("fastify");
 const winston = require("winston");
+const fs = require("fs");
 const normalize = require("./lib/normalize");
 
 const FEED_URL = process.env.FEED_URL || "wss://example.com/feed";
@@ -17,13 +18,34 @@ const MAX_RECONNECT_DELAY = 30000;
 
 let reconnectAttempts = 0;
 
+const service = "feed-aggregator";
+
 const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || "info",
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.printf(({ level, message, timestamp }) =>
+      `${timestamp} ${level} [${service}] ${message}`
+    )
+  ),
   transports: [new winston.transports.Console()],
 });
 
 const redis = new Redis({ host: REDIS_HOST, port: REDIS_PORT });
 const ALERT_CHANNEL = process.env.ALERT_CHANNEL || "alerts";
+const THROTTLE_MS = 60000;
+const lastAlertTimes = {};
+
+function fallbackAlert(payload) {
+  fs.appendFile(
+    "alerts-fallback.log",
+    `${new Date().toISOString()} ${payload}\n`,
+    (err) => {
+      if (err) logger.error("Failed to write fallback alert", err);
+    }
+  );
+  logger.warn("Alert fallback engaged - redis unavailable");
+}
 
 function sendAlert(type, message) {
   const payload = JSON.stringify({
@@ -32,8 +54,19 @@ function sendAlert(type, message) {
     source: "feed-aggregator",
     ts: Date.now(),
   });
+
+  if (
+    lastAlertTimes[message] &&
+    Date.now() - lastAlertTimes[message] < THROTTLE_MS
+  ) {
+    logger.debug(`Alert suppressed for '${message}'`);
+    return Promise.resolve();
+  }
+  lastAlertTimes[message] = Date.now();
+
   return redis.publish(ALERT_CHANNEL, payload).catch((err) => {
     logger.error("Failed to publish alert", err);
+    fallbackAlert(payload);
   });
 }
 


### PR DESCRIPTION
## Summary
- standardize Winston logger format across services
- log more context when trades fail
- surface triangular arb detections at info level
- throttle feed aggregator alerts and write fallback log when Redis is down
- use shared logger in API test sweep endpoint and adjust docs

## Testing
- `npm --prefix api test -- --runInBand`
- `pytest`
- `executor/gradlew test -p executor -PtestEnv=local`


------
https://chatgpt.com/codex/tasks/task_b_687c1bf8b968832c9b98bed1353efd00