### PR TITLE
Fix docs and live tests

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -33,3 +33,13 @@ Lint all files:
 ```bash
 npm run lint
 ```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and set values as needed.
+Key settings include:
+
+- `VITE_ENABLE_SENTRY` – enable Sentry monitoring when `true`
+- `VITE_SENTRY_DSN` – DSN for Sentry error tracking
+
+See [../docs/env-vars.md](../docs/env-vars.md) for the complete list.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -67,3 +67,24 @@ Lists environment variables used across services.
 | `MODEL_PATH` | Location of the production model |
 | `MODEL_SHADOW_PATH` | Path to the shadow model |
 | `LOG_LEVEL` | Logging level for analytics service |
+
+## Feed Aggregator Variables
+
+| Name | Purpose |
+|------|---------|
+| `FEED_URL` | WebSocket endpoint for exchange data |
+| `ORDERBOOK_CHANNEL` | Redis channel for normalized books |
+| `REDIS_HOST` / `REDIS_PORT` | Redis connection details |
+| `HEALTH_PORT` | Port for the `/health` endpoint |
+| `MAX_RECONNECT_ATTEMPTS` | Reconnect attempts before exit |
+| `ALERT_CHANNEL` | Redis channel for alerts |
+| `THROTTLE_MS` | Minimum milliseconds between alerts |
+| `LOG_LEVEL` | Logging level for the service |
+| `MOCK_REDIS` | Disable Redis writes during tests |
+
+## Dashboard Variables
+
+| Name | Purpose |
+|------|---------|
+| `VITE_ENABLE_SENTRY` | Enable Sentry monitoring when `true` |
+| `VITE_SENTRY_DSN` | Sentry DSN for React error reports |

--- a/feed-aggregator/README.md
+++ b/feed-aggregator/README.md
@@ -21,6 +21,23 @@ Alerts are throttled so repeated errors with the same message within 60 seconds
 are suppressed. If Redis is unavailable, alert payloads are written to
 `alerts-fallback.log`.
 
+## Configuration
+
+Create an `.env` file or export the following variables before starting the
+service:
+
+| Name | Description |
+|------|-------------|
+| `FEED_URL` | WebSocket endpoint for order book data |
+| `ORDERBOOK_CHANNEL` | Redis channel for normalized books |
+| `REDIS_HOST` / `REDIS_PORT` | Redis connection info |
+| `HEALTH_PORT` | Port for the `/health` check |
+| `MAX_RECONNECT_ATTEMPTS` | Number of reconnect tries before exit |
+| `ALERT_CHANNEL` | Redis channel for alert payloads |
+| `THROTTLE_MS` | Minimum time between duplicate alerts |
+| `LOG_LEVEL` | Logging level (`info`, `debug`, etc.) |
+| `MOCK_REDIS` | Skip Redis publishing when set |
+
 ## Tests
 
 Run the Python-based test suite after installing dependencies:

--- a/test/run-live.sh
+++ b/test/run-live.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # @dev-note: runs integration tests against live services
 export TEST_ENV=live
-npx jest --runInBand
+npm --prefix dashboard test -- --runInBand
+npm --prefix api test -- --runInBand
 pytest -m "env('live')"
 executor/gradlew test -PtestEnv=live


### PR DESCRIPTION
## Summary
- fix `run-live.sh` so it runs all Jest suites
- document aggregator and dashboard env vars
- add configuration section to feed aggregator docs
- detail dashboard environment variables

## Testing
- `npm --prefix api test -- --runInBand`
- `npm --prefix dashboard test -- --runInBand`
- `pytest`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_687d320a0bc4832ca774e60d43d9e598