### PR TITLE
Fix logger null handling and deterministic adapter

### DIFF
--- a/executor/src/main/java/MockExchangeAdapter.java
+++ b/executor/src/main/java/MockExchangeAdapter.java
@@ -44,7 +44,7 @@ public class MockExchangeAdapter implements ExchangeAdapter {
      * @param cancelFeeRate  fee charged when an order is cancelled or partially filled
      */
     public MockExchangeAdapter(String name, double cancelFeeRate) {
-        this(name, cancelFeeRate, new Random());
+        this(name, cancelFeeRate, new Random(42));
     }
 
     /**

--- a/executor/src/main/java/NearMissLogger.java
+++ b/executor/src/main/java/NearMissLogger.java
@@ -31,6 +31,10 @@ public class NearMissLogger {
      * @param reason textual reason for rejection
      */
     public void log(SpreadOpportunity opp, String reason) {
+        if (connection == null) {
+            logger.warn("No DB connection; skipping near miss record for {}", opp.getPair());
+            return;
+        }
         String sql = "INSERT INTO near_misses (buy_exchange, sell_exchange, pair, gross_edge, net_edge, reason, latency_ms, round_trip_latency_ms) " +
                      "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
         String safeReason = reason != null ? reason : "";

--- a/executor/src/test/java/NearMissLoggerTest.java
+++ b/executor/src/test/java/NearMissLoggerTest.java
@@ -1,0 +1,16 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class NearMissLoggerTest {
+    @Test
+    void logDoesNothingWhenConnectionNull() {
+        NearMissLogger logger = new NearMissLogger(null);
+        SpreadOpportunity opp = new SpreadOpportunity("BTC/USDT", "A", "B", 1.0, 1.0, 0L);
+        assertDoesNotThrow(() -> logger.log(opp, "test"));
+    }
+}

--- a/executor/src/test/java/SpreadOpportunityTest.java
+++ b/executor/src/test/java/SpreadOpportunityTest.java
@@ -13,10 +13,7 @@ public class SpreadOpportunityTest {
         SpreadOpportunity opp = new SpreadOpportunity("BTC/USDT", "A", "B", 2.0, 2.0, 0L);
         TradeResult result = opp.execute(1.0, 100.0);
         double expected = 2.0 - (1.0 * 100.0 * 0.001) - (1.0 * 100.0 * 0.001);
-        if (result.success) {
-            assertEquals(expected, result.pnl, 1e-9);
-        } else {
-            assertEquals(0.0, result.pnl, 1e-9);
-        }
+        assertTrue(result.success);
+        assertEquals(expected, result.pnl, 1e-9);
     }
 }


### PR DESCRIPTION
## Summary
- handle null DB connection gracefully in NearMissLogger
- use seeded RNG for MockExchangeAdapter default constructor
- update SpreadOpportunityTest to assert deterministic execution
- add NearMissLoggerTest

## Testing
- `./test/run-local.sh` *(fails: native ECMAScript module configuration not supported)*

------
https://chatgpt.com/codex/tasks/task_b_687c285d6100832c894439e0635a59ce