### PR TITLE
Fix concurrency for shared state

### DIFF
--- a/analytics/app.py
+++ b/analytics/app.py
@@ -3,6 +3,7 @@ import sys
 import time
 from .logger import logger
 from collections import deque
+import threading
 
 import numpy as np
 from flask import Flask, g, request, jsonify, Response
@@ -57,21 +58,24 @@ inference_latency = Histogram(
 # In-memory trade store
 MAX_TRADES = 1000
 trades = deque(maxlen=MAX_TRADES)
+trades_lock = threading.Lock()
 
 
 def record_trade(pnl: float, timestamp: float | None = None) -> None:
     """Record a trade's PnL in memory using a fixed-size deque."""
     if timestamp is None:
         timestamp = time.time()
-    trades.append({"pnl": pnl, "time": timestamp})
+    with trades_lock:
+        trades.append({"pnl": pnl, "time": timestamp})
 
 
 def compute_stats():
     """Compute aggregate PnL and Sharpe ratio for all stored trades."""
-    if not trades:
-        return {"pnl": 0, "sharpe": 0}
+    with trades_lock:
+        if not trades:
+            return {"pnl": 0, "sharpe": 0}
 
-    pnl_array = np.array([t["pnl"] for t in trades], dtype=np.float32)
+        pnl_array = np.array([t["pnl"] for t in trades], dtype=np.float32)
     pnl = pnl_array.sum()
     if len(pnl_array) < 2:
         sharpe = 0.0
@@ -87,13 +91,15 @@ def compute_stats():
 
 def rolling_pnl(window: int = 50) -> float:
     """Return the rolling P&L for the last `window` trades."""
-    recent = list(trades)[-window:]
+    with trades_lock:
+        recent = list(trades)[-window:]
     return float(sum(t["pnl"] for t in recent))
 
 
 def sharpe_ratio(window: int = 50) -> float:
     """Compute the Sharpe ratio for the last `window` trades."""
-    recent = list(trades)[-window:]
+    with trades_lock:
+        recent = list(trades)[-window:]
     if len(recent) < 2:
         return 0.0
     returns = np.array([t['pnl'] for t in recent], dtype=np.float32)
@@ -107,7 +113,8 @@ def sharpe_ratio(window: int = 50) -> float:
 def recent_performance(days: int = 7) -> dict:
     """Return volatility and win rate for trades within the last `days`."""
     cutoff = time.time() - days * 86400
-    recent = [t for t in trades if t["time"] >= cutoff]
+    with trades_lock:
+        recent = [t for t in trades if t["time"] >= cutoff]
     if not recent:
         return {"volatility": 0.0, "win_rate": 0.0}
 

--- a/executor/src/main/java/CircuitBreaker.java
+++ b/executor/src/main/java/CircuitBreaker.java
@@ -13,7 +13,7 @@ public class CircuitBreaker {
     private final double minWinRate;
     private final double maxDrawdownPct;
     private final RedisClient redisClient;
-    private boolean tripped = false;
+    private final java.util.concurrent.atomic.AtomicBoolean tripped = new java.util.concurrent.atomic.AtomicBoolean(false);
 
     public CircuitBreaker(RedisClient redisClient, double minWinRate, double maxDrawdownPct) {
         this.redisClient = redisClient;
@@ -27,8 +27,8 @@ public class CircuitBreaker {
      * @param drawdownPct current drawdown percentage
      */
     public void check(double winRate, double drawdownPct) {
-        if (!tripped && (winRate < minWinRate || drawdownPct > maxDrawdownPct)) {
-            tripped = true;
+        if (!tripped.get() && (winRate < minWinRate || drawdownPct > maxDrawdownPct)) {
+            tripped.set(true);
             logger.error("CIRCUIT BREAKER TRIPPED winRate={} drawdownPct={}", winRate, drawdownPct);
             AlertManager.sendAlert("CIRCUIT BREAKER TRIPPED");
             redisClient.publish("alerts", "CIRCUIT BREAKER TRIPPED");
@@ -40,7 +40,7 @@ public class CircuitBreaker {
      * Reset the breaker allowing trading to resume.
      */
     public void reset() {
-        tripped = false;
+        tripped.set(false);
         logger.info("Circuit breaker reset");
     }
 
@@ -48,6 +48,6 @@ public class CircuitBreaker {
      * @return true if breaker is currently tripped
      */
     public boolean isTripped() {
-        return tripped;
+        return tripped.get();
     }
 }

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -52,7 +52,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     private int totalTrades;
     private int winTrades;
     private long cumulativeLatencyMs;
-    private boolean isPanic;
+    private final java.util.concurrent.atomic.AtomicBoolean isPanic = new java.util.concurrent.atomic.AtomicBoolean(false);
     private boolean canaryMode;
     private boolean ghostMode;
     private boolean sandboxMode;
@@ -60,7 +60,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
 
     // Track open trades
     private final int maxOpenTrades;
-    private int currentOpenTrades = 0;
+    private final java.util.concurrent.atomic.AtomicInteger currentOpenTrades = new java.util.concurrent.atomic.AtomicInteger(0);
 
     /**
      * Create a new executor instance.
@@ -170,7 +170,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
      * @param message JSON encoded opportunity
      */
     public void handleMessage(String message) {
-        if (isPanic) {
+        if (isPanic.get()) {
             logger.warn("Trading halted due to panic brake.");
             return;
         }
@@ -179,7 +179,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             return;
         }
 
-        if (currentOpenTrades >= maxOpenTrades) {
+        if (currentOpenTrades.get() >= maxOpenTrades) {
             logger.warn("Max open trades ({}) reached; skipping opportunity", maxOpenTrades);
             return;
         }
@@ -229,7 +229,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             return;
         }
 
-        if (isPanic) {
+        if (isPanic.get()) {
             logger.warn("Panic brake active; skipping execution.");
             return;
         }
@@ -238,7 +238,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
 
         double tradeSize = riskSettings.computeTradeSize();
         TradeResult result;
-        currentOpenTrades++;
+        currentOpenTrades.incrementAndGet();
         try {
             if (sandboxMode) {
                 SandboxExchangeAdapter adapter = new SandboxExchangeAdapter(
@@ -249,7 +249,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
                 result = opp.execute(tradeSize, 1.0);
             }
         } finally {
-            currentOpenTrades--;
+            currentOpenTrades.decrementAndGet();
         }
 
         updatePerformanceMetrics(result);
@@ -293,7 +293,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         circuitBreaker.check(winRate, drawdown);
 
         if (PanicBrake.shouldHalt(dailyLossPct, avgLatencyMs, winRate)) {
-            isPanic = true;
+            isPanic.set(true);
             logger.error("PANIC BRAKE TRIGGERED");
             AlertManager.sendAlert("PANIC BRAKE TRIGGERED");
             redisClient.publish("alerts", "PANIC BRAKE TRIGGERED");
@@ -350,7 +350,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
      * Manually resume trading after a user initiated halt.
      */
     public void resumeTrading() {
-        isPanic = false;
+        isPanic.set(false);
         circuitBreaker.reset();
         logger.info("Trading manually resumed.");
     }
@@ -359,7 +359,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
      * Resume trading after a panic brake was triggered.
      */
     public void resumeFromPanic() {
-        isPanic = false;
+        isPanic.set(false);
         circuitBreaker.reset();
         logger.info("PANIC RESUME SIGNAL RECEIVED");
     }

--- a/executor/src/main/java/ProfitTracker.java
+++ b/executor/src/main/java/ProfitTracker.java
@@ -23,6 +23,7 @@ public class ProfitTracker {
     private static double globalTotal = 0.0;
     private static double dailyTotal = 0.0;
     private static double cumulativeProfit = 0.0;
+    private static final Object lock = new Object();
 
     private static double startingBalance = 10_000.0;
     private static String analyticsUrl = "http://localhost:5000/trade";
@@ -46,9 +47,11 @@ public class ProfitTracker {
      * @param pnl profit (positive) or loss (negative)
      */
     public static void record(double pnl) {
-        dailyTotal += pnl;
-        globalTotal += pnl;
-        cumulativeProfit += pnl;
+        synchronized (lock) {
+            dailyTotal += pnl;
+            globalTotal += pnl;
+            cumulativeProfit += pnl;
+        }
         sendWithRetry(pnl, 0);
     }
 
@@ -84,7 +87,9 @@ public class ProfitTracker {
 
     /** Reset the running daily total back to zero. */
     public static void resetDailyTotals() {
-        dailyTotal = 0.0;
+        synchronized (lock) {
+            dailyTotal = 0.0;
+        }
     }
 
     /**
@@ -93,10 +98,12 @@ public class ProfitTracker {
      * @param pnl profit (positive) or loss (negative)
      */
     public static double getDailyLossPct() {
-        if (dailyTotal >= 0) {
-            return 0.0;
+        synchronized (lock) {
+            if (dailyTotal >= 0) {
+                return 0.0;
+            }
+            return (-dailyTotal / startingBalance) * 100.0;
         }
-        return (-dailyTotal / startingBalance) * 100.0;
     }
 
     /**
@@ -105,7 +112,9 @@ public class ProfitTracker {
      * @return global profit
      */
     public static double getGlobalTotal() {
-        return globalTotal;
+        synchronized (lock) {
+            return globalTotal;
+        }
     }
 
     /**
@@ -114,12 +123,16 @@ public class ProfitTracker {
      * @return cumulative profit
      */
     public static double getCumulativeProfit() {
-        return cumulativeProfit;
+        synchronized (lock) {
+            return cumulativeProfit;
+        }
     }
 
     /** Reset the cumulative profit after a cold sweep. */
     public static void resetCumulativeProfit() {
-        cumulativeProfit = 0.0;
+        synchronized (lock) {
+            cumulativeProfit = 0.0;
+        }
     }
     
     /**

--- a/executor/src/main/java/TriangularArbDetector.java
+++ b/executor/src/main/java/TriangularArbDetector.java
@@ -33,8 +33,9 @@ public class TriangularArbDetector {
         double getAsk() { return ask; }
     }
 
-    private final Map<String, OrderBook> books = new HashMap<>();
-    private final Map<String, Set<String>> adjacency = new HashMap<>();
+    // Concurrent maps to allow update() and scan() to run without explicit locks
+    private final Map<String, OrderBook> books = new java.util.concurrent.ConcurrentHashMap<>();
+    private final Map<String, Set<String>> adjacency = new java.util.concurrent.ConcurrentHashMap<>();
     private final Executor executor;
     private final ObjectMapper mapper = new ObjectMapper();
     private final double feeRate = 0.001;
@@ -98,14 +99,15 @@ public class TriangularArbDetector {
      * @param bestBid highest bid price
      * @param bestAsk lowest ask price
      */
-    public synchronized void update(String pair, double bestBid, double bestAsk) {
+    public void update(String pair, double bestBid, double bestAsk) {
         if (!validBook(bestBid, bestAsk)) {
             return;
         }
         books.put(pair, new OrderBook(bestBid, bestAsk));
         String[] parts = split(pair);
         if (parts != null) {
-            adjacency.computeIfAbsent(parts[0], k -> new HashSet<>()).add(pair);
+            adjacency.computeIfAbsent(parts[0], k -> java.util.concurrent.ConcurrentHashMap.newKeySet())
+                    .add(pair);
         }
         dirty.set(true);
         if (intervalMs == 0) {


### PR DESCRIPTION
## Summary
- protect trade bookkeeping with locks and atomics
- prevent iterator races in `TriangularArbDetector`
- add locking for analytics trade history

## Testing
- `bash test/run-local.sh`

------
https://chatgpt.com/codex/tasks/task_b_687cbcf08200832c83f98c019f2c97f6