### PR TITLE
Sync documentation with audited state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - CVE scanning with Trivy
 - Split metrics endpoints by execution mode to support safe observability
 - Update documentation and config comments to match final audit-compliant platform behavior
+- Rewrite documentation to reflect all audited system behavior and enforce operator clarity
 
 ## [Batch 1] - 2025-07-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,22 +9,24 @@
 
 ## Overview
 
-**Crypto Arbitrage** is a multi-agent platform that scans dozens of centralized and decentralized exchanges for price discrepancies and executes low-latency trades. Each service is containerized and communicates through Redis and PostgreSQL while metrics flow to Prometheus and Grafana. Live and sandbox modes run side by side on the same server so you can test without disrupting production. For a step-by-step sandbox setup, see [docs/sandbox.md](docs/sandbox.md).
+**Crypto Arbitrage** is an audited multi-agent platform that executes cross-exchange trades.  A feed aggregator publishes order books to Redis, a Java executor reacts to spreads, and supporting services expose APIs, analytics, and a real‑time operator dashboard.  The system can run in `live` or `sandbox` mode on the same host.  Sandbox mode performs every action except fund movement so strategies can be tested safely.
+
+For a guided sandbox walkthrough see [docs/sandbox.md](docs/sandbox.md).
 
 ---
 
 ## Features
 
-- Real-time order book aggregation across 14 exchanges
-- Feed aggregator service publishes normalized books to Redis
-- Java executor for sub-60µs trade execution
-- REST API with JWT authentication
-- React dashboard for live monitoring
+- WebSocket feed aggregation across 14 venues
+- Sub‑60µs Java trade executor
+- REST API secured by JWTs and an admin token
+- React dashboard with persistent system status banner
 - Predictive analytics with optional GPU acceleration
-- Alerting and circuit breaking for risk management
-- Audit-compliant panic brake with a live banner; resume only works if the heartbeat is healthy, the cold sweeper is idle, and panic flags are cleared
-- Sandbox and live modes share the same host using Redis channels `control-feed-live` and `control-feed-sandbox`
-- Dry-run mode enforced by the `ExecutionMode` enum with logs like `[DRY-RUN] Skipping cold wallet transfer`
+- Panic brake halts trading on loss, latency, or win‑rate breaches
+- Resume only succeeds when heartbeat checks pass and the cold sweeper is idle
+- Mode specific Redis channels `control-feed-live` and `control-feed-sandbox`
+- Dry‑run behavior via `ExecutionMode.SANDBOX` with logs like `[DRY-RUN] Skipping cold wallet transfer`
+- Container builds produce SBOMs and are scanned by Trivy during CI
 
 ---
 
@@ -45,26 +47,25 @@ graph TD
 
 - `api/` – Fastify API server
 - `dashboard/` – React frontend
-- `analytics/` – Flask ML microservice
+- `analytics/` – Python ML service
 - `executor/` – Java trading engine
-- `scripts/` – helper CLI tools
+- `feed-aggregator/` – order book collector
+- `scripts/` – CLI helpers and ops tools
 - `infra/` – Kubernetes Helm charts
 
 ---
 
 ## Required Tools
 
-The pre-push hook runs tests across multiple languages. Make sure the following tools are installed locally:
+The git hooks run tests across all languages. Install the following before contributing:
 
- - **Node.js 20** with `npm`
-- **Python 3.10** with `pytest`
-- **Java 17** with `gradle`
-- **Podman** for building container images
+- **Node.js 20** and `npm`
+- **Python 3.10** and `pytest`
+- **Java 17** and `gradle`
+- **Podman** for container builds
 - **Helm** and `kubectl` for Kubernetes
 
-Ensure these tools are available in your `PATH` so `githooks/pre-push` can execute them.
-
-To enable the Git hooks in this repository run:
+Enable the hooks once by running:
 
 ```bash
 git config core.hooksPath githooks
@@ -74,7 +75,7 @@ git config core.hooksPath githooks
 
 ## Dev Setup
 
-1. Start Colima using the Podman runtime:
+1. Start the local container runtime:
    ```bash
    colima start --runtime podman
    ```
@@ -87,141 +88,126 @@ git config core.hooksPath githooks
    helm dependency update infra/helm
    helm install arb infra/helm
    ```
+3. Copy any `*.env.example` file to `.env` and adjust for your environment.  For demos, create `.env.sandbox` and run `./scripts/start-sandbox.sh`.
 
 ---
 
-## Envs & Secrets
+## Environment & Secrets
 
-Example environment files live under `api/.env.example`, `analytics/.env.example`, and `executor/.env.example`. Copy them to `.env` for local development. All production secrets must be stored as SealedSecrets. Use `kubeseal` to encrypt the secret YAML before committing. GitHub Actions will fail if any raw `.env` files are detected.
+All production credentials are stored as SealedSecrets.  Never commit plain `.env` files.  `test/verify-env.sh` fails if unsealed secrets or `.env.sandbox` exist in the repository.
 
-### Common variables
-- `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` – Postgres connection
-- `REDIS_HOST`, `REDIS_PORT` – Redis connection
-- `JWT_SECRET` – token signing key for the API (required in production)
-- `ADMIN_TOKEN` – admin-only endpoints in the API (set a strong value for production)
-- `SENTRY_DSN` – API error reporting endpoint
-- `PROM_URL` – Prometheus base URL for metrics
-- `SANDBOX_MODE` – enable demo login without a DB (must be disabled in production)
+To seal a new secret:
 
-### Executor specific
-- `STARTING_BALANCE`, `COIN_CAP_PCT`, `MAX_BOOK_DEPTH_USD` – risk parameters
-- `PREDICT_URL` – ML scoring endpoint
-- `CB_WIN_RATE_THRESHOLD`, `CB_MAX_DRAWDOWN_PCT` – circuit breaker limits
-- `CANARY_MODE`, `GHOST_MODE`, `USE_ENSEMBLE` – feature toggles
-- `sweep_cadence` – choose Daily, Monthly, or None for automatic cold sweeps
-- `TEST_COLD_WALLET_ADDRESS` – wallet address used in sweep tests
-- `GHOST_FEED_CHANNEL` – Redis channel for ghost trades overlay
-- `DB_RETRIES`, `DB_RETRY_DELAY_MS` – DB reconnection settings
+```bash
+kubectl create secret generic api-keys --from-literal=API_KEY=abc123 \
+  --dry-run=client -o yaml > secret.yaml
+kubeseal < secret.yaml > sealed-secret.yaml
+```
 
-### Analytics specific
-- `MODEL_PATH`, `MODEL_SHADOW_PATH` – model files
+Commit the sealed file and apply it during deployment:
+
+```bash
+kubectl apply -f sealed-secret.yaml
+```
 
 ---
 
 ## Running Tests
 
-Run the local mocked suite and the live dry-run integration:
+Run all mocked tests locally:
 ```bash
-./test/run-local.sh      # mocked tests [test:local]
-./test/run-live.sh       # dry-run integration [test:live]
+./test/run-local.sh
 ```
-For an explanation of these tags and sample CI output see [docs/testing.md](docs/testing.md).
-During dry-run, the executor logs messages such as `[DRY-RUN] Skipping cold wallet transfer` to indicate that no funds are moved.
-
-### Continuous Integration
-
-GitHub Actions blocks pushes that fail any safety gate. The `test/verify-env.sh` script ensures no plaintext `.env` files or unsealed Kubernetes secrets are committed.
-  
-  
-### Live Trade Simulation
-
-- Toggle ghost mode in settings
-- Simulated trades appear in dashboard overlay
-- Data streamed from Redis → WebSocket → UI
-- Disable for live trading
-
-To feed sample trades, use the CLI mock tester:
+For the optional live dry‑run suite:
 ```bash
-node scripts/replay-trade.js --pair BTC-USD
+./test/run-live.sh
 ```
-Inspect raw WebSocket messages:
+
+Individual service tests can be run with `npm test`, `pytest`, or `./gradlew test`.
+
+---
+
+## Continuous Integration
+
+GitHub Actions enforces safety gates:
+
+1. `test/verify-env.sh` blocks plaintext secrets or unsealed manifests.
+2. Each service runs unit tests and ESLint/flake8 checks.
+3. Containers build with Podman and are scanned by Trivy.
+4. Kubernetes manifests are validated with kubeconform and a dry‑run apply.
+5. All Actions are pinned to commit SHAs for reproducibility.
+
+Run `bash test/verify-env.sh` before pushing to mirror the CI checks.
+
+---
+
+## Live Trade Simulation
+
+Enable ghost mode in settings or run:
 ```bash
-npx wscat -c ws://localhost:3000/ws/trades
+node scripts/mock-ghost-feed.js --pair BTC-USD
 ```
+Trades stream through Redis and appear on the dashboard.  Disable ghost mode for real trading.
 
 ---
 
 ## Monitoring
 
-- **Sentry** captures runtime exceptions
-- **Prometheus** scrapes metrics from all agents
-- **StatusCake** monitors uptime of public endpoints
-- Metrics are separated by mode: `/metrics/live` and `/metrics/sandbox`
+- **Sentry** captures runtime exceptions.
+- **Prometheus** scrapes `/metrics/live` or `/metrics/sandbox`.
+- **StatusCake** monitors public endpoints using the API token and contact group defined in `.env.example`.
+
+Port‑forward services locally to inspect metrics:
+```bash
+kubectl -n arbitrage port-forward svc/api 9100:8080 &
+kubectl -n arbitrage port-forward svc/executor 9200:9100 &
+kubectl -n arbitrage port-forward svc/analytics 9300:5000 &
+
+curl http://localhost:9100/api/metrics/live
+curl http://localhost:9100/api/metrics/sandbox
+curl http://localhost:9200/metrics
+curl http://localhost:9300/metrics
+```
 
 ---
 
 ## ML Training Pipeline
 
-- **Feature logging**: the Java executor stores trade inputs via `FeatureLogger`.
-- **Export**: run `analytics/train/export_features.py` to dump recent rows from
-  the `training_features` table as CSV or NumPy files.
-- **Model retraining**: execute `analytics/train/retrain.py` to train the
-  `SpreadLSTM` model on exported features and log results.
-- **Versioning**: models are recorded in the `model_metadata` table for
-  reproducibility.
-- **Shadow testing**: new models are validated against the live model before
-  promotion.
-- **Rollback**: use `model_swap.py` to swap to a prior model if issues arise.
-- **Scheduling**: `crontab.txt` runs `retrain.py` every Sunday at 2&nbsp;AM.
-- **Retrain flow**: features are loaded, the LSTM trains for 10 epochs, and
-  validation loss and Sharpe ratio are saved for review.
+1. Export features:
+   ```bash
+   python analytics/train/export_features.py
+   ```
+2. Retrain the LSTM model:
+   ```bash
+   python analytics/train/retrain.py --epochs 10
+   ```
+3. Swap to a previous model if required:
+   ```bash
+   python analytics/model_swap.py --version <hash>
+   ```
 
-### AI Lifecycle
-
-- Trade execution → feature log → weekly retrain → scoring → version tag
-
-### Model Registry
-
-- Git-based model archive under `analytics/models/archive`
-- SHA256 hash used to track each saved model
-- Model audit endpoint: `GET /api/model/version`
-- Rollback via `analytics/model_swap.py` with alert notifications
-
-**CLI**
-
-```bash
-python analytics/train/retrain.py --epochs 10
-python analytics/model_swap.py --version <hash>
-```
-
-**API**
-
-```bash
-curl http://localhost:3000/api/model/version
-```
+Model versions are stored in `analytics/models/archive` and tracked via SHA256 hashes.
 
 ---
 
 ## Deployment
 
-The platform runs on a Xeon host and is orchestrated by Kubernetes. Deploy or upgrade services using Helm charts located in `infra/helm`.
+Deploy or upgrade services using Helm:
+```bash
+./scripts/ops-tools.sh start
+```
+Check pod status:
+```bash
+./scripts/ops-tools.sh status
+```
 
-## SBOM Generation
-
-Each container build produces a Software Bill of Materials using Syft. The JSON artifacts are uploaded to GitHub Releases so dependencies remain transparent.
-
-## Rollback Procedures
-
-Refer to [docs/ops/helm-rollback-guide.MD](docs/ops/helm-rollback-guide.MD) for step-by-step instructions on rolling back a failed deployment using Helm.
+See [docs/ops/helm-rollback-guide.MD](docs/ops/helm-rollback-guide.MD) for rollback instructions.
 
 ---
+
 ## System Documentation
 
-Additional guides covering architecture, strategy modes, UI features, risk controls, and environment variables live under the [`docs/`](docs/) directory. Start with [docs/architecture.md](docs/architecture.md) for a high-level overview of the platform.
-
-## AI & ML Model Registry Lifecycle
-
-The platform uses a Git-backed registry to track every model version and related metrics. Each training run stores a version hash and evaluation scores. Shadow models are compared to production prior to promotion, and all updates trigger audit logs and notifications.
+Additional architecture, strategy, and operations guides are in the [`docs/`](docs/) directory.
 
 ## License
 

--- a/docs/ci_setup.md
+++ b/docs/ci_setup.md
@@ -1,12 +1,21 @@
-# CI Setup
+# Continuous Integration Guide
 
-GitHub Actions validates every push and pull request. The workflow runs unit tests and `test/verify-env.sh` which fails the build if any plaintext `.env` files or unsealed Kubernetes secrets are present. Because of this policy pushes that violate the secret policy are automatically blocked.
+Every push is validated by GitHub Actions. The pipeline executes tests for each service, builds container images with Podman, and scans them with Trivy. Kubernetes manifests are linted with kubeconform and a dry‑run apply step ensures syntax validity.
 
-To run the same checks locally:
+The first job `verify-env` runs `test/verify-env.sh` which fails immediately if any plain `.env` files or unsealed `Secret` manifests are present. Run this script locally before committing:
 
 ```bash
 bash test/verify-env.sh
 ```
 
-This ensures your environment mirrors the CI gates before opening a pull request.
+To mimic the full workflow locally execute the individual test suites:
 
+```bash
+npm test --prefix api
+npx jest --prefix dashboard
+pytest feed-aggregator
+pytest analytics
+( cd executor && ./gradlew test )
+```
+
+If all tests pass and `verify-env.sh` reports no issues you can push your branch. GitHub Actions uses pinned commit SHAs for all actions so results are reproducible.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,80 +1,34 @@
-# StatusCake Monitoring Setup
+# Monitoring and Metrics
 
-Use StatusCake to monitor the Dashboard, API, and Analytics services on your server.
-These checks ensure you are alerted when any endpoint goes offline.
+This platform exposes metrics for every service and uses StatusCake to monitor external availability.
 
----
+## 1. StatusCake Uptime Checks
 
-## Step 1 – Log in to StatusCake
+1. Sign in at <https://statuscake.com>.
+2. Create HTTP tests for the dashboard (`http://YOUR_IP:3000`), API (`http://YOUR_IP:8080`), and analytics service (`http://YOUR_IP:5000`).
+3. Add a **Contact Group** for your email or webhook and attach it to each test.
+4. Optionally publish a public status page.
 
-1. Visit [https://statuscake.com](https://statuscake.com) and sign up or log in.
-2. From the dashboard click **Add New Test**.
-
----
-
-## Step 2 – Create uptime tests
-
-Create one HTTP test for each service using your server IP address:
-
-1. **Dashboard**
-   - **URL**: `http://YOUR_IP:3000`
-   - Pick your desired check rate and location.
-   - Save the test.
-2. **API**
-   - **URL**: `http://YOUR_IP:8080`
-   - Use similar settings.
-   - Save the test.
-3. **Analytics**
-   - **URL**: `http://YOUR_IP:5000`
-   - Repeat the options as above.
-   - Save the test.
-
----
-
-## Step 3 – Enable a public status page
-
-1. In the sidebar choose **Status Pages**.
-2. Click **Create Status Page** and select your three tests.
-3. Set the page visibility to **Public**.
-4. Copy the status page URL for sharing.
-
----
-
-## Step 4 – Set up alerts
-
-1. Go to **User Settings → Contact Groups**.
-2. Add your email address or webhook URL (e.g. Slack) as a contact.
-3. Attach this contact group to each test so you are notified of downtime.
-
----
-
-## Step 5 – Verify alerts
-
-1. Temporarily disable a test to trigger an alert.
-2. Confirm you receive the notification via email or webhook.
-
----
-
-## Environment variables
-
-Add these keys to `.env.example` so automation can create or update tests:
+Set the following environment variables in your `.env.example` so automation scripts can update the tests:
 
 ```bash
 STATUSCAKE_API_TOKEN=
 STATUSCAKE_CONTACT_GROUP=
 ```
 
-The API token authenticates Terraform or scripts. `STATUSCAKE_CONTACT_GROUP` is the name or ID
-of the contact group to receive alerts.
+## 2. Prometheus Metrics
 
-## Prometheus metrics
+Prometheus scrapes mode-specific endpoints:
+- `api` – `/api/metrics/live` or `/api/metrics/sandbox`
+- `executor` – `/metrics`
+- `analytics` – `/metrics`
 
-The API now separates live and sandbox telemetry. Prometheus should scrape `/metrics/live` or `/metrics/sandbox` based on the running mode. To view these metrics locally, forward the service ports and curl the endpoints:
+To view them locally:
 
 ```bash
-kubectl port-forward svc/api 9100:8080 &
-kubectl port-forward svc/executor 9200:9100 &
-kubectl port-forward svc/analytics 9300:5000 &
+kubectl -n arbitrage port-forward svc/api 9100:8080 &
+kubectl -n arbitrage port-forward svc/executor 9200:9100 &
+kubectl -n arbitrage port-forward svc/analytics 9300:5000 &
 
 curl http://localhost:9100/api/metrics/live
 curl http://localhost:9100/api/metrics/sandbox
@@ -82,9 +36,4 @@ curl http://localhost:9200/metrics
 curl http://localhost:9300/metrics
 ```
 
-These metrics populate Grafana dashboards and alert rules.
-
-
----
-
-Follow these steps to keep your services monitored and receive alerts if any endpoint becomes unavailable.
+Grafana dashboards use these metrics for alert rules. Verify alerts by temporarily stopping a pod and confirming a notification is sent through StatusCake and Prometheus.

--- a/docs/operator-ui.md
+++ b/docs/operator-ui.md
@@ -1,12 +1,25 @@
-# Operator UI
+# Operator Dashboard
 
-The dashboard displays a persistent banner at the top of every page indicating the current execution mode and whether the panic brake is active.
+The dashboard provides real‑time visibility and control. After logging in, a banner across the top indicates the current execution mode and whether the panic brake is active.
 
-| Color | Text |
-|-------|------|
-| Green | `✅ Live - Trading Active` |
-| Red   | `🔴 Panic Mode - Trading Halted` |
-| Orange| `🧪 Sandbox Mode - Simulation Running` |
-| Dark Red | `🔒 Sandbox Panic - Simulating Failure State` |
+| Color     | Meaning                                    |
+|-----------|--------------------------------------------|
+| **Green** | ✅ Live – trading active                   |
+| **Red**   | 🔴 Panic Mode – trading halted             |
+| **Orange**| 🧪 Sandbox – simulation running            |
+| **Dark Red** | 🔒 Sandbox Panic – simulated failure    |
 
-Use the banner to verify that trading has resumed after an incident or that sandbox simulations are running as expected. Mode changes are published on `control-feed-live` and `control-feed-sandbox` so the banner updates instantly.
+The banner updates automatically by polling `/api/system/status` every 30 seconds and by listening for messages on the relevant Redis control channel.
+
+## Resume Button
+
+When the system is in panic mode a **Resume Trading** button appears. Pressing it sends a POST to `/api/resume`. In live mode the request must include an admin JWT token. If the API returns `503` the UI disables the button and displays a tooltip instructing the operator to check logs.
+
+## Example Workflow
+
+1. Observe the banner turn red after a risk breach.
+2. Inspect metrics and logs from Grafana and the executor pod.
+3. Once resolved, click **Resume Trading** (or run `curl` as shown in [panic-brake.md](panic-brake.md)).
+4. The banner switches back to green (live) or orange (sandbox) indicating normal operation.
+
+Use the banner and button together to safely control trading without shell access to the server.

--- a/docs/panic-brake.md
+++ b/docs/panic-brake.md
@@ -1,14 +1,29 @@
-# Panic Brake Resume Behavior
+# Panic Brake and Safe Resume
 
-When the system enters panic mode, trading halts until a resume request is issued. A red banner appears across the operator dashboard to make the state obvious.
-To prevent unsafe restarts, the resume action now verifies several health checks:
+The panic brake stops all trading when risk limits are breached. A red banner across the dashboard and the `/api/system/status` endpoint both indicate the active panic state.
 
-1. **Heartbeat Alive** – ensures internal monitoring threads are responsive.
-2. **Cold Sweeper Idle** – avoids conflicts with ongoing cold wallet transfers.
-3. **Panic State Cleared** – confirms alerts and flags have been reset.
+## Triggering Conditions
 
-If any check fails, the resume endpoint responds with HTTP `503` and the dashboard disables the **Resume Trading** button. Operators should inspect the logs for the specific reason before retrying.
+- Daily loss exceeds the configured percentage
+- Average latency rises above the set maximum
+- Win rate drops below the minimum threshold
 
-Redis publishes the resume event to either `control-feed-live` or `control-feed-sandbox` depending on the current mode. The executor listens to the correct channel and will not restart if the message arrives on the wrong one.
+When triggered, the executor publishes a `halt` message on `control-feed-live` or `control-feed-sandbox` based on its execution mode.
 
-In live operation the `/resume` API requires an authenticated admin JWT. Sandbox mode leaves the endpoint open so QA environments can easily toggle panic states.
+## Resume Procedure
+
+1. Investigate logs and metrics to confirm the issue is resolved.
+2. Send a POST request to `/api/resume` using an admin JWT when running in live mode.
+   ```bash
+   curl -H "Authorization: Bearer $ADMIN_TOKEN" -X POST \
+     http://localhost:8080/api/resume
+   ```
+   Sandbox mode does not require authentication.
+3. The API verifies:
+   - Heartbeat threads are responsive
+   - The cold sweeper is not transferring funds
+   - Panic flags have been cleared
+4. If any check fails the endpoint returns `503` and the Resume button becomes disabled. Review logs for `[RESUME-BLOCKED]` entries.
+5. On success the API publishes `resume` to the appropriate control channel. The executor only resumes if the message matches its current mode.
+
+Use the dashboard banner to confirm trading has restarted. If the banner stays red, repeat the checks above and resend the request once conditions are safe.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,93 +1,48 @@
-# Sealed Secrets Setup
+# Secrets Management
 
-The Secret Manager agent encrypts credentials so they can be safely stored in Git and deployed to Kubernetes. All secrets in this repository must be sealed before merging.
+All production credentials are stored as Kubernetes SealedSecrets. Plain `.env` files are forbidden in the repository and the CI workflow fails if any are detected.
 
----
-
-## Step 1 – Install kubeseal
-
-Install the Bitnami `kubeseal` CLI with Homebrew:
+## 1. Install `kubeseal`
 
 ```bash
 brew install kubeseal
 ```
 
----
+## 2. Create a base secret
 
-## Step 2 – Create a Kubernetes secret
-
-Create your regular Kubernetes secret locally. For example:
+Generate a normal Kubernetes secret from your environment file:
 
 ```bash
 kubectl create secret generic api-keys \
-  --from-literal=EXCHANGE_KEY=abc123 \
-  --from-literal=EXCHANGE_SECRET=def456 \
+  --from-env-file=.env \
   --dry-run=client -o yaml > secret.yaml
 ```
 
----
+## 3. Seal the secret
 
-## Step 3 – Encrypt the secret
-
-Use `kubeseal` to generate an encrypted version that is safe to commit:
+Encrypt the manifest so it is safe to commit:
 
 ```bash
 kubeseal < secret.yaml > sealed-secret.yaml
 ```
 
-You can also combine creation and sealing in one step:
-
-```bash
-kubectl create secret generic api-keys \
-  --from-env-file=.env \
-  --dry-run=client -o json | \
-  kubeseal --format yaml > sealed-secret.yaml
-```
-
-This is safe to run inside GitHub Actions when credentials come from repository
-secrets.
-
----
-
-## Step 4 – Commit the sealed secret
-
-Add `sealed-secret.yaml` to your repository so it can be deployed with your manifests:
+## 4. Commit and deploy
 
 ```bash
 git add sealed-secret.yaml
-```
-
----
-
-## Step 5 – Apply the sealed secret
-
-Apply the sealed secret to your cluster at deploy time:
-
-```bash
 kubectl apply -f sealed-secret.yaml
 ```
 
-Our GitHub Actions workflow executes `test/verify-env.sh` to enforce this
-policy. The script fails the build if any plaintext `.env` files or unsealed
-`Secret` objects are present in the repository. Run the script locally before
-opening a pull request to avoid a failed push.
+The `test/verify-env.sh` script ensures no raw secrets or `.env.sandbox` files slip into version control. Run it locally before pushing:
 
-For sandbox demonstrations, copy values from `.env.sandbox.example` into your
-own `.env.sandbox` file. This file is ignored by Git and must never be
+```bash
+bash test/verify-env.sh
+```
 
-committed. Detailed instructions are available in
-[docs/sandbox.md](sandbox.md).
+For local demos, copy `.env.sandbox.example` to `.env.sandbox`. This file remains untracked and is loaded by `scripts/start-sandbox.sh`.
 
----
+## 5. Rotation
 
-## Rotation
-
-Rotate credentials at least every 90 days:
-
-1. Create a new Kubernetes secret with updated values.
-2. Reseal using `kubeseal` and commit the new file.
-3. Deploy the sealed secret and remove the old one after rollout.
-
-
-Follow these steps whenever you need to store or update sensitive credentials.
-
+1. Create a new secret with updated values.
+2. Reseal and commit the new file.
+3. Apply it and remove the old sealed secret after verification.


### PR DESCRIPTION
## Summary
- rewrite README and docs to match system behavior after PR16
- document panic brake and resume flow
- clarify secrets policy and sealed secrets usage
- expand monitoring and CI setup guides
- update operator dashboard instructions
- add changelog entry for documentation rewrite

## Testing
- `bash test/verify-env.sh`
- `npm test --prefix api`

------
https://chatgpt.com/codex/tasks/task_b_687e85c60cd4832c9580af4f47e42b84