### PR TITLE
Fix exposure bug by canceling both legs on partial fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Added feed-aggregator deployment
 - Integrated sealed secrets
 - Fix panic resume and Redis signal behavior in Executor and PanicBrake
+- Cancel all legs on partial fill to prevent orphaned exposure in SpreadOpportunity
 - CVE scanning with Trivy
 - Split metrics endpoints by execution mode to support safe observability
 - Update documentation and config comments to match final audit-compliant platform behavior

--- a/executor/src/main/java/SpreadOpportunity.java
+++ b/executor/src/main/java/SpreadOpportunity.java
@@ -5,176 +5,224 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Represents an executable arbitrage opportunity between two exchanges.
- */
+/** Represents an executable arbitrage opportunity between two exchanges. */
 public class SpreadOpportunity {
-    private static final Logger logger = LoggerFactory.getLogger(SpreadOpportunity.class);
-    private final String pair;
-    private final String buyExchange;
-    private final String sellExchange;
-    private final double grossEdge;
-    private final double netEdge;
-    private long latencyMs;
-    private long roundTripLatencyMs;
-    private long latencyMicros;
-    private long roundTripLatencyMicros;
+  private static final Logger logger = LoggerFactory.getLogger(SpreadOpportunity.class);
+  private final String pair;
+  private final String buyExchange;
+  private final String sellExchange;
+  private final double grossEdge;
+  private final double netEdge;
+  private long latencyMs;
+  private long roundTripLatencyMs;
+  private long latencyMicros;
+  private long roundTripLatencyMicros;
 
-    /**
-     * Factory method for creating exchange adapters. Allows tests to override
-     * with custom behaviour.
-     */
-    protected MockExchangeAdapter createAdapter(String name) {
-        return new MockExchangeAdapter(name);
+  /**
+   * Factory method for creating exchange adapters. Allows tests to override with custom behaviour.
+   */
+  protected MockExchangeAdapter createAdapter(String name) {
+    return new MockExchangeAdapter(name);
+  }
+
+  /** Create an opportunity with the given parameters. */
+  public SpreadOpportunity(
+      String pair,
+      String buyExchange,
+      String sellExchange,
+      double grossEdge,
+      double netEdge,
+      long latencyMs) {
+    this.pair = pair;
+    this.buyExchange = buyExchange;
+    this.sellExchange = sellExchange;
+    this.grossEdge = grossEdge;
+    this.netEdge = netEdge;
+    this.latencyMs = latencyMs;
+    this.roundTripLatencyMs = latencyMs;
+    this.latencyMicros = latencyMs * 1000;
+    this.roundTripLatencyMicros = latencyMs * 1000;
+  }
+
+  /** Parse an opportunity from a JSON payload. */
+  public static SpreadOpportunity fromJson(String json) {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode node = mapper.readTree(json);
+      long latency = node.has("latencyMs") ? node.get("latencyMs").asLong() : 0L;
+      return new SpreadOpportunity(
+          node.get("pair").asText(),
+          node.get("buyExchange").asText(),
+          node.get("sellExchange").asText(),
+          node.get("grossEdge").asDouble(),
+          node.get("netEdge").asDouble(),
+          latency);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid opportunity JSON", e);
+    }
+  }
+
+  /** Convert a simple spread into a SpreadOpportunity instance. */
+  public static SpreadOpportunity fromSpread(Spread spread) {
+    SpreadOpportunity opp =
+        new SpreadOpportunity(
+            "", "", "", spread.getEdge(), spread.getEdge(), spread.getLatencyMs());
+    opp.roundTripLatencyMs = spread.getLatencyMs();
+    opp.latencyMicros = spread.getLatencyMs() * 1000;
+    opp.roundTripLatencyMicros = spread.getLatencyMs() * 1000;
+    return opp;
+  }
+
+  /** Execute the opportunity using mock exchanges. */
+  public TradeResult execute(double size, double price) {
+    MockExchangeAdapter buy = createAdapter(buyExchange);
+    MockExchangeAdapter sell = createAdapter(sellExchange);
+
+    String buyOrderId = "BUY-" + System.nanoTime();
+    String sellOrderId = "SELL-" + System.nanoTime();
+
+    long start = System.nanoTime();
+
+    double buyCancel = 0.0;
+    double sellCancel = 0.0;
+    boolean buyOk = false;
+    boolean sellOk = false;
+    boolean partial = false;
+    int attempts = 0;
+    final int maxRetries = 3;
+
+    while (attempts < maxRetries && !buyOk) {
+      buyOk = buy.placeIocOrder(pair, "BUY", size, price);
+      buyCancel += buy.getLastCancelFee();
+      if (!buyOk && buy.getLastFillSize() > 0) {
+        partial = true;
+        break;
+      }
+      attempts++;
     }
 
-    /**
-     * Create an opportunity with the given parameters.
-     */
-    public SpreadOpportunity(String pair,
-                             String buyExchange,
-                             String sellExchange,
-                             double grossEdge,
-                             double netEdge,
-                             long latencyMs) {
-        this.pair = pair;
-        this.buyExchange = buyExchange;
-        this.sellExchange = sellExchange;
-        this.grossEdge = grossEdge;
-        this.netEdge = netEdge;
-        this.latencyMs = latencyMs;
-        this.roundTripLatencyMs = latencyMs;
-        this.latencyMicros = latencyMs * 1000;
-        this.roundTripLatencyMicros = latencyMs * 1000;
-    }
-
-    /**
-     * Parse an opportunity from a JSON payload.
-     */
-    public static SpreadOpportunity fromJson(String json) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            JsonNode node = mapper.readTree(json);
-            long latency = node.has("latencyMs") ? node.get("latencyMs").asLong() : 0L;
-            return new SpreadOpportunity(
-                node.get("pair").asText(),
-                node.get("buyExchange").asText(),
-                node.get("sellExchange").asText(),
-                node.get("grossEdge").asDouble(),
-                node.get("netEdge").asDouble(),
-                latency
-            );
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Invalid opportunity JSON", e);
+    if (!partial) {
+      attempts = 0;
+      while (attempts < maxRetries && !sellOk) {
+        sellOk = sell.placeIocOrder(pair, "SELL", size, price);
+        sellCancel += sell.getLastCancelFee();
+        if (!sellOk && sell.getLastFillSize() > 0) {
+          partial = true;
+          break;
         }
+        attempts++;
+      }
     }
 
-    /**
-     * Convert a simple spread into a SpreadOpportunity instance.
-     */
-    public static SpreadOpportunity fromSpread(Spread spread) {
-        SpreadOpportunity opp = new SpreadOpportunity(
-            "",
-            "",
-            "",
-            spread.getEdge(),
-            spread.getEdge(),
-            spread.getLatencyMs()
-        );
-        opp.roundTripLatencyMs = spread.getLatencyMs();
-        opp.latencyMicros = spread.getLatencyMs() * 1000;
-        opp.roundTripLatencyMicros = spread.getLatencyMs() * 1000;
-        return opp;
+    if (partial) {
+      buy.cancel(buyOrderId);
+      sell.cancel(sellOrderId);
+      logger.info(
+          "[CANCEL] Partial fill detected. Canceling all legs: {}, {}", buyOrderId, sellOrderId);
+    } else if (!buyOk) {
+      sell.cancel(sellOrderId);
+      logger.info("[CANCEL] Orphan order canceled: {}", sellOrderId);
+    } else if (!sellOk) {
+      buy.cancel(buyOrderId);
+      logger.info("[CANCEL] Orphan order canceled: {}", buyOrderId);
     }
 
-    /**
-     * Execute the opportunity using mock exchanges.
-     */
-    public TradeResult execute(double size, double price) {
-        MockExchangeAdapter buy = createAdapter(buyExchange);
-        MockExchangeAdapter sell = createAdapter(sellExchange);
+    long end = System.nanoTime();
 
-        String buyOrderId = "BUY-" + System.nanoTime();
-        String sellOrderId = "SELL-" + System.nanoTime();
+    latencyMicros = (end - start) / 1000;
+    roundTripLatencyMicros = latencyMicros;
+    latencyMs = latencyMicros / 1000;
+    roundTripLatencyMs = latencyMs;
 
-        long start = System.nanoTime();
+    double buyFee = size * price * buy.getFeeRate(pair);
+    double sellFee = size * price * sell.getFeeRate(pair);
+    double pnl = netEdge - buyFee - sellFee - buyCancel - sellCancel;
+    boolean success = !partial && buyOk && sellOk;
 
-        double buyCancel = 0.0;
-        double sellCancel = 0.0;
-        boolean buyOk = false;
-        boolean sellOk = false;
-        int attempts = 0;
-        final int maxRetries = 3;
+    return new TradeResult(success, success ? pnl : 0.0, latencyMs);
+  }
 
-        while (attempts < maxRetries && !buyOk) {
-            buyOk = buy.placeIocOrder(pair, "BUY", size, price);
-            buyCancel += buy.getLastCancelFee();
-            if (!buyOk && buy.getLastFillSize() > 0) {
-                sell.cancel(sellOrderId);
-                logger.info("[CANCEL] Orphan order canceled: {}", sellOrderId);
-                break;
-            }
-            attempts++;
-        }
+  /**
+   * @return trading pair
+   */
+  public String getPair() {
+    return pair;
+  }
 
-        if (buyOk) {
-            attempts = 0;
-            while (attempts < maxRetries && !sellOk) {
-                sellOk = sell.placeIocOrder(pair, "SELL", size, price);
-                sellCancel += sell.getLastCancelFee();
-                if (!sellOk && sell.getLastFillSize() > 0) {
-                    buy.cancel(buyOrderId);
-                    logger.info("[CANCEL] Orphan order canceled: {}", buyOrderId);
-                    break;
-                }
-                attempts++;
-            }
-        }
+  /**
+   * @return buy exchange name
+   */
+  public String getBuyExchange() {
+    return buyExchange;
+  }
 
-        long end = System.nanoTime();
+  /**
+   * @return sell exchange name
+   */
+  public String getSellExchange() {
+    return sellExchange;
+  }
 
-        latencyMicros = (end - start) / 1000;
-        roundTripLatencyMicros = latencyMicros;
-        latencyMs = latencyMicros / 1000;
-        roundTripLatencyMs = latencyMs;
+  /**
+   * @return gross edge value
+   */
+  public double getGrossEdge() {
+    return grossEdge;
+  }
 
-        double buyFee = size * price * buy.getFeeRate(pair);
-        double sellFee = size * price * sell.getFeeRate(pair);
-        double pnl = netEdge - buyFee - sellFee - buyCancel - sellCancel;
-        boolean success = buyOk && sellOk;
+  /**
+   * @return net edge value
+   */
+  public double getNetEdge() {
+    return netEdge;
+  }
 
-        return new TradeResult(success, success ? pnl : 0.0, latencyMs);
-    }
+  /**
+   * @return measured latency in ms
+   */
+  public long getLatencyMs() {
+    return latencyMs;
+  }
 
-    /** @return trading pair */
-    public String getPair() { return pair; }
-    /** @return buy exchange name */
-    public String getBuyExchange() { return buyExchange; }
-    /** @return sell exchange name */
-    public String getSellExchange() { return sellExchange; }
-    /** @return gross edge value */
-    public double getGrossEdge() { return grossEdge; }
-    /** @return net edge value */
-    public double getNetEdge() { return netEdge; }
-    /** @return measured latency in ms */
-    public long getLatencyMs() { return latencyMs; }
-    /** @return round trip latency in ms */
-    public long getRoundTripLatencyMs() { return roundTripLatencyMs; }
-    /** @return latency in microseconds */
-    public long getLatencyMicros() { return latencyMicros; }
-    /** @return round trip latency in microseconds */
-    public long getRoundTripLatencyMicros() { return roundTripLatencyMicros; }
+  /**
+   * @return round trip latency in ms
+   */
+  public long getRoundTripLatencyMs() {
+    return roundTripLatencyMs;
+  }
 
-    @Override
-    public String toString() {
-        return "SpreadOpportunity{" +
-                "pair='" + pair + '\'' +
-                ", buyExchange='" + buyExchange + '\'' +
-                ", sellExchange='" + sellExchange + '\'' +
-                ", grossEdge=" + grossEdge +
-                ", netEdge=" + netEdge +
-                ", latencyMs=" + latencyMs +
-                '}';
-    }
+  /**
+   * @return latency in microseconds
+   */
+  public long getLatencyMicros() {
+    return latencyMicros;
+  }
+
+  /**
+   * @return round trip latency in microseconds
+   */
+  public long getRoundTripLatencyMicros() {
+    return roundTripLatencyMicros;
+  }
+
+  @Override
+  public String toString() {
+    return "SpreadOpportunity{"
+        + "pair='"
+        + pair
+        + '\''
+        + ", buyExchange='"
+        + buyExchange
+        + '\''
+        + ", sellExchange='"
+        + sellExchange
+        + '\''
+        + ", grossEdge="
+        + grossEdge
+        + ", netEdge="
+        + netEdge
+        + ", latencyMs="
+        + latencyMs
+        + '}';
+  }
 }
-

--- a/executor/src/test/java/SpreadOpportunityTest.java
+++ b/executor/src/test/java/SpreadOpportunityTest.java
@@ -1,85 +1,116 @@
 package executor;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Tag;
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Random;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 @Tag("local")
 public class SpreadOpportunityTest {
-    static class FixedRandom extends Random {
-        private final double[] values;
-        private int idx = 0;
-        FixedRandom(double... v) { this.values = v; }
-        @Override
-        public double nextDouble() { return values[idx < values.length ? idx++ : values.length - 1]; }
+  static class FixedRandom extends Random {
+    private final double[] values;
+    private int idx = 0;
+
+    FixedRandom(double... v) {
+      this.values = v;
     }
 
-    static class TestOpportunity extends SpreadOpportunity {
-        private final MockExchangeAdapter buy;
-        private final MockExchangeAdapter sell;
-        TestOpportunity(MockExchangeAdapter buy, MockExchangeAdapter sell) {
-            super("BTC/USDT", "A", "B", 2.0, 2.0, 0L);
-            this.buy = buy;
-            this.sell = sell;
-        }
-
-        @Override
-        protected MockExchangeAdapter createAdapter(String name) {
-            return name.equals("A") ? buy : sell;
-        }
+    @Override
+    public double nextDouble() {
+      return values[idx < values.length ? idx++ : values.length - 1];
     }
-    @Test
-    void subtractsFeesFromBothSides() {
-        MockExchangeAdapter.setFeeRate("A", 0.001);
-        MockExchangeAdapter.setFeeRate("B", 0.001);
-        SpreadOpportunity opp = new SpreadOpportunity("BTC/USDT", "A", "B", 2.0, 2.0, 0L);
-        TradeResult result = opp.execute(1.0, 100.0);
-        double expected = 2.0 - (1.0 * 100.0 * 0.001) - (1.0 * 100.0 * 0.001);
-        assertTrue(result.success);
-        assertEquals(expected, result.pnl, 1e-9);
+  }
+
+  static class TestOpportunity extends SpreadOpportunity {
+    private final MockExchangeAdapter buy;
+    private final MockExchangeAdapter sell;
+
+    TestOpportunity(MockExchangeAdapter buy, MockExchangeAdapter sell) {
+      super("BTC/USDT", "A", "B", 2.0, 2.0, 0L);
+      this.buy = buy;
+      this.sell = sell;
     }
 
-    @Test
-    void partialFillTriggersCancel() {
-        MockExchangeAdapter buy = new MockExchangeAdapter("A", 0.0002, new FixedRandom(0.85));
-        MockExchangeAdapter sell = new MockExchangeAdapter("B", 0.0002, new FixedRandom(0.5));
-        TestOpportunity opp = new TestOpportunity(buy, sell);
+    @Override
+    protected MockExchangeAdapter createAdapter(String name) {
+      return name.equals("A") ? buy : sell;
+    }
+  }
 
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
-        PrintStream origErr = System.err;
-        System.setErr(new PrintStream(err));
-        try {
-            opp.execute(1.0, 100.0);
-        } finally {
-            System.setErr(origErr);
-        }
+  @Test
+  void subtractsFeesFromBothSides() {
+    MockExchangeAdapter.setFeeRate("A", 0.001);
+    MockExchangeAdapter.setFeeRate("B", 0.001);
+    SpreadOpportunity opp = new SpreadOpportunity("BTC/USDT", "A", "B", 2.0, 2.0, 0L);
+    TradeResult result = opp.execute(1.0, 100.0);
+    double expected = 2.0 - (1.0 * 100.0 * 0.001) - (1.0 * 100.0 * 0.001);
+    assertTrue(result.success);
+    assertEquals(expected, result.pnl, 1e-9);
+  }
 
-        assertEquals(1, sell.getCanceledOrders().size());
-        String logs = err.toString();
-        assertTrue(logs.contains("[CANCEL] Orphan order canceled:"));
+  @Test
+  void partialFillTriggersCancel() {
+    MockExchangeAdapter buy = new MockExchangeAdapter("A", 0.0002, new FixedRandom(0.85));
+    MockExchangeAdapter sell = new MockExchangeAdapter("B", 0.0002, new FixedRandom(0.5));
+    TestOpportunity opp = new TestOpportunity(buy, sell);
+
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    PrintStream origErr = System.err;
+    System.setErr(new PrintStream(err));
+    try {
+      opp.execute(1.0, 100.0);
+    } finally {
+      System.setErr(origErr);
     }
 
-    @Test
-    void noCancelWhenAllFilled() {
-        MockExchangeAdapter buy = new MockExchangeAdapter("A", 0.0002, new FixedRandom(0.5));
-        MockExchangeAdapter sell = new MockExchangeAdapter("B", 0.0002, new FixedRandom(0.5));
-        TestOpportunity opp = new TestOpportunity(buy, sell);
+    assertEquals(1, buy.getCanceledOrders().size());
+    assertEquals(1, sell.getCanceledOrders().size());
+    String logs = err.toString();
+    assertTrue(logs.contains("[CANCEL] Partial fill detected. Canceling all legs:"));
+  }
 
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
-        PrintStream origErr = System.err;
-        System.setErr(new PrintStream(err));
-        try {
-            opp.execute(1.0, 100.0);
-        } finally {
-            System.setErr(origErr);
-        }
+  @Test
+  void bothLegsPartialFillCancelBoth() {
+    MockExchangeAdapter buy = new MockExchangeAdapter("A", 0.0002, new FixedRandom(0.85));
+    MockExchangeAdapter sell = new MockExchangeAdapter("B", 0.0002, new FixedRandom(0.85));
+    TestOpportunity opp = new TestOpportunity(buy, sell);
 
-        assertTrue(buy.getCanceledOrders().isEmpty());
-        assertTrue(sell.getCanceledOrders().isEmpty());
-        String logs = err.toString();
-        assertFalse(logs.contains("[CANCEL]"));
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    PrintStream origErr = System.err;
+    System.setErr(new PrintStream(err));
+    try {
+      opp.execute(1.0, 100.0);
+    } finally {
+      System.setErr(origErr);
     }
+
+    assertEquals(1, buy.getCanceledOrders().size());
+    assertEquals(1, sell.getCanceledOrders().size());
+    String logs = err.toString();
+    assertTrue(logs.contains("[CANCEL] Partial fill detected. Canceling all legs:"));
+  }
+
+  @Test
+  void noCancelWhenAllFilled() {
+    MockExchangeAdapter buy = new MockExchangeAdapter("A", 0.0002, new FixedRandom(0.5));
+    MockExchangeAdapter sell = new MockExchangeAdapter("B", 0.0002, new FixedRandom(0.5));
+    TestOpportunity opp = new TestOpportunity(buy, sell);
+
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    PrintStream origErr = System.err;
+    System.setErr(new PrintStream(err));
+    try {
+      opp.execute(1.0, 100.0);
+    } finally {
+      System.setErr(origErr);
+    }
+
+    assertTrue(buy.getCanceledOrders().isEmpty());
+    assertTrue(sell.getCanceledOrders().isEmpty());
+    String logs = err.toString();
+    assertFalse(logs.contains("[CANCEL]"));
+  }
 }


### PR DESCRIPTION
## Summary
- cancel both legs on partial fill in `SpreadOpportunity.execute`
- update `SpreadOpportunityTest` with new coverage for partial fills
- document change in CHANGELOG

## Testing
- `npm --prefix dashboard test -- --runInBand` *(fails: ResumeButton.test.jsx)*
- `pytest`
- `executor/gradlew test -p executor -PtestEnv=local`


------
https://chatgpt.com/codex/tasks/task_b_687e78c560b4832ca0f5050ba09d77a6