### PR TITLE
Add persistent status banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add real-time panic brake and execution mode banner to operator dashboard
 
 - Downgrade numpy to 2.1.3 to resolve TensorFlow install conflict.
 - Store Postgres credentials in sealed secrets

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { SystemStatusProvider } from './context/SystemStatusContext.jsx';
 import Header from './layout/Header.jsx';
+import SystemStatusBanner from './components/SystemStatusBanner.jsx';
 import Dashboard from './pages/Dashboard';
 import Settings from './pages/Settings';
 import Analytics from './pages/Analytics';
@@ -21,6 +22,7 @@ function App() {
     <BrowserRouter>
       <AuthProvider>
         <SystemStatusProvider>
+          <SystemStatusBanner />
           <Header />
           <Routes>
             <Route path="/dashboard" element={<RequireAuth><Dashboard /></RequireAuth>} />

--- a/dashboard/src/__tests__/SystemStatusBanner.test.jsx
+++ b/dashboard/src/__tests__/SystemStatusBanner.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen, act, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SystemStatusBanner from '../components/SystemStatusBanner.jsx';
+
+async function setup(response) {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(response),
+    })
+  );
+  await act(async () => {
+    render(<SystemStatusBanner />);
+  });
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('shows live active state', async () => {
+  await setup({ mode: 'live', panic: false });
+  const banner = await screen.findByTestId('system-status-banner');
+  expect(banner).toHaveTextContent('Live - Trading Active');
+  expect(banner).toHaveClass('bg-green-600');
+  expect(within(banner).queryByRole('button')).not.toBeInTheDocument();
+});
+
+test('shows live panic state', async () => {
+  await setup({ mode: 'live', panic: true });
+  const banner = await screen.findByTestId('system-status-banner');
+  expect(banner).toHaveTextContent('Panic Mode - Trading Halted');
+  expect(banner).toHaveClass('bg-red-600');
+});
+
+test('shows sandbox active state', async () => {
+  await setup({ mode: 'sandbox', panic: false });
+  const banner = await screen.findByTestId('system-status-banner');
+  expect(banner).toHaveTextContent('Sandbox Mode - Simulation Running');
+  expect(banner).toHaveClass('bg-orange-500');
+});
+
+test('shows sandbox panic state', async () => {
+  await setup({ mode: 'sandbox', panic: true });
+  const banner = await screen.findByTestId('system-status-banner');
+  expect(banner).toHaveTextContent('Sandbox Panic - Simulating Failure State');
+  expect(banner).toHaveClass('bg-red-900');
+});

--- a/dashboard/src/components/SystemStatusBanner.jsx
+++ b/dashboard/src/components/SystemStatusBanner.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { fetchSystemStatus } from '../utils/api.js';
+
+export default function SystemStatusBanner() {
+  const [mode, setMode] = useState('live');
+  const [panic, setPanic] = useState(false);
+
+  async function loadStatus() {
+    try {
+      const data = await fetchSystemStatus(mode);
+      setMode(data.mode);
+      setPanic(Boolean(data.panic));
+    } catch (err) {
+      console.error('Failed to fetch system status', err);
+    }
+  }
+
+  useEffect(() => {
+    loadStatus();
+    const id = setInterval(loadStatus, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  let bg = 'bg-green-600';
+  let text = '✅ Live - Trading Active';
+  if (mode === 'live' && panic) {
+    bg = 'bg-red-600';
+    text = '🔴 Panic Mode - Trading Halted';
+  } else if (mode === 'sandbox' && !panic) {
+    bg = 'bg-orange-500';
+    text = '🧪 Sandbox Mode - Simulation Running';
+  } else if (mode === 'sandbox' && panic) {
+    bg = 'bg-red-900';
+    text = '🔒 Sandbox Panic - Simulating Failure State';
+  }
+
+  return (
+    <div data-testid="system-status-banner" className={`${bg} text-white text-center py-2 font-semibold`}>
+      {text}
+    </div>
+  );
+}

--- a/dashboard/src/utils/api.js
+++ b/dashboard/src/utils/api.js
@@ -1,0 +1,7 @@
+export async function fetchSystemStatus(mode = 'live') {
+  const res = await fetch(`/status?mode=${mode}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch system status');
+  }
+  return res.json();
+}

--- a/docs/operator-ui.md
+++ b/docs/operator-ui.md
@@ -1,0 +1,12 @@
+# Operator UI
+
+The dashboard displays a persistent banner at the top of every page indicating the current execution mode and whether the panic brake is active.
+
+| Color | Text |
+|-------|------|
+| Green | `✅ Live - Trading Active` |
+| Red   | `🔴 Panic Mode - Trading Halted` |
+| Orange| `🧪 Sandbox Mode - Simulation Running` |
+| Dark Red | `🔒 Sandbox Panic - Simulating Failure State` |
+
+Use the banner to verify that trading has resumed after an incident or that sandbox simulations are running as expected.


### PR DESCRIPTION
## Summary
- show panic brake & execution mode on every page via new `SystemStatusBanner`
- query `/status` endpoint through utility helper
- mount banner in `App` layout so it always shows
- document new banner in operator UI guide
- test all four banner states

## Testing
- `npm test --prefix dashboard`

------
https://chatgpt.com/codex/tasks/task_b_687d7b1acd7c832cafff892b44aca41b