### PR TITLE
Fix feed-aggregator alert cache leak

### DIFF
--- a/feed-aggregator/index.js
+++ b/feed-aggregator/index.js
@@ -31,9 +31,11 @@ const logger = winston.createLogger({
   transports: [new winston.transports.Console()],
 });
 
-const redis = new Redis({ host: REDIS_HOST, port: REDIS_PORT });
+const redis = process.env.MOCK_REDIS
+  ? { publish: () => Promise.resolve() }
+  : new Redis({ host: REDIS_HOST, port: REDIS_PORT });
 const ALERT_CHANNEL = process.env.ALERT_CHANNEL || "alerts";
-const THROTTLE_MS = 60000;
+const THROTTLE_MS = parseInt(process.env.THROTTLE_MS || "60000", 10);
 const lastAlertTimes = {};
 
 function fallbackAlert(payload) {
@@ -69,6 +71,17 @@ function sendAlert(type, message) {
     fallbackAlert(payload);
   });
 }
+
+function cleanupAlertCache() {
+  const now = Date.now();
+  for (const [msg, ts] of Object.entries(lastAlertTimes)) {
+    if (now - ts > THROTTLE_MS) {
+      delete lastAlertTimes[msg];
+    }
+  }
+}
+
+setInterval(cleanupAlertCache, THROTTLE_MS).unref();
 
 
 function connect() {
@@ -135,10 +148,15 @@ function connect() {
 // small health endpoint
 const app = Fastify();
 app.get("/health", async () => ({ ok: true }));
-app.listen({ port: HEALTH_PORT, host: "0.0.0.0" });
 
-connect();
+if (require.main === module) {
+  app.listen({ port: HEALTH_PORT, host: "0.0.0.0" });
+  connect();
+}
 
 module.exports = {
   normalize,
+  sendAlert,
+  cleanupAlertCache,
+  _lastAlertTimes: lastAlertTimes,
 };

--- a/feed-aggregator/tests/test_alert_cache.py
+++ b/feed-aggregator/tests/test_alert_cache.py
@@ -1,0 +1,35 @@
+import subprocess
+import json
+import os
+import shutil
+import pytest
+
+pytestmark = pytest.mark.env("local")
+
+if not shutil.which("node"):
+    pytest.skip("node not installed", allow_module_level=True)
+
+if not os.path.exists(os.path.join(os.path.dirname(__file__), "..", "node_modules")):
+    pytest.skip("feed-aggregator dependencies not installed", allow_module_level=True)
+
+
+def test_sendAlert_throttles_and_cleanup():
+    repo = os.path.dirname(__file__) + '/..'
+    script = """
+const mod = require('./index');
+(async () => {
+  await mod.sendAlert('email', 'msg');
+  const first = mod._lastAlertTimes['msg'];
+  await mod.sendAlert('email', 'msg');
+  const second = mod._lastAlertTimes['msg'];
+  mod._lastAlertTimes['old'] = Date.now() - 1000;
+  mod.cleanupAlertCache();
+  console.log(JSON.stringify({same:first===second, keys:Object.keys(mod._lastAlertTimes).sort()}));
+})();
+"""
+    env = dict(os.environ, THROTTLE_MS='50', MOCK_REDIS='1')
+    result = subprocess.run(['node', '-e', script], cwd=repo, capture_output=True, text=True, env=env)
+    assert result.returncode == 0
+    out = json.loads(result.stdout.strip())
+    assert out['same'] is True
+    assert out['keys'] == ['msg']


### PR DESCRIPTION
## Summary
- make throttle duration configurable and add cache cleanup
- allow using MOCK_REDIS for tests and avoid starting server when required
- export helper functions from feed-aggregator
- add test covering throttle and cleanup logic

## Testing
- `npm --prefix feed-aggregator test --silent`
- `./test/run-local.sh`

------
https://chatgpt.com/codex/tasks/task_b_687cc6d8096c832caa1c81209c966bb2