### PR TITLE
Add live & sandbox metrics endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Integrated sealed secrets
 - Fix panic resume and Redis signal behavior in Executor and PanicBrake
 - CVE scanning with Trivy
+- Split metrics endpoints by execution mode to support safe observability
 
 ## [Batch 1] - 2025-07-02
 ### Added

--- a/api/__tests__/metrics.mode.test.js
+++ b/api/__tests__/metrics.mode.test.js
@@ -1,0 +1,37 @@
+import request from 'supertest';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+
+let buildApp;
+let app;
+
+beforeAll(async () => {
+  ({ buildApp } = await import('../index.js'));
+  app = buildApp();
+  await app.listen({ port: 0 });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describeLocal('mode specific metrics endpoints', () => {
+  test('live metrics endpoint returns data', async () => {
+    const res = await request(app.server).get('/api/metrics/live');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('equityCurve');
+  });
+
+  test('sandbox metrics endpoint returns data', async () => {
+    const res = await request(app.server).get('/api/metrics/sandbox');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('latency');
+  });
+
+  test('deprecated metrics endpoint returns 404', async () => {
+    const res = await request(app.server).get('/api/metrics');
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/api/__tests__/panicResume.test.js
+++ b/api/__tests__/panicResume.test.js
@@ -23,14 +23,14 @@ describeLocal('panic resume cycle', () => {
     expect(panicRes.statusCode).toBe(200);
     expect(testState.panic).toBe(true);
 
-    const metrics1 = await request(app.server).get('/api/metrics');
+    const metrics1 = await request(app.server).get('/api/metrics/sandbox');
     expect(metrics1.body.panicActive).toBe(true);
 
     const resumeRes = await request(app.server).post('/api/test/resume');
     expect(resumeRes.statusCode).toBe(200);
     expect(testState.panic).toBe(false);
 
-    const metrics2 = await request(app.server).get('/api/metrics');
+    const metrics2 = await request(app.server).get('/api/metrics/sandbox');
     expect(metrics2.body.panicActive).toBe(false);
   });
 });

--- a/api/config/settings.js
+++ b/api/config/settings.js
@@ -1,4 +1,4 @@
-export default {
+export const settings = {
   schema_version: 1,
   sandbox_mode: process.env.SANDBOX_MODE === "true",
   canary_mode: false,
@@ -10,3 +10,13 @@ export default {
   maxLossPct: 0,
   latencyMaxMs: 250,
 };
+
+export function getExecutionMode(req) {
+  const sessionMode = req?.session?.mode;
+  if (sessionMode === 'live' || sessionMode === 'sandbox') {
+    return sessionMode;
+  }
+  return settings.sandbox_mode ? 'sandbox' : 'live';
+}
+
+export default settings;

--- a/api/index.js
+++ b/api/index.js
@@ -104,6 +104,8 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
       '/login',
       '/api/reset-password',
       '/reset-password',
+      '/api/metrics/live',
+      '/api/metrics/sandbox',
       '/api/metrics',
       ...(process.env.SANDBOX_MODE !== 'true' ? ['/api/resume'] : []),
       ...(isTest ? ['/api/test/panic', '/api/test/resume', '/api/test/sweep'] : []),

--- a/api/routes/metrics.js
+++ b/api/routes/metrics.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
-import { settings } from './settings.js';
+import { getExecutionMode } from '../config/settings.js';
 
-const PROM_URL = process.env.PROM_URL || 'http://prometheus:9090';
+const PROM_LIVE_URL = process.env.PROM_LIVE_URL || process.env.PROM_URL || 'http://prometheus:9090';
+const PROM_SANDBOX_URL = process.env.PROM_SANDBOX_URL || 'http://prometheus-sandbox:9090';
 
 export default async function metricsRoutes(app, { testState } = {}) {
   const seeded = {
@@ -13,16 +14,18 @@ export default async function metricsRoutes(app, { testState } = {}) {
     winRate: [],
   };
 
-  app.get('/metrics', async (req) => {
-    if (settings.sandbox_mode || process.env.NODE_ENV === 'test') {
-     return { ...seeded, panicActive: testState?.panic ?? false };
+  const fetchMetrics = async (req, mode) => {
+    const execMode = mode || getExecutionMode(req);
+    if (execMode === 'sandbox' || process.env.NODE_ENV === 'test') {
+      return { ...seeded, panicActive: testState?.panic ?? false };
     }
 
+    const promUrl = execMode === 'live' ? PROM_LIVE_URL : PROM_SANDBOX_URL;
     try {
-      const eq = await axios.get(`${PROM_URL}/api/v1/query`, {
+      const eq = await axios.get(`${promUrl}/api/v1/query`, {
         params: { query: 'equity' },
       });
-      const lat = await axios.get(`${PROM_URL}/api/v1/query`, {
+      const lat = await axios.get(`${promUrl}/api/v1/query`, {
         params: { query: 'request_latency_seconds' },
       });
 
@@ -41,5 +44,12 @@ export default async function metricsRoutes(app, { testState } = {}) {
       req.log.error(err, 'prometheus fetch failed');
       return { equityCurve: [], latency: [] };
     }
+  };
+
+  app.get('/metrics/live', async (req) => fetchMetrics(req, 'live'));
+  app.get('/metrics/sandbox', async (req) => fetchMetrics(req, 'sandbox'));
+
+  app.get('/metrics', async (_req, reply) => {
+    reply.code(404).send({ error: 'deprecated endpoint' });
   });
 }

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -69,14 +69,15 @@ of the contact group to receive alerts.
 
 ## Prometheus metrics
 
-Each service exposes a `/metrics` endpoint that Prometheus scrapes. To view these metrics locally, forward the service ports and curl the endpoints:
+The API now separates live and sandbox telemetry. Prometheus should scrape `/metrics/live` or `/metrics/sandbox` based on the running mode. To view these metrics locally, forward the service ports and curl the endpoints:
 
 ```bash
 kubectl port-forward svc/api 9100:8080 &
 kubectl port-forward svc/executor 9200:9100 &
 kubectl port-forward svc/analytics 9300:5000 &
 
-curl http://localhost:9100/api/metrics
+curl http://localhost:9100/api/metrics/live
+curl http://localhost:9100/api/metrics/sandbox
 curl http://localhost:9200/metrics
 curl http://localhost:9300/metrics
 ```

--- a/test/verify-env.sh
+++ b/test/verify-env.sh
@@ -53,3 +53,6 @@ else
 fi
 
 echo "Environment verified"
+
+curl -sf http://localhost:8080/api/metrics/live >/dev/null
+curl -sf http://localhost:8080/api/metrics/sandbox >/dev/null


### PR DESCRIPTION
## Summary
- expose `getExecutionMode()` in API config
- add `/metrics/live` and `/metrics/sandbox` endpoints and deprecate `/metrics`
- update openPaths list
- check new endpoints in verify-env
- document split metrics endpoints
- test coverage for new routes

## Testing
- `npm --prefix api test -- --runInBand`
- `npm --prefix dashboard test -- --runInBand`
- `pytest`
- `executor/gradlew test -p executor`

------
https://chatgpt.com/codex/tasks/task_b_687d778c9ba0832c803e63c3d6c756c8