### PR TITLE
Fix panic enforcement and publish control-feed messages by execution mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Added profit targets and slippage caps
 - Added feed-aggregator deployment
 - Integrated sealed secrets
+- Fix panic resume and Redis signal behavior in Executor and PanicBrake
 - CVE scanning with Trivy
 
 ## [Batch 1] - 2025-07-02

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -8,6 +8,8 @@ import executor.PanicBrake;
 import executor.FeatureLogger;
 import executor.ConfigValidator;
 import executor.CircuitBreaker;
+import executor.Config;
+import executor.ExecutionMode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
@@ -35,7 +37,8 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     private final ProfitEstimator profitEstimator;
     private final SimulatedPublisher simulatedPublisher;
     private final RiskSettings riskSettings;
-    private final ResumeHandler resumeHandler;
+    private final Config config;
+    private final String controlChannel;
     private final String redisHost;
     private final int redisPort;
     private Connection dbConnection;
@@ -73,10 +76,15 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
      * @param nearMissLogger logger used for near miss events
      */
     public Executor(RedisClient redisClient, String redisHost, int redisPort, RiskFilter riskFilter, NearMissLogger nearMissLogger) {
+        this(redisClient, redisHost, redisPort, riskFilter, nearMissLogger, new Config(ExecutionMode.LIVE));
+    }
+
+    public Executor(RedisClient redisClient, String redisHost, int redisPort, RiskFilter riskFilter, NearMissLogger nearMissLogger, Config config) {
         this.redisClient = redisClient;
         this.redisHost = redisHost;
         this.redisPort = redisPort;
-        this.resumeHandler = new ResumeHandler(new redis.clients.jedis.Jedis(redisHost, redisPort), this);
+        this.config = config == null ? new Config(ExecutionMode.LIVE) : config;
+        this.controlChannel = this.config.getExecutionMode() == ExecutionMode.LIVE ? "control-feed-live" : "control-feed-sandbox";
         this.riskFilter = riskFilter;
         this.nearMissLogger = nearMissLogger;
         this.scoringEngine = new ScoringEngine();
@@ -89,7 +97,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         this.circuitBreaker = new CircuitBreaker(redisClient, cbWinRate, cbDrawdown);
         this.canaryMode = Boolean.parseBoolean(System.getenv().getOrDefault("CANARY_MODE", "false"));
         this.ghostMode = Boolean.parseBoolean(System.getenv().getOrDefault("GHOST_MODE", "false"));
-        this.sandboxMode = Boolean.parseBoolean(System.getenv().getOrDefault("SANDBOX_MODE", "false"));
+        this.sandboxMode = this.config.isDryRun();
         this.maxOpenTrades = Integer.parseInt(System.getenv().getOrDefault("MAX_OPEN_TRADES", "5"));
     }
 
@@ -155,8 +163,17 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         } catch (Exception e) {
             logger.warn("Failed to start Redis client", e);
         }
-        logger.info("🔁 Starting ResumeHandler thread");
-        resumeHandler.start();
+        setupControlSubscription();
+    }
+
+    /** Subscribe to control channel for resume signals. */
+    protected void setupControlSubscription() {
+        redisClient.subscribeControl(config, msg -> {
+            if ("resume".equalsIgnoreCase(msg)) {
+                logger.info("Resume signal received on {}", controlChannel);
+                resumeFromPanic();
+            }
+        });
     }
 
     /** {@inheritDoc} */
@@ -295,11 +312,12 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         }
         circuitBreaker.check(winRate, drawdown);
 
-        if (PanicBrake.shouldHalt(dailyLossPct, avgLatencyMs, winRate)) {
-            isPanic.set(true);
-            logger.error("PANIC BRAKE TRIGGERED");
-            AlertManager.sendAlert("PANIC BRAKE TRIGGERED");
-            redisClient.publish("alerts", "PANIC BRAKE TRIGGERED");
+        if (PanicBrake.shouldHalt(redisClient, config, dailyLossPct, avgLatencyMs, winRate)) {
+            if (isPanic.compareAndSet(false, true)) {
+                logger.error("PANIC BRAKE TRIGGERED - trading paused");
+                AlertManager.sendAlert("PANIC BRAKE TRIGGERED");
+                redisClient.publish("alerts", "PANIC BRAKE TRIGGERED");
+            }
         }
     }
 

--- a/executor/src/main/java/PanicBrake.java
+++ b/executor/src/main/java/PanicBrake.java
@@ -3,11 +3,13 @@ package executor;
 /**
  * Utility class that determines when trading should halt based on a few
  * safety thresholds.  All thresholds are fixed and checked in the static
- * {@link #shouldHalt(double, double, double)} method.
+ * {@link #shouldHalt(RedisClient, Config, double, double, double)} method.
  */
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import executor.ProfitTracker;
+import executor.RedisClient;
+import executor.Config;
 
 public class PanicBrake {
     private static final Logger logger = LoggerFactory.getLogger(PanicBrake.class);
@@ -61,30 +63,35 @@ public class PanicBrake {
         }
     }
 
-    public static boolean shouldHalt(double dailyLossPct, double avgLatencyMs, double winRate) {
+    public static boolean shouldHalt(RedisClient redis, Config config,
+                                     double dailyLossPct, double avgLatencyMs, double winRate) {
         double lossCap = getLossCapPct();
         double latencyCap = getLatencyMaxMs();
         double winRateThresh = getWinRateThreshold();
         double profitTarget = getProfitTargetUsd();
         double profitSoFar = ProfitTracker.getCumulativeProfit();
 
+        boolean triggered = false;
+
         if (dailyLossPct > lossCap) {
             logger.warn("PANIC BRAKE TRIGGERED: loss {}% > {}%", dailyLossPct, lossCap);
-            return true;
-        }
-        if (avgLatencyMs > latencyCap) {
+            triggered = true;
+        } else if (avgLatencyMs > latencyCap) {
             logger.warn("PANIC BRAKE TRIGGERED: latency {}ms > {}ms", avgLatencyMs, latencyCap);
-            return true;
-        }
-        if (winRate < winRateThresh) {
+            triggered = true;
+        } else if (winRate < winRateThresh) {
             logger.warn("PANIC BRAKE TRIGGERED: winRate {} < {}", winRate, winRateThresh);
-            return true;
-        }
-        if (profitTarget > 0 && profitSoFar >= profitTarget) {
+            triggered = true;
+        } else if (profitTarget > 0 && profitSoFar >= profitTarget) {
             logger.warn("PANIC BRAKE TRIGGERED: profit {} >= target {}", profitSoFar, profitTarget);
-            return true;
+            triggered = true;
         }
-        return false;
+
+        if (triggered && redis != null) {
+            redis.publishControl(config, "pause");
+        }
+
+        return triggered;
     }
 }
 

--- a/executor/src/main/java/RedisClient.java
+++ b/executor/src/main/java/RedisClient.java
@@ -84,6 +84,19 @@ public class RedisClient extends Thread {
     }
 
     /**
+     * Publish a message to the control channel derived from execution mode.
+     */
+    public void publishControl(Config config, String message) {
+        if (config == null) {
+            publish("control-feed-live", message);
+            return;
+        }
+        String channel = config.getExecutionMode() == ExecutionMode.LIVE
+                ? "control-feed-live" : "control-feed-sandbox";
+        publish(channel, message);
+    }
+
+    /**
      * Subscribe with a provided {@link JedisPubSub} listener.
      * A new thread will be created for the subscription.
      *
@@ -122,6 +135,19 @@ public class RedisClient extends Thread {
      */
     public void subscribe(String channel, Consumer<String> handler) {
         subscribe(channel, (ch, msg) -> handler.accept(msg));
+    }
+
+    /**
+     * Subscribe to the control channel derived from execution mode.
+     */
+    public void subscribeControl(Config config, Consumer<String> handler) {
+        if (config == null) {
+            subscribe("control-feed-live", handler);
+            return;
+        }
+        String channel = config.getExecutionMode() == ExecutionMode.LIVE
+                ? "control-feed-live" : "control-feed-sandbox";
+        subscribe(channel, handler);
     }
 
     /**

--- a/executor/src/test/java/ExecutorRedisRecoveryTest.java
+++ b/executor/src/test/java/ExecutorRedisRecoveryTest.java
@@ -2,47 +2,65 @@ package executor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import executor.Config;
+import executor.ExecutionMode;
+import executor.RiskFilter;
+import executor.NearMissLogger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Ensures Executor continues processing after Redis reconnects. */
 @Tag("local")
 public class ExecutorRedisRecoveryTest {
-    /** Redis client stub emitting a message, a disconnect, then another message. */
-    static class FlakyRedisClient extends RedisClient {
-        MessageHandler handler;
-        FlakyRedisClient() {
-            super("localhost", 6379, "chan", (c, m) -> {}, 1L, 2L);
-        }
-        void setHandler(MessageHandler h) { this.handler = h; }
-        @Override public void start() { run(); }
-        @Override public void run() {
-            if (handler == null) return;
-            handler.onMessage("chan", "{\"pair\":\"A/B\",\"buyExchange\":\"A\",\"sellExchange\":\"B\",\"grossEdge\":1.0,\"netEdge\":1.0}");
-            handler.onMessage("chan", "{}"); // disconnect signal
-            handler.onMessage("chan", "{\"pair\":\"C/D\",\"buyExchange\":\"C\",\"sellExchange\":\"D\",\"grossEdge\":1.0,\"netEdge\":1.0}");
-        }
+    /** Redis client stub for feed and control channels. */
+    static class StubRedisClient extends RedisClient {
+        MessageHandler feedHandler;
+        java.util.function.Consumer<String> controlHandler;
+        StubRedisClient() { super("localhost", 6379, "chan", (c,m)->{}, 1L, 2L); }
+        @Override public void start() {}
+        @Override public void subscribe(String channel, MessageHandler handler) { feedHandler = handler; }
+        @Override public void subscribeControl(Config config, java.util.function.Consumer<String> handler) { controlHandler = handler; }
+        void sendFeed(String msg) { if (feedHandler != null) feedHandler.onMessage("chan", msg); }
+        void sendControl(String msg) { if (controlHandler != null) controlHandler.accept(msg); }
     }
 
     /** Executor capturing handled messages. */
     static class DummyExecutor extends Executor {
         int count = 0;
-        DummyExecutor(FlakyRedisClient client) {
-            super(client, "localhost", 6379, new RiskFilter(), new NearMissLogger(null));
+        StubRedisClient client;
+        DummyExecutor(StubRedisClient client) {
+            super(client, "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.LIVE));
+            this.client = client;
         }
-        @Override public void start() {}
+        @Override public void start() { setupControlSubscription(); }
         @Override public void handleMessage(String msg) {
             if (msg == null || msg.trim().isEmpty() || msg.equals("{}")) return;
+            try {
+                java.lang.reflect.Field f = Executor.class.getDeclaredField("isPanic");
+                f.setAccessible(true);
+                java.util.concurrent.atomic.AtomicBoolean p = (java.util.concurrent.atomic.AtomicBoolean) f.get(this);
+                if (p.get()) return;
+            } catch (Exception ignored) {}
             count++;
         }
     }
 
     @Test
-    void processesMessagesAfterReconnect() {
-        FlakyRedisClient client = new FlakyRedisClient();
+    void resumesAfterControlSignal() throws Exception {
+        StubRedisClient client = new StubRedisClient();
         DummyExecutor exec = new DummyExecutor(client);
-        client.setHandler((c, m) -> exec.handleMessage(m));
-        client.start();
-        assertEquals(2, exec.count);
+        exec.start();
+        client.subscribe("chan", (c,m) -> exec.handleMessage(m));
+
+        java.lang.reflect.Field f = Executor.class.getDeclaredField("isPanic");
+        f.setAccessible(true);
+        ((java.util.concurrent.atomic.AtomicBoolean)f.get(exec)).set(true);
+
+        client.sendFeed("{\"pair\":\"A/B\",\"buyExchange\":\"A\",\"sellExchange\":\"B\",\"grossEdge\":1.0,\"netEdge\":1.0}");
+        assertEquals(0, exec.count);
+
+        client.sendControl("resume");
+        client.sendFeed("{\"pair\":\"C/D\",\"buyExchange\":\"C\",\"sellExchange\":\"D\",\"grossEdge\":1.0,\"netEdge\":1.0}");
+        assertEquals(1, exec.count);
     }
 }

--- a/executor/src/test/java/PanicBrakeTest.java
+++ b/executor/src/test/java/PanicBrakeTest.java
@@ -5,27 +5,38 @@ import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 import executor.PanicBrake;
 import executor.ProfitTracker;
+import executor.RedisClient;
+import executor.Config;
+import executor.ExecutionMode;
 
 @Tag("local")
 public class PanicBrakeTest {
+    static class DummyRedis extends RedisClient {
+        String channel;
+        String message;
+        DummyRedis() { super("localhost", 6379, "chan", (c,m)->{}); }
+        @Override public void start() {}
+        @Override public void publish(String ch, String msg) { this.channel = ch; this.message = msg; }
+    }
+
     @Test
     void triggersOnHighLoss() {
-        assertTrue(PanicBrake.shouldHalt(4.0, 100.0, 0.8));
+        assertTrue(PanicBrake.shouldHalt(null, new Config(ExecutionMode.LIVE), 4.0, 100.0, 0.8));
     }
 
     @Test
     void triggersOnHighLatency() {
-        assertTrue(PanicBrake.shouldHalt(2.0, 800.0, 0.8));
+        assertTrue(PanicBrake.shouldHalt(null, new Config(ExecutionMode.LIVE), 2.0, 800.0, 0.8));
     }
 
     @Test
     void triggersOnLowWinRate() {
-        assertTrue(PanicBrake.shouldHalt(2.0, 100.0, 0.2));
+        assertTrue(PanicBrake.shouldHalt(null, new Config(ExecutionMode.LIVE), 2.0, 100.0, 0.2));
     }
 
     @Test
     void passesIfAllWithinLimits() {
-        assertFalse(PanicBrake.shouldHalt(1.0, 100.0, 0.8));
+        assertFalse(PanicBrake.shouldHalt(null, new Config(ExecutionMode.LIVE), 1.0, 100.0, 0.8));
     }
 
     @Test
@@ -34,7 +45,7 @@ public class PanicBrakeTest {
         System.setProperty("LATENCY_MAX_MS", "200.0");
         System.setProperty("WIN_RATE_THRESHOLD", "0.9");
         try {
-            assertTrue(PanicBrake.shouldHalt(2.0, 300.0, 0.5));
+            assertTrue(PanicBrake.shouldHalt(null, new Config(ExecutionMode.LIVE), 2.0, 300.0, 0.5));
         } finally {
             System.clearProperty("LOSS_CAP_PCT");
             System.clearProperty("LATENCY_MAX_MS");
@@ -47,10 +58,19 @@ public class PanicBrakeTest {
         System.setProperty("PROFIT_TARGET_USD", "100.0");
         ProfitTracker.record(150.0);
         try {
-            assertTrue(PanicBrake.shouldHalt(0.0, 100.0, 0.9));
+            assertTrue(PanicBrake.shouldHalt(null, new Config(ExecutionMode.LIVE), 0.0, 100.0, 0.9));
         } finally {
             ProfitTracker.resetCumulativeProfit();
             System.clearProperty("PROFIT_TARGET_USD");
         }
+    }
+
+    @Test
+    void publishesPauseToSandboxChannel() {
+        DummyRedis redis = new DummyRedis();
+        Config config = new Config(ExecutionMode.SANDBOX);
+        assertTrue(PanicBrake.shouldHalt(redis, config, 4.0, 100.0, 0.8));
+        assertEquals("control-feed-sandbox", redis.channel);
+        assertEquals("pause", redis.message);
     }
 }


### PR DESCRIPTION
## Summary
- implement mode-aware control channel helpers in RedisClient
- trigger panic pause publication in PanicBrake
- inject Config into Executor and listen for resume signals
- update tests for panic brake and executor redis recovery
- document panic resume in CHANGELOG

## Testing
- `./executor/gradlew test -p executor -PtestEnv=local`

------
https://chatgpt.com/codex/tasks/task_b_687d5c65b87c832c8aa87c9fe0c03ef6