### PR TITLE
Secure resume endpoint with admin auth check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased]
 - Add real-time panic brake and execution mode banner to operator dashboard
 - Enforce system health validation before allowing panic resume actions
+- Secure /resume endpoint with execution-mode-aware admin check
 
 - Downgrade numpy to 2.1.3 to resolve TensorFlow install conflict.
 - Store Postgres credentials in sealed secrets

--- a/api/__tests__/resume.auth.test.js
+++ b/api/__tests__/resume.auth.test.js
@@ -1,0 +1,59 @@
+import request from 'supertest';
+import { jest } from '@jest/globals';
+import logger from '../services/logger.js';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+let buildApp;
+let app;
+let warnSpy;
+
+beforeAll(async () => {
+  ({ buildApp } = await import('../index.js'));
+  app = buildApp();
+  await app.listen({ port: 0 });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  process.env.EXECUTION_MODE = 'live';
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describeLocal('resume endpoint auth', () => {
+  test('200 with admin token', async () => {
+    const token = app.jwt.sign({ role: 'admin' }, { algorithm: 'HS256' });
+    const res = await request(app.server)
+      .post('/api/resume')
+      .set('Cookie', `token=${token}`);
+    expect(res.statusCode).toBe(200);
+  });
+
+  test('401 without token in live mode', async () => {
+    const res = await request(app.server).post('/api/resume');
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('logs rejection for non-admin', async () => {
+    const token = app.jwt.sign({ role: 'user' }, { algorithm: 'HS256' });
+    const res = await request(app.server)
+      .post('/api/resume')
+      .set('Cookie', `token=${token}`);
+    expect(res.statusCode).toBe(401);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[RESUME-BLOCKED]'));
+  });
+
+  test('200 in sandbox without token', async () => {
+    process.env.EXECUTION_MODE = 'sandbox';
+    const res = await request(app.server).post('/api/resume');
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/api/index.js
+++ b/api/index.js
@@ -16,6 +16,7 @@ import modelRoutes from './routes/models.js';
 import metricsRoutes from './routes/metrics.js';
 import analyticsRoutes from './routes/analytics.js';
 import cgtRoutes from './routes/cgt.js';
+import resumeRoutes from './routes/resume.js';
 import { sendAlert } from './services/alertManager.js';
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
 import { start as startWsServer } from './services/wsServer.js';
@@ -113,7 +114,7 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
       '/api/metrics/live',
       '/api/metrics/sandbox',
       '/api/metrics',
-      ...(process.env.SANDBOX_MODE !== 'true' ? ['/api/resume'] : []),
+      ...(process.env.EXECUTION_MODE === 'sandbox' ? ['/api/resume'] : []),
       ...(isTest ? ['/api/test/panic', '/api/test/resume', '/api/test/sweep'] : []),
     ];
     if (openPaths.includes(req.url)) return;
@@ -152,11 +153,6 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
     return { loggedOut: true };
   });
 
-  api.post('/resume', async () => {
-    if (testState) testState.panic = false;
-    await redis.publish('control-feed', 'resume');
-    return { resumed: true };
-  });
 
   api.get('/system/status', async () => ({
     panic: testState.panic,
@@ -187,6 +183,7 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
   api.register(userRoutes, { prefix: '/users' });
   api.register(infraRoutes, { redis, pool });
   api.register(modelRoutes, { pool });
+  api.register(resumeRoutes, { redis, testState });
   api.register(metricsRoutes, { testState });
   api.register(analyticsRoutes, { pool });
   api.register(cgtRoutes, { pool });

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -1,0 +1,13 @@
+import logger from '../services/logger.js';
+
+export async function requireAdmin(req, reply) {
+  const mode = process.env.EXECUTION_MODE || (process.env.SANDBOX_MODE === 'true' ? 'sandbox' : 'live');
+  if (mode === 'sandbox') {
+    return;
+  }
+  if (req.user && (req.user.role === 'admin' || req.user.isAdmin)) {
+    return;
+  }
+  logger.warn(`[RESUME-BLOCKED] mode=${mode} ip=${req.ip}`);
+  reply.code(401).send({ error: 'unauthorized' });
+}

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -1,0 +1,11 @@
+import { requireAdmin } from '../middleware/auth.js';
+
+export default async function resumeRoutes(app, opts) {
+  const { redis, testState } = opts;
+
+  app.post('/resume', { preHandler: requireAdmin }, async () => {
+    if (testState) testState.panic = false;
+    await redis.publish('control-feed', 'resume');
+    return { resumed: true };
+  });
+}

--- a/docs/panic-brake.md
+++ b/docs/panic-brake.md
@@ -10,3 +10,5 @@ To prevent unsafe restarts, the resume action now verifies several health checks
 If any check fails, the resume endpoint responds with HTTP `503` and the dashboard disables the **Resume Trading** button. Operators should inspect the logs for the specific reason before retrying.
 
 Redis publishes the resume event to either `control-feed-live` or `control-feed-sandbox` depending on the current mode. The executor listens to the correct channel and will not restart if the message arrives on the wrong one.
+
+In live operation the `/resume` API requires an authenticated admin JWT. Sandbox mode leaves the endpoint open so QA environments can easily toggle panic states.


### PR DESCRIPTION
## Summary
- drop `/resume` from openPaths and use execution-mode check
- require admin role unless running in sandbox
- add `/resume` route module and middleware
- document new resume security in panic brake docs
- test auth flows for resume

## Testing
- `npm test --prefix api`

------
https://chatgpt.com/codex/tasks/task_b_687e748465dc832cae2f6e7874ecc47f