### PR TITLE
Improve credential safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Example environment files live under `api/.env.example`, `analytics/.env.example
 - `ADMIN_TOKEN` – admin-only endpoints in the API (set a strong value for production)
 - `SENTRY_DSN` – API error reporting endpoint
 - `PROM_URL` – Prometheus base URL for metrics
-- `SANDBOX_MODE` – enable demo login without a DB
+- `SANDBOX_MODE` – enable demo login without a DB (must be disabled in production)
 
 ### Executor specific
 - `STARTING_BALANCE`, `COIN_CAP_PCT`, `MAX_BOOK_DEPTH_USD` – risk parameters

--- a/api/index.js
+++ b/api/index.js
@@ -32,6 +32,10 @@ if (process.env.NODE_ENV === 'production') {
     console.error('JWT_SECRET and ADMIN_TOKEN must be set in production');
     process.exit(1);
   }
+  if (process.env.SANDBOX_MODE === 'true') {
+    console.error('SANDBOX_MODE must be disabled in production');
+    process.exit(1);
+  }
 }
 
 const isTest = process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID;

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -14,7 +14,7 @@ Lists environment variables used across services.
 | `ADMIN_TOKEN` | Required for admin-only API endpoints (set a strong value for production) |
 | `SENTRY_DSN` | Error reporting endpoint |
 | `PROM_URL` | Base URL for Prometheus |
-| `SANDBOX_MODE` | Enable demo login without a database |
+| `SANDBOX_MODE` | Enable demo login without a database (must be `false` in production) |
 
 ## Executor Variables
 

--- a/docs/manual-wallet-sweep.md
+++ b/docs/manual-wallet-sweep.md
@@ -11,7 +11,7 @@ Explains how to manually initiate a cold wallet sweep when automated transfers a
    curl -X POST http://localhost:8080/api/test/sweep
    ```
    This endpoint performs a dry-run sweep and logs the action.
-3. Check the executor logs for `Cold wallet sweep` messages.
+3. Check the executor logs for `Cold wallet sweep` messages. The wallet address is partially masked for security.
 4. Verify on a blockchain explorer once funds settle.
 5. Resume trading from the dashboard when complete.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -57,5 +57,14 @@ kubectl apply -f sealed-secret.yaml
 
 ---
 
+## Rotation
+
+Rotate credentials at least every 90 days:
+
+1. Create a new Kubernetes secret with updated values.
+2. Reseal using `kubeseal` and commit the new file.
+3. Deploy the sealed secret and remove the old one after rollout.
+
+
 Follow these steps whenever you need to store or update sensitive credentials.
 

--- a/executor/src/main/java/ColdSweeper.java
+++ b/executor/src/main/java/ColdSweeper.java
@@ -57,6 +57,15 @@ public class ColdSweeper {
         this.sweepLogger = logger;
     }
 
+    private String maskAddress(String address) {
+        if (address == null || address.length() <= 10) {
+            return "********";
+        }
+        String start = address.substring(0, 6);
+        String end = address.substring(address.length() - 4);
+        return start + "****" + end;
+    }
+
     /**
      * Evaluate sweep condition.
      *
@@ -83,7 +92,7 @@ public class ColdSweeper {
      */
     public void sweepToColdWallet(double amountUsd) {
         String address = config.getTestColdWalletAddress();
-        logger.info("Cold wallet sweep triggered for: {} amount {}", address, amountUsd);
+        logger.info("Cold wallet sweep triggered for: {} amount {}", maskAddress(address), amountUsd);
         walletClient.withdraw(address, amountUsd);
         ProfitTracker.resetCumulativeProfit();
         if (sweepLogger != null) {
@@ -98,7 +107,7 @@ public class ColdSweeper {
      * @param amountUsd amount to sweep
      */
     public void sweepToColdWallet(String address, double amountUsd) {
-        logger.info("Cold wallet sweep triggered for: {} amount {}", address, amountUsd);
+        logger.info("Cold wallet sweep triggered for: {} amount {}", maskAddress(address), amountUsd);
         walletClient.withdraw(address, amountUsd);
         ProfitTracker.resetCumulativeProfit();
         if (sweepLogger != null) {


### PR DESCRIPTION
## Summary
- mask wallet addresses in ColdSweeper logs
- abort API startup if SANDBOX_MODE is enabled in production
- document credential rotation requirements
- note SANDBOX_MODE restriction in env docs
- clarify manual sweep docs about masked address

## Testing
- `./test/run-local.sh`

------
https://chatgpt.com/codex/tasks/task_b_687cd2501c48832c9a7ee6844f80b569