### PR TITLE
Add dry-run logic and guard fund movement using injected config

### DIFF
--- a/executor/src/main/java/ColdSweeper.java
+++ b/executor/src/main/java/ColdSweeper.java
@@ -3,6 +3,9 @@ package executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import executor.Config;
+import executor.ExecutionMode;
+
 /**
  * Decides when to sweep profits to cold wallet based on profit amount and capital ratio.
  */
@@ -12,14 +15,16 @@ public class ColdSweeper {
     private final double minAmountUsd;
     private final double minCapitalRatio;
     private final WalletClient walletClient;
-    private final ColdSweeperConfig config;
+    private final ColdSweeperConfig sweeperConfig;
     private final SweepLogger sweepLogger;
+    private final Config config;
+    private final boolean isDryRun;
 
     /**
      * Default: sweep when profit ≥ $5,000 or ≥ 30% of capital.
      */
     public ColdSweeper() {
-        this(5000.0, 0.30, new MockWalletClient(), new ColdSweeperConfig(), null);
+        this(5000.0, 0.30, new MockWalletClient(), new ColdSweeperConfig(), null, new Config(ExecutionMode.LIVE));
     }
 
     /**
@@ -27,7 +32,7 @@ public class ColdSweeper {
      * @param minCapitalRatio relative profit threshold (e.g. 0.30 = 30%)
      */
     public ColdSweeper(double minAmountUsd, double minCapitalRatio) {
-        this(minAmountUsd, minCapitalRatio, new MockWalletClient(), new ColdSweeperConfig(), null);
+        this(minAmountUsd, minCapitalRatio, new MockWalletClient(), new ColdSweeperConfig(), null, new Config(ExecutionMode.LIVE));
     }
 
     /**
@@ -36,25 +41,31 @@ public class ColdSweeper {
      * @param walletClient    wallet client implementation
      */
     public ColdSweeper(double minAmountUsd, double minCapitalRatio, WalletClient walletClient) {
-        this(minAmountUsd, minCapitalRatio, walletClient, new ColdSweeperConfig(), null);
+        this(minAmountUsd, minCapitalRatio, walletClient, new ColdSweeperConfig(), null, new Config(ExecutionMode.LIVE));
     }
 
     /**
      * @param minAmountUsd    absolute profit threshold
      * @param minCapitalRatio relative profit threshold
      * @param walletClient    wallet client implementation
-     * @param config          configuration loader
+     * @param sweeperConfig   configuration loader
      */
-    public ColdSweeper(double minAmountUsd, double minCapitalRatio, WalletClient walletClient, ColdSweeperConfig config) {
-        this(minAmountUsd, minCapitalRatio, walletClient, config, null);
+    public ColdSweeper(double minAmountUsd, double minCapitalRatio, WalletClient walletClient, ColdSweeperConfig sweeperConfig) {
+        this(minAmountUsd, minCapitalRatio, walletClient, sweeperConfig, null, new Config(ExecutionMode.LIVE));
     }
 
-    public ColdSweeper(double minAmountUsd, double minCapitalRatio, WalletClient walletClient, ColdSweeperConfig config, SweepLogger logger) {
+    public ColdSweeper(double minAmountUsd, double minCapitalRatio, WalletClient walletClient, ColdSweeperConfig sweeperConfig, SweepLogger logger) {
+        this(minAmountUsd, minCapitalRatio, walletClient, sweeperConfig, logger, new Config(ExecutionMode.LIVE));
+    }
+
+    public ColdSweeper(double minAmountUsd, double minCapitalRatio, WalletClient walletClient, ColdSweeperConfig sweeperConfig, SweepLogger logger, Config configObj) {
         this.minAmountUsd = minAmountUsd;
         this.minCapitalRatio = minCapitalRatio;
         this.walletClient = walletClient;
-        this.config = config;
+        this.sweeperConfig = sweeperConfig;
         this.sweepLogger = logger;
+        this.config = configObj;
+        this.isDryRun = configObj != null && configObj.isDryRun();
     }
 
     private String maskAddress(String address) {
@@ -91,9 +102,13 @@ public class ColdSweeper {
      * Uses the address from {@link ColdSweeperConfig}.
      */
     public void sweepToColdWallet(double amountUsd) {
-        String address = config.getTestColdWalletAddress();
+        String address = sweeperConfig.getTestColdWalletAddress();
         logger.info("Cold wallet sweep triggered for: {} amount {}", maskAddress(address), amountUsd);
-        walletClient.withdraw(address, amountUsd);
+        if (isDryRun) {
+            logger.info("[DRY-RUN] Skipping cold wallet transfer");
+        } else {
+            walletClient.withdraw(address, amountUsd);
+        }
         ProfitTracker.resetCumulativeProfit();
         if (sweepLogger != null) {
             sweepLogger.logSweep(amountUsd, address, "auto");
@@ -108,7 +123,11 @@ public class ColdSweeper {
      */
     public void sweepToColdWallet(String address, double amountUsd) {
         logger.info("Cold wallet sweep triggered for: {} amount {}", maskAddress(address), amountUsd);
-        walletClient.withdraw(address, amountUsd);
+        if (isDryRun) {
+            logger.info("[DRY-RUN] Skipping cold wallet transfer");
+        } else {
+            walletClient.withdraw(address, amountUsd);
+        }
         ProfitTracker.resetCumulativeProfit();
         if (sweepLogger != null) {
             sweepLogger.logSweep(amountUsd, address, "manual");

--- a/executor/src/main/java/Config.java
+++ b/executor/src/main/java/Config.java
@@ -1,0 +1,21 @@
+package executor;
+
+/** Configuration object supplying runtime execution mode. */
+public class Config {
+    private final ExecutionMode executionMode;
+
+    public Config(ExecutionMode mode) {
+        this.executionMode = mode;
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    /**
+     * @return true when running in sandbox/dry-run mode
+     */
+    public boolean isDryRun() {
+        return executionMode == ExecutionMode.SANDBOX;
+    }
+}

--- a/executor/src/main/java/ExecutionMode.java
+++ b/executor/src/main/java/ExecutionMode.java
@@ -1,0 +1,6 @@
+package executor;
+
+public enum ExecutionMode {
+    LIVE,
+    SANDBOX
+}

--- a/executor/src/main/java/Rebalancer.java
+++ b/executor/src/main/java/Rebalancer.java
@@ -6,6 +6,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Objects;
 
+import executor.Config;
+import executor.ExecutionMode;
+
 import java.util.Map;
 
 /**
@@ -16,12 +19,14 @@ public class Rebalancer {
     private static final Logger logger = LoggerFactory.getLogger(Rebalancer.class);
     private final double threshold;
     private final Map<String, ExchangeAdapter> adapters;
+    private final Config config;
+    private final boolean isDryRun;
 
     /**
      * @param threshold allowed deviation from target before logging (e.g. 0.3 * target for ±30%)
      */
     public Rebalancer(double threshold) {
-        this(threshold, Collections.emptyMap());
+        this(threshold, Collections.emptyMap(), new Config(ExecutionMode.LIVE));
     }
 
     /**
@@ -29,8 +34,14 @@ public class Rebalancer {
      * @param adapters  exchange adapters used for optional transfers
      */
     public Rebalancer(double threshold, Map<String, ExchangeAdapter> adapters) {
+        this(threshold, adapters, new Config(ExecutionMode.LIVE));
+    }
+
+    public Rebalancer(double threshold, Map<String, ExchangeAdapter> adapters, Config config) {
         this.threshold = threshold;
         this.adapters = Objects.requireNonNullElse(adapters, Collections.emptyMap());
+        this.config = config;
+        this.isDryRun = config != null && config.isDryRun();
     }
 
     /**
@@ -57,7 +68,12 @@ public class Rebalancer {
                 status.put(exchange, String.format("OVER by %.2f", balance - target));
                 ExchangeAdapter adapter = adapters.get(exchange);
                 if (adapter != null) {
-                    adapter.transfer("USDT", balance - target, "treasury");
+                    double amount = balance - target;
+                    if (isDryRun) {
+                        logger.info("[DRY-RUN] Skipping exchange transfer");
+                    } else {
+                        adapter.transfer("USDT", amount, "treasury");
+                    }
                 }
             } else if (balance < target - threshold) {
                 logger.info("{} under target by {} ({} vs target {})",
@@ -65,7 +81,12 @@ public class Rebalancer {
                 status.put(exchange, String.format("UNDER by %.2f", target - balance));
                 ExchangeAdapter adapter = adapters.get(exchange);
                 if (adapter != null) {
-                    adapter.transfer("USDT", target - balance, exchange);
+                    double amount = target - balance;
+                    if (isDryRun) {
+                        logger.info("[DRY-RUN] Skipping exchange transfer");
+                    } else {
+                        adapter.transfer("USDT", amount, exchange);
+                    }
                 }
             } else {
                 logger.info("{} within acceptable threshold ({} vs target {})",

--- a/executor/src/test/java/ColdSweeperTest.java
+++ b/executor/src/test/java/ColdSweeperTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
 @Tag("local")
 public class ColdSweeperTest {
 
@@ -33,6 +36,36 @@ public class ColdSweeperTest {
         ColdSweeper sweeper = new ColdSweeper();
         assertTrue(sweeper.shouldSweep(6000.0, 0.0));  // absolute threshold met
         assertFalse(sweeper.shouldSweep(1000.0, -500.0)); // invalid capital
+    }
+
+    static class TestWalletClient implements WalletClient {
+        boolean called = false;
+        @Override
+        public void withdraw(String address, double amountUsd) { called = true; }
+    }
+
+    @Test
+    void dryRunSkipsWithdrawal() {
+        TestWalletClient wallet = new TestWalletClient();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream orig = System.err;
+        System.setErr(new PrintStream(err));
+        try {
+            ColdSweeper sweeper = new ColdSweeper(0, 0, wallet, new ColdSweeperConfig(), null, new Config(ExecutionMode.SANDBOX));
+            sweeper.sweepToColdWallet(10.0);
+        } finally {
+            System.setErr(orig);
+        }
+        assertFalse(wallet.called);
+        assertTrue(err.toString().contains("[DRY-RUN]"));
+    }
+
+    @Test
+    void liveModeWithdraws() {
+        TestWalletClient wallet = new TestWalletClient();
+        ColdSweeper sweeper = new ColdSweeper(0, 0, wallet, new ColdSweeperConfig(), null, new Config(ExecutionMode.LIVE));
+        sweeper.sweepToColdWallet(10.0);
+        assertTrue(wallet.called);
     }
 }
 

--- a/executor/src/test/java/RebalancerTest.java
+++ b/executor/src/test/java/RebalancerTest.java
@@ -2,7 +2,10 @@ package executor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,5 +21,45 @@ public class RebalancerTest {
 
         Rebalancer rebalancer = new Rebalancer(250.0);
         assertDoesNotThrow(() -> rebalancer.rebalance(balances, 5000.0));
+    }
+
+    static class DummyAdapter implements ExchangeAdapter {
+        boolean called = false;
+        @Override public boolean placeOrder(String pair, String side, double size, double limitPrice) { return true; }
+        @Override public double getFeeRate(String pair) { return 0; }
+        @Override public double getBalance(String asset) { return 0; }
+        @Override public void transfer(String asset, double amount, String destination) { called = true; }
+    }
+
+    @Test
+    void dryRunSkipsTransfer() {
+        Map<String, Double> balances = new HashMap<>();
+        balances.put("Binance", 6000.0);
+        DummyAdapter adapter = new DummyAdapter();
+        Map<String, ExchangeAdapter> adapters = new HashMap<>();
+        adapters.put("Binance", adapter);
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream orig = System.err;
+        System.setErr(new PrintStream(err));
+        try {
+            Rebalancer r = new Rebalancer(250.0, adapters, new Config(ExecutionMode.SANDBOX));
+            r.scan(balances, 5000.0);
+        } finally {
+            System.setErr(orig);
+        }
+        assertFalse(adapter.called);
+        assertTrue(err.toString().contains("[DRY-RUN]"));
+    }
+
+    @Test
+    void liveModeTransfers() {
+        Map<String, Double> balances = new HashMap<>();
+        balances.put("Binance", 6000.0);
+        DummyAdapter adapter = new DummyAdapter();
+        Map<String, ExchangeAdapter> adapters = new HashMap<>();
+        adapters.put("Binance", adapter);
+        Rebalancer r = new Rebalancer(250.0, adapters, new Config(ExecutionMode.LIVE));
+        r.scan(balances, 5000.0);
+        assertTrue(adapter.called);
     }
 }


### PR DESCRIPTION
## Summary
- inject Config with ExecutionMode into ColdSweeper and Rebalancer
- guard transfer/withdraw calls when dry-run is enabled
- add ExecutionMode enum and Config helper
- test dry-run behaviour for wallet sweeps and rebalance transfers

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_b_687d504a1fc4832cbc13307817d9764b