### PR TITLE
Improve alert error handling

### DIFF
--- a/api/__tests__/alertManager.test.js
+++ b/api/__tests__/alertManager.test.js
@@ -1,0 +1,21 @@
+import { jest } from '@jest/globals';
+
+jest.mock('../services/emailAlert.js', () => ({
+  sendEmail: jest.fn(() => {
+    throw new Error('fail');
+  })
+}));
+
+import { sendAlert } from '../services/alertManager.js';
+
+describe('sendAlert error handling', () => {
+  beforeEach(() => {
+    process.env.SMTP_USER = 'u';
+    process.env.SMTP_PASS = 'p';
+    process.env.ALERT_RECIPIENT = 'r';
+  });
+
+  test('email failures are propagated', async () => {
+    await expect(sendAlert('email', 'msg')).rejects.toThrow('fail');
+  });
+});

--- a/api/services/alertManager.js
+++ b/api/services/alertManager.js
@@ -27,6 +27,7 @@ async function sendAlert(type, message) {
         logger.info('Email alert sent');
       } catch (err) {
         logger.error(`Email alert failed: ${err.message}`);
+        throw err;
       }
       break;
     case 'telegram':
@@ -39,6 +40,7 @@ async function sendAlert(type, message) {
         logger.info('Telegram alert sent');
       } catch (err) {
         logger.error(`Telegram alert failed: ${err.message}`);
+        throw err;
       }
       break;
     case 'webhook':
@@ -51,6 +53,7 @@ async function sendAlert(type, message) {
         logger.info('Webhook alert sent');
       } catch (err) {
         logger.error(`Webhook alert failed: ${err.message}`);
+        throw err;
       }
       break;
     default:


### PR DESCRIPTION
## Summary
- rethrow errors in `sendAlert` so failures surface
- add a Jest test ensuring alert errors propagate

## Testing
- `npm test --silent` in `api`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687cd6d8c5d4832c94c2d72c66b0e494