### PR TITLE
Enforce secure secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Example environment files live under `api/.env.example`, `analytics/.env.example
 ### Common variables
 - `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` – Postgres connection
 - `REDIS_HOST`, `REDIS_PORT` – Redis connection
-- `JWT_SECRET` – token signing key for the API
-- `ADMIN_TOKEN` – admin-only endpoints in the API
+- `JWT_SECRET` – token signing key for the API (required in production)
+- `ADMIN_TOKEN` – admin-only endpoints in the API (set a strong value for production)
 - `SENTRY_DSN` – API error reporting endpoint
 - `PROM_URL` – Prometheus base URL for metrics
 - `SANDBOX_MODE` – enable demo login without a DB

--- a/api/__tests__/api.test.js
+++ b/api/__tests__/api.test.js
@@ -3,6 +3,7 @@ import request from 'supertest';
 const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 process.env.NODE_ENV = 'test';
 process.env.ADMIN_TOKEN = 'testadmintoken';
+process.env.JWT_SECRET = 'testsecret';
 process.env.SANDBOX_MODE = 'true';
 let buildApp;
 let app;

--- a/api/__tests__/panicResume.test.js
+++ b/api/__tests__/panicResume.test.js
@@ -2,6 +2,7 @@ import request from 'supertest';
 
 const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
 let buildApp;
 let testState;
 let app;

--- a/api/__tests__/settings.validation.test.js
+++ b/api/__tests__/settings.validation.test.js
@@ -2,6 +2,7 @@ import request from 'supertest';
 
 const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
 process.env.SANDBOX_MODE = 'true';
 let buildApp;
 let app;

--- a/api/index.js
+++ b/api/index.js
@@ -25,6 +25,13 @@ if (process.env.NODE_ENV === 'production') {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
   });
+
+  const jwt = process.env.JWT_SECRET;
+  const admin = process.env.ADMIN_TOKEN;
+  if (!jwt || jwt === 'change-me' || !admin || admin === 'admin-secret') {
+    console.error('JWT_SECRET and ADMIN_TOKEN must be set in production');
+    process.exit(1);
+  }
 }
 
 const isTest = process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID;

--- a/docs/Complete Guide.MD
+++ b/docs/Complete Guide.MD
@@ -861,7 +861,7 @@ yaml
 CopyEdit
 api:
   env:
-    JWT_SECRET: "change-me"
+    JWT_SECRET: "<your-secret>"
 analytics:
   env:
     MODEL_PATH: "/models/model.h5"

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -10,8 +10,8 @@ Lists environment variables used across services.
 | `PGHOST` / `PGPORT` / `PGUSER` / `PGPASSWORD` / `PGDATABASE` | Postgres connection settings |
 | `REDIS_HOST` / `REDIS_PORT` / `REDIS_CHANNEL` | Redis host, port and pub/sub channel |
 | `ORDERBOOK_CHANNEL` / `ALERT_CHANNEL` | Feed and alert Redis channels |
-| `JWT_SECRET` | Token signing key for the API |
-| `ADMIN_TOKEN` | Required for admin-only API endpoints |
+| `JWT_SECRET` | Token signing key for the API (required in production) |
+| `ADMIN_TOKEN` | Required for admin-only API endpoints (set a strong value for production) |
 | `SENTRY_DSN` | Error reporting endpoint |
 | `PROM_URL` | Base URL for Prometheus |
 | `SANDBOX_MODE` | Enable demo login without a database |

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -17,7 +17,7 @@ api:
       cpu: "500m"
       memory: "512Mi"
   env:
-    # JWT_SECRET: "change-me"
+    # JWT_SECRET: "<your-secret>"
     # PGHOST: "postgres"
     # PGUSER: "arb_user"
     # PGPASSWORD: "secret"


### PR DESCRIPTION
## Summary
- enforce JWT_SECRET and ADMIN_TOKEN presence in production
- update documentation to remove insecure examples
- clarify env var requirements in README and docs
- show how to set JWT secret in tests

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687c205eb9f8832c8ae817f5468e52a3