### PR TITLE
Enforce strict validation for settings API

### DIFF
--- a/api/__tests__/settings.validation.test.js
+++ b/api/__tests__/settings.validation.test.js
@@ -1,69 +1,120 @@
-import request from 'supertest';
+import request from "supertest";
+import { jest } from "@jest/globals";
+import logger from "../services/logger.js";
 
-const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
-process.env.NODE_ENV = 'test';
-process.env.JWT_SECRET = 'testsecret';
-process.env.SANDBOX_MODE = 'true';
+const describeLocal =
+  process.env.TEST_ENV === "local" || !process.env.TEST_ENV
+    ? describe
+    : describe.skip;
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "testsecret";
+process.env.SANDBOX_MODE = "true";
 let buildApp;
 let app;
 let cookie;
+let warnSpy;
 
 beforeAll(async () => {
-  ({ buildApp } = await import('../index.js'));
+  ({ buildApp } = await import("../index.js"));
   app = buildApp();
   await app.listen({ port: 0 });
   const login = await request(app.server)
-    .post('/api/login')
-    .send({ email: 'user', password: 'pass' });
-  cookie = login.headers['set-cookie'][0].split(';')[0];
+    .post("/api/login")
+    .send({ email: "user", password: "pass" });
+  cookie = login.headers["set-cookie"][0].split(";")[0];
 });
 
 afterAll(async () => {
   await app.close();
 });
 
-describeLocal('settings validation', () => {
-  test('rejects unknown properties', async () => {
+beforeEach(() => {
+  warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describeLocal("settings validation", () => {
+  test("rejects unknown properties", async () => {
     const res = await request(app.server)
-      .patch('/api/settings')
-      .set('Cookie', cookie)
+      .patch("/api/settings")
+      .set("Cookie", cookie)
       .send({ evil: true });
     expect(res.statusCode).toBe(400);
   });
 
-  test('rejects incorrect types', async () => {
+  test("rejects incorrect types", async () => {
     const res = await request(app.server)
-      .patch('/api/settings')
-      .set('Cookie', cookie)
-      .send({ ghost_mode: 'true' });
+      .patch("/api/settings")
+      .set("Cookie", cookie)
+      .send({ ghost_mode: "true" });
     expect(res.statusCode).toBe(400);
   });
 
-  test('ignores invalid sweep_cadence values', async () => {
+  test("rejects invalid sweep_cadence values", async () => {
     const res = await request(app.server)
-      .patch('/api/settings')
-      .set('Cookie', cookie)
-      .send({ sweep_cadence: 'Weekly' });
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ saved: true });
-
-    const verify = await request(app.server)
-      .get('/api/settings')
-      .set('Cookie', cookie);
-    expect(verify.body.sweep_cadence).toBe('None');
+      .patch("/api/settings")
+      .set("Cookie", cookie)
+      .send({ sweep_cadence: "Weekly" });
+    expect(res.statusCode).toBe(400);
   });
 
-  test('forced sandbox_mode cannot be disabled', async () => {
+  test("forced sandbox_mode cannot be disabled", async () => {
     const res = await request(app.server)
-      .patch('/api/settings')
-      .set('Cookie', cookie)
+      .patch("/api/settings")
+      .set("Cookie", cookie)
       .send({ sandbox_mode: false });
     expect(res.statusCode).toBe(200);
 
     const verify = await request(app.server)
-      .get('/api/settings')
-      .set('Cookie', cookie);
+      .get("/api/settings")
+      .set("Cookie", cookie);
     expect(verify.body.sandbox_mode).toBe(true);
   });
-});
 
+  test("rejects unsafe maxLossPct", async () => {
+    const res = await request(app.server)
+      .patch("/api/settings")
+      .set("Cookie", cookie)
+      .send({ maxLossPct: 99 });
+    expect(res.statusCode).toBe(400);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[SETTINGS-REJECTED] maxLossPct=99 exceeds limit",
+    );
+  });
+
+  test("rejects unsafe latencyMaxMs", async () => {
+    const res = await request(app.server)
+      .patch("/api/settings")
+      .set("Cookie", cookie)
+      .send({ latencyMaxMs: 9999 });
+    expect(res.statusCode).toBe(400);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[SETTINGS-REJECTED] latencyMaxMs=9999 exceeds limit",
+    );
+  });
+
+  test("rejects malformed sweep_cadence", async () => {
+    const res = await request(app.server)
+      .patch("/api/settings")
+      .set("Cookie", cookie)
+      .send({ sweep_cadence: "dailyX" });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test("accepts valid payload", async () => {
+    const res = await request(app.server)
+      .patch("/api/settings")
+      .set("Cookie", cookie)
+      .send({
+        maxLossPct: 10,
+        latencyMaxMs: 500,
+        personality_mode: "Aggressive",
+        sweep_cadence: "Daily",
+      });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ saved: true });
+  });
+});

--- a/api/config/settings.js
+++ b/api/config/settings.js
@@ -1,8 +1,12 @@
 export default {
   schema_version: 1,
-  sandbox_mode: process.env.SANDBOX_MODE === 'true',
+  sandbox_mode: process.env.SANDBOX_MODE === "true",
   canary_mode: false,
   useEnsemble: true,
   shadowOnly: false,
-  ghost_mode: false
+  ghost_mode: false,
+  personality_mode: "Realistic",
+  sweep_cadence: "None",
+  maxLossPct: 0,
+  latencyMaxMs: 250,
 };

--- a/api/routes/settings.js
+++ b/api/routes/settings.js
@@ -1,4 +1,5 @@
-import { z } from 'zod';
+import { z } from "zod";
+import logger from "../services/logger.js";
 
 export let settings = {
   schema_version: 1,
@@ -6,14 +7,16 @@ export let settings = {
   useEnsemble: true,
   shadowOnly: false,
   ghost_mode: false,
-  sandbox_mode: process.env.SANDBOX_MODE === 'true',
-  personality_mode: 'Realistic',
-  sweep_cadence: 'None',
-  maxLoss: 0
+  sandbox_mode: process.env.SANDBOX_MODE === "true",
+  personality_mode: "Realistic",
+  sweep_cadence: "None",
+  maxLoss: 0,
+  maxLossPct: 0,
+  latencyMaxMs: 250,
 };
 
 export default async function settingsRoutes(app) {
-  app.get('/settings', async () => settings);
+  app.get("/settings", async () => settings);
 
   const schema = z
     .object({
@@ -26,6 +29,8 @@ export default async function settingsRoutes(app) {
       personality_mode: z.string().optional(),
       sweep_cadence: z.string().optional(),
       maxLoss: z.number().optional(),
+      maxLossPct: z.number().optional(),
+      latencyMaxMs: z.number().optional(),
     })
     .strict();
 
@@ -33,30 +38,70 @@ export default async function settingsRoutes(app) {
     const result = schema.safeParse(req.body);
     if (!result.success) {
       reply.code(400);
-      return { error: 'invalid settings' };
+      return { error: "invalid settings" };
     }
-    req.body = result.data;
+    const data = result.data;
+
+    if (typeof data.maxLossPct === "number" && data.maxLossPct > 20) {
+      logger.warn(
+        `[SETTINGS-REJECTED] maxLossPct=${data.maxLossPct} exceeds limit`,
+      );
+      reply.code(400);
+      return { error: "maxLossPct exceeds limit" };
+    }
+
+    if (typeof data.latencyMaxMs === "number" && data.latencyMaxMs > 1000) {
+      logger.warn(
+        `[SETTINGS-REJECTED] latencyMaxMs=${data.latencyMaxMs} exceeds limit`,
+      );
+      reply.code(400);
+      return { error: "latencyMaxMs exceeds limit" };
+    }
+
+    if (typeof data.personality_mode === "string") {
+      const modes = ["Realistic", "Aggressive", "Auto"];
+      if (!modes.includes(data.personality_mode)) {
+        logger.warn(
+          `[SETTINGS-REJECTED] personality_mode=${data.personality_mode} invalid`,
+        );
+        reply.code(400);
+        return { error: "invalid personality_mode" };
+      }
+    }
+
+    if (typeof data.sweep_cadence === "string") {
+      const allowed = ["Daily", "Monthly", "None"];
+      if (!allowed.includes(data.sweep_cadence)) {
+        logger.warn(
+          `[SETTINGS-REJECTED] sweep_cadence=${data.sweep_cadence} invalid`,
+        );
+        reply.code(400);
+        return { error: "invalid sweep_cadence" };
+      }
+    }
+
+    req.body = data;
   };
 
-  const saveSettings = async req => {
-    if (typeof req.body.schema_version === 'number') {
+  const saveSettings = async (req) => {
+    if (typeof req.body.schema_version === "number") {
       settings.schema_version = req.body.schema_version;
     }
-    if (typeof req.body.canary_mode === 'boolean') {
+    if (typeof req.body.canary_mode === "boolean") {
       settings.canary_mode = req.body.canary_mode;
     }
-    if (typeof req.body.useEnsemble === 'boolean') {
+    if (typeof req.body.useEnsemble === "boolean") {
       settings.useEnsemble = req.body.useEnsemble;
     }
-    if (typeof req.body.shadowOnly === 'boolean') {
+    if (typeof req.body.shadowOnly === "boolean") {
       settings.shadowOnly = req.body.shadowOnly;
     }
-    if (typeof req.body.ghost_mode === 'boolean') {
+    if (typeof req.body.ghost_mode === "boolean") {
       settings.ghost_mode = req.body.ghost_mode;
     }
-    if (typeof req.body.sandbox_mode === 'boolean') {
+    if (typeof req.body.sandbox_mode === "boolean") {
       if (
-        process.env.SANDBOX_MODE === 'true' &&
+        process.env.SANDBOX_MODE === "true" &&
         req.body.sandbox_mode === false
       ) {
         // Ignore attempts to disable sandbox mode when forced by env
@@ -64,25 +109,31 @@ export default async function settingsRoutes(app) {
         settings.sandbox_mode = req.body.sandbox_mode;
       }
     }
-    if (typeof req.body.personality_mode === 'string') {
+    if (typeof req.body.personality_mode === "string") {
       settings.personality_mode = req.body.personality_mode;
     }
-    if (typeof req.body.sweep_cadence === 'string') {
-      const allowed = ['Daily', 'Monthly', 'None'];
+    if (typeof req.body.sweep_cadence === "string") {
+      const allowed = ["Daily", "Monthly", "None"];
       if (allowed.includes(req.body.sweep_cadence)) {
         settings.sweep_cadence = req.body.sweep_cadence;
       }
     }
-    if (typeof req.body.maxLoss === 'number') {
+    if (typeof req.body.maxLoss === "number") {
       settings.maxLoss = req.body.maxLoss;
+    }
+    if (typeof req.body.maxLossPct === "number") {
+      settings.maxLossPct = req.body.maxLossPct;
+    }
+    if (typeof req.body.latencyMaxMs === "number") {
+      settings.latencyMaxMs = req.body.latencyMaxMs;
     }
     return { saved: true };
   };
 
   app.route({
-    method: ['POST', 'PATCH'],
-    url: '/settings',
+    method: ["POST", "PATCH"],
+    url: "/settings",
     preHandler: validateSettings,
-    handler: saveSettings
+    handler: saveSettings,
   });
 }


### PR DESCRIPTION
## Summary
- validate settings PATCH input against stricter limits
- reject and log unsafe values for `maxLossPct`, `latencyMaxMs`, `personality_mode`, and `sweep_cadence`
- extend default settings with new risk fields
- update tests for new validation rules

## Testing
- `npm --prefix api test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_687d70cc929c832cad15ee9a548f56d0