### PR TITLE
Fix partial fill cancelation in SpreadOpportunity

### DIFF
--- a/executor/src/main/java/ExchangeAdapter.java
+++ b/executor/src/main/java/ExchangeAdapter.java
@@ -53,5 +53,15 @@ public interface ExchangeAdapter {
      * @param destination target destination identifier
      */
     void transfer(String asset, double amount, String destination);
+
+    /**
+     * Cancel an existing order. Default implementation is a no-op so tests can
+     * override as needed.
+     *
+     * @param orderId unique order identifier
+     */
+    default void cancel(String orderId) {
+        // no-op
+    }
 }
 

--- a/executor/src/main/java/MockExchangeAdapter.java
+++ b/executor/src/main/java/MockExchangeAdapter.java
@@ -26,6 +26,7 @@ public class MockExchangeAdapter implements ExchangeAdapter {
     private double lastFillSize = 0.0;
     private double lastCancelFee = 0.0;
     private double lastExecPrice = 0.0;
+    private final java.util.List<String> canceledOrders = new java.util.ArrayList<>();
 
     /** Create an adapter with the default exchange name. */
     public MockExchangeAdapter() {
@@ -152,5 +153,17 @@ public class MockExchangeAdapter implements ExchangeAdapter {
      */
     public double getCancelFeeRate() {
         return cancelFeeRate;
+    }
+
+    @Override
+    public void cancel(String orderId) {
+        canceledOrders.add(orderId);
+    }
+
+    /**
+     * @return list of order ids that were canceled
+     */
+    public java.util.List<String> getCanceledOrders() {
+        return canceledOrders;
     }
 }

--- a/executor/src/main/java/SpreadOpportunity.java
+++ b/executor/src/main/java/SpreadOpportunity.java
@@ -2,11 +2,14 @@ package executor;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents an executable arbitrage opportunity between two exchanges.
  */
 public class SpreadOpportunity {
+    private static final Logger logger = LoggerFactory.getLogger(SpreadOpportunity.class);
     private final String pair;
     private final String buyExchange;
     private final String sellExchange;
@@ -16,6 +19,14 @@ public class SpreadOpportunity {
     private long roundTripLatencyMs;
     private long latencyMicros;
     private long roundTripLatencyMicros;
+
+    /**
+     * Factory method for creating exchange adapters. Allows tests to override
+     * with custom behaviour.
+     */
+    protected MockExchangeAdapter createAdapter(String name) {
+        return new MockExchangeAdapter(name);
+    }
 
     /**
      * Create an opportunity with the given parameters.
@@ -80,8 +91,11 @@ public class SpreadOpportunity {
      * Execute the opportunity using mock exchanges.
      */
     public TradeResult execute(double size, double price) {
-        MockExchangeAdapter buy = new MockExchangeAdapter(buyExchange);
-        MockExchangeAdapter sell = new MockExchangeAdapter(sellExchange);
+        MockExchangeAdapter buy = createAdapter(buyExchange);
+        MockExchangeAdapter sell = createAdapter(sellExchange);
+
+        String buyOrderId = "BUY-" + System.nanoTime();
+        String sellOrderId = "SELL-" + System.nanoTime();
 
         long start = System.nanoTime();
 
@@ -95,6 +109,11 @@ public class SpreadOpportunity {
         while (attempts < maxRetries && !buyOk) {
             buyOk = buy.placeIocOrder(pair, "BUY", size, price);
             buyCancel += buy.getLastCancelFee();
+            if (!buyOk && buy.getLastFillSize() > 0) {
+                sell.cancel(sellOrderId);
+                logger.info("[CANCEL] Orphan order canceled: {}", sellOrderId);
+                break;
+            }
             attempts++;
         }
 
@@ -103,6 +122,11 @@ public class SpreadOpportunity {
             while (attempts < maxRetries && !sellOk) {
                 sellOk = sell.placeIocOrder(pair, "SELL", size, price);
                 sellCancel += sell.getLastCancelFee();
+                if (!sellOk && sell.getLastFillSize() > 0) {
+                    buy.cancel(buyOrderId);
+                    logger.info("[CANCEL] Orphan order canceled: {}", buyOrderId);
+                    break;
+                }
                 attempts++;
             }
         }

--- a/executor/src/test/java/SpreadOpportunityTest.java
+++ b/executor/src/test/java/SpreadOpportunityTest.java
@@ -2,10 +2,35 @@ package executor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Random;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("local")
 public class SpreadOpportunityTest {
+    static class FixedRandom extends Random {
+        private final double[] values;
+        private int idx = 0;
+        FixedRandom(double... v) { this.values = v; }
+        @Override
+        public double nextDouble() { return values[idx < values.length ? idx++ : values.length - 1]; }
+    }
+
+    static class TestOpportunity extends SpreadOpportunity {
+        private final MockExchangeAdapter buy;
+        private final MockExchangeAdapter sell;
+        TestOpportunity(MockExchangeAdapter buy, MockExchangeAdapter sell) {
+            super("BTC/USDT", "A", "B", 2.0, 2.0, 0L);
+            this.buy = buy;
+            this.sell = sell;
+        }
+
+        @Override
+        protected MockExchangeAdapter createAdapter(String name) {
+            return name.equals("A") ? buy : sell;
+        }
+    }
     @Test
     void subtractsFeesFromBothSides() {
         MockExchangeAdapter.setFeeRate("A", 0.001);
@@ -15,5 +40,46 @@ public class SpreadOpportunityTest {
         double expected = 2.0 - (1.0 * 100.0 * 0.001) - (1.0 * 100.0 * 0.001);
         assertTrue(result.success);
         assertEquals(expected, result.pnl, 1e-9);
+    }
+
+    @Test
+    void partialFillTriggersCancel() {
+        MockExchangeAdapter buy = new MockExchangeAdapter("A", 0.0002, new FixedRandom(0.85));
+        MockExchangeAdapter sell = new MockExchangeAdapter("B", 0.0002, new FixedRandom(0.5));
+        TestOpportunity opp = new TestOpportunity(buy, sell);
+
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream origErr = System.err;
+        System.setErr(new PrintStream(err));
+        try {
+            opp.execute(1.0, 100.0);
+        } finally {
+            System.setErr(origErr);
+        }
+
+        assertEquals(1, sell.getCanceledOrders().size());
+        String logs = err.toString();
+        assertTrue(logs.contains("[CANCEL] Orphan order canceled:"));
+    }
+
+    @Test
+    void noCancelWhenAllFilled() {
+        MockExchangeAdapter buy = new MockExchangeAdapter("A", 0.0002, new FixedRandom(0.5));
+        MockExchangeAdapter sell = new MockExchangeAdapter("B", 0.0002, new FixedRandom(0.5));
+        TestOpportunity opp = new TestOpportunity(buy, sell);
+
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream origErr = System.err;
+        System.setErr(new PrintStream(err));
+        try {
+            opp.execute(1.0, 100.0);
+        } finally {
+            System.setErr(origErr);
+        }
+
+        assertTrue(buy.getCanceledOrders().isEmpty());
+        assertTrue(sell.getCanceledOrders().isEmpty());
+        String logs = err.toString();
+        assertFalse(logs.contains("[CANCEL]"));
     }
 }


### PR DESCRIPTION
## Summary
- add cancel method to ExchangeAdapter and MockExchangeAdapter
- log and cancel remaining orders on partial fills
- expose adapter factory for testing
- verify cancelation logic in SpreadOpportunityTest

## Testing
- `./executor/gradlew clean test -p executor`

------
https://chatgpt.com/codex/tasks/task_b_687d63879008832c82a4ec8348601100