### PR TITLE
Add feed-aggregator deployment and secure Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased]
 
 - Downgrade numpy to 2.1.3 to resolve TensorFlow install conflict.
+- Store Postgres credentials in sealed secrets
+- Added feed-aggregator deployment manifest
+- Introduced HorizontalPodAutoscaler resources
 
 ## [Batch 1] - 2025-07-02
 ### Added

--- a/infra/helm/templates/feed-aggregator-deployment.yaml
+++ b/infra/helm/templates/feed-aggregator-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feed-aggregator
+  labels:
+    app: feed-aggregator
+    {{- include "crypto-arbitrage.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: feed-aggregator
+  template:
+    metadata:
+      labels:
+        app: feed-aggregator
+    spec:
+      containers:
+        - name: feed-aggregator
+          image: {{ .Values.feedAggregator.image }}
+          ports:
+            - containerPort: {{ .Values.feedAggregator.port }}
+          resources: {{- toYaml .Values.feedAggregator.resources | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: feed-aggregator-secrets
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.feedAggregator.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.feedAggregator.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: feed-aggregator
+  labels:
+    app: feed-aggregator
+spec:
+  type: ClusterIP
+  selector:
+    app: feed-aggregator
+  ports:
+    - port: {{ .Values.feedAggregator.port }}
+      targetPort: {{ .Values.feedAggregator.port }}

--- a/infra/helm/templates/sealed-secret.yaml
+++ b/infra/helm/templates/sealed-secret.yaml
@@ -41,3 +41,27 @@ spec:
     REDIS_HOST: AgFAKEREDISHOST
     REDIS_PORT: AgFAKEREDISPORT
     ANALYTICS_URL: AgFAKEANALYTICSURL
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: postgres-secrets
+  namespace: default
+spec:
+  encryptedData:
+    POSTGRES_USER: AgFAKEENCRYPTEDPGUSER
+    POSTGRES_PASSWORD: AgFAKEENCRYPTEDPGPASSWORD
+    POSTGRES_DB: AgFAKEENCRYPTEDPGDATABASE
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: feed-aggregator-secrets
+  namespace: default
+spec:
+  encryptedData:
+    FEED_URL: AgFAKEFEEDURL
+    REDIS_HOST: AgFAKEREDISHOST
+    REDIS_PORT: AgFAKEREDISPORT
+    ORDERBOOK_CHANNEL: AgFAKEORDERBOOKCHANNEL
+    ALERT_CHANNEL: AgFAKEALERTCHANNEL

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -68,3 +68,20 @@ executor:
     # ANALYTICS_URL: "http://analytics:5000/trade"
     # PERSONALITY_MODE: "REALISTIC"
     # STARTING_BALANCE: "10000"
+
+feedAggregator:
+  image: arb-feed-aggregator
+  port: 8090
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+  env:
+    # FEED_URL: "wss://example.com/feed"
+    # REDIS_HOST: "redis"
+    # REDIS_PORT: "6379"
+    # ORDERBOOK_CHANNEL: "orderbook"
+    # ALERT_CHANNEL: "alerts"

--- a/infra/k8s/autoscale.yaml
+++ b/infra/k8s/autoscale.yaml
@@ -1,0 +1,94 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: dashboard-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: dashboard
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: analytics-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: analytics
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: executor-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: executor
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: feed-aggregator-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: feed-aggregator
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/infra/k8s/dashboard.yaml
+++ b/infra/k8s/dashboard.yaml
@@ -36,6 +36,7 @@ spec:
           envFrom:
             - secretRef:
                 name: dashboard-secrets
+          resources:
             requests:
               cpu: "100m"
               memory: "128Mi"

--- a/infra/k8s/feed-aggregator.yaml
+++ b/infra/k8s/feed-aggregator.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feed-aggregator
+  labels:
+    app: feed-aggregator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: feed-aggregator
+  template:
+    metadata:
+      labels:
+        app: feed-aggregator
+    spec:
+      containers:
+        - name: feed-aggregator
+          image: arb-feed-aggregator
+          ports:
+            - containerPort: 8090
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
+          envFrom:
+            - secretRef:
+                name: feed-aggregator-secrets
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8090
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8090
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: feed-aggregator
+  labels:
+    app: feed-aggregator
+spec:
+  type: ClusterIP
+  selector:
+    app: feed-aggregator
+  ports:
+    - port: 8090
+      targetPort: 8090

--- a/infra/k8s/postgres.yaml
+++ b/infra/k8s/postgres.yaml
@@ -22,13 +22,9 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
-          env:
-            - name: POSTGRES_USER
-              value: sandbox
-            - name: POSTGRES_PASSWORD
-              value: sandbox
-            - name: POSTGRES_DB
-              value: arbitrage_demo
+          envFrom:
+            - secretRef:
+                name: postgres-secrets
           livenessProbe:
             tcpSocket:
               port: 5432

--- a/infra/k8s/sealed-secret.yaml
+++ b/infra/k8s/sealed-secret.yaml
@@ -41,3 +41,27 @@ spec:
     REDIS_HOST: AgFAKEREDISHOST
     REDIS_PORT: AgFAKEREDISPORT
     ANALYTICS_URL: AgFAKEANALYTICSURL
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: postgres-secrets
+  namespace: default
+spec:
+  encryptedData:
+    POSTGRES_USER: AgFAKEENCRYPTEDPGUSER
+    POSTGRES_PASSWORD: AgFAKEENCRYPTEDPGPASSWORD
+    POSTGRES_DB: AgFAKEENCRYPTEDPGDATABASE
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: feed-aggregator-secrets
+  namespace: default
+spec:
+  encryptedData:
+    FEED_URL: AgFAKEFEEDURL
+    REDIS_HOST: AgFAKEREDISHOST
+    REDIS_PORT: AgFAKEREDISPORT
+    ORDERBOOK_CHANNEL: AgFAKEORDERBOOKCHANNEL
+    ALERT_CHANNEL: AgFAKEALERTCHANNEL


### PR DESCRIPTION
## Summary
- use sealed secrets for Postgres credentials
- add deployment and Helm template for feed-aggregator
- add HorizontalPodAutoscaler resources
- fix dashboard manifest lint issue
- update Helm chart values
- update CHANGELOG

## Testing
- `bash test/verify-env.sh`
- `bash test/verify-release-workflow.sh`
- `bash test/run-local.sh`
- `kubeconform -strict -ignore-missing-schemas -summary infra/k8s/`

------
https://chatgpt.com/codex/tasks/task_b_687cf27178a8832c87c8fdec4681ee5b