### PR TITLE
Harden panic/resume and config endpoints

### DIFF
--- a/api/__tests__/api.test.js
+++ b/api/__tests__/api.test.js
@@ -6,10 +6,11 @@ process.env.ADMIN_TOKEN = 'testadmintoken';
 process.env.JWT_SECRET = 'testsecret';
 process.env.SANDBOX_MODE = 'true';
 let buildApp;
+let testState;
 let app;
 
 beforeAll(async () => {
-  ({ buildApp } = await import('../index.js'));
+  ({ buildApp, testState } = await import('../index.js'));
   app = buildApp();
   await app.listen({ port: 8080 });
 });
@@ -60,6 +61,7 @@ describeLocal('API authentication', () => {
       .post('/api/login')
       .send({ email: 'user', password: 'pass' });
     const cookie = login.headers['set-cookie'][0].split(';')[0];
+    testState.paused = true;
     const authRes = await request(app.server)
       .post('/api/resume')
       .set('Cookie', cookie);

--- a/api/__tests__/config.validation.test.js
+++ b/api/__tests__/config.validation.test.js
@@ -1,0 +1,53 @@
+import request from 'supertest';
+
+const describeLocal =
+  process.env.TEST_ENV === 'local' || !process.env.TEST_ENV
+    ? describe
+    : describe.skip;
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
+let buildApp;
+let app;
+let cookie;
+
+beforeAll(async () => {
+  ({ buildApp } = await import('../index.js'));
+  app = buildApp();
+  await app.listen({ port: 0 });
+  const login = await request(app.server)
+    .post('/api/login')
+    .send({ email: 'user', password: 'pass' });
+  cookie = login.headers['set-cookie'][0].split(';')[0];
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describeLocal('config validation', () => {
+  test('rejects unsafe maxLoss', async () => {
+    const res = await request(app.server)
+      .post('/api/config')
+      .set('Cookie', cookie)
+      .send({ maxLoss: 99 });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('rejects unsafe maxLatency', async () => {
+    const res = await request(app.server)
+      .post('/api/config')
+      .set('Cookie', cookie)
+      .send({ maxLatency: 6000 });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('accepts valid payload', async () => {
+    const res = await request(app.server)
+      .post('/api/config')
+      .set('Cookie', cookie)
+      .send({ maxLoss: 5, maxLatency: 1000 });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ saved: true });
+  });
+});

--- a/api/__tests__/panicResume.test.js
+++ b/api/__tests__/panicResume.test.js
@@ -3,6 +3,7 @@ import request from 'supertest';
 const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'testsecret';
+process.env.MODE = 'dry-run';
 let buildApp;
 let testState;
 let app;
@@ -19,16 +20,18 @@ afterAll(async () => {
 
 describeLocal('panic resume cycle', () => {
   test('panic and resume cycle updates metrics', async () => {
-    const panicRes = await request(app.server).post('/api/test/panic');
+    const panicRes = await request(app.server)
+      .post('/api/test/panic')
+      .send({ type: 'loss' });
     expect(panicRes.statusCode).toBe(200);
-    expect(testState.panic).toBe(true);
+    expect(testState.paused).toBe(true);
 
     const metrics1 = await request(app.server).get('/api/metrics/sandbox');
     expect(metrics1.body.panicActive).toBe(true);
 
     const resumeRes = await request(app.server).post('/api/test/resume');
     expect(resumeRes.statusCode).toBe(200);
-    expect(testState.panic).toBe(false);
+    expect(testState.paused).toBe(false);
 
     const metrics2 = await request(app.server).get('/api/metrics/sandbox');
     expect(metrics2.body.panicActive).toBe(false);

--- a/api/__tests__/resume.auth.test.js
+++ b/api/__tests__/resume.auth.test.js
@@ -6,11 +6,12 @@ const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV 
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'testsecret';
 let buildApp;
+let testState;
 let app;
 let warnSpy;
 
 beforeAll(async () => {
-  ({ buildApp } = await import('../index.js'));
+  ({ buildApp, testState } = await import('../index.js'));
   app = buildApp();
   await app.listen({ port: 0 });
 });
@@ -30,6 +31,7 @@ afterEach(() => {
 
 describeLocal('resume endpoint auth', () => {
   test('200 with admin token', async () => {
+    testState.paused = true;
     const token = app.jwt.sign({ role: 'admin' }, { algorithm: 'HS256' });
     const res = await request(app.server)
       .post('/api/resume')
@@ -43,6 +45,7 @@ describeLocal('resume endpoint auth', () => {
   });
 
   test('logs rejection for non-admin', async () => {
+    testState.paused = true;
     const token = app.jwt.sign({ role: 'user' }, { algorithm: 'HS256' });
     const res = await request(app.server)
       .post('/api/resume')
@@ -53,6 +56,7 @@ describeLocal('resume endpoint auth', () => {
 
   test('200 in sandbox without token', async () => {
     process.env.EXECUTION_MODE = 'sandbox';
+    testState.paused = true;
     const res = await request(app.server).post('/api/resume');
     expect(res.statusCode).toBe(200);
   });

--- a/api/__tests__/system.status.test.js
+++ b/api/__tests__/system.status.test.js
@@ -1,0 +1,42 @@
+import request from 'supertest';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV
+  ? describe
+  : describe.skip;
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.MODE = 'dry-run';
+let buildApp;
+let testState;
+let app;
+let cookie;
+
+beforeAll(async () => {
+  ({ buildApp, testState } = await import('../index.js'));
+  app = buildApp();
+  await app.listen({ port: 0 });
+  const login = await request(app.server)
+    .post('/api/login')
+    .send({ email: 'user', password: 'pass' });
+  cookie = login.headers['set-cookie'][0].split(';')[0];
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describeLocal('system status endpoint', () => {
+  test('reports paused state and reason', async () => {
+    await request(app.server).post('/api/test/panic').send({ type: 'loss' });
+    const res = await request(app.server)
+      .get('/api/system/status')
+      .set('Cookie', cookie);
+    expect(res.body).toEqual({ paused: true, panic_reason: 'loss' });
+
+    await request(app.server).post('/api/test/resume');
+    const res2 = await request(app.server)
+      .get('/api/system/status')
+      .set('Cookie', cookie);
+    expect(res2.body).toEqual({ paused: false, panic_reason: null });
+  });
+});

--- a/api/index.js
+++ b/api/index.js
@@ -17,6 +17,7 @@ import metricsRoutes from './routes/metrics.js';
 import analyticsRoutes from './routes/analytics.js';
 import cgtRoutes from './routes/cgt.js';
 import resumeRoutes from './routes/resume.js';
+import configRoutes from './routes/config.js';
 import { sendAlert } from './services/alertManager.js';
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
 import { start as startWsServer } from './services/wsServer.js';
@@ -43,7 +44,7 @@ if (process.env.NODE_ENV === 'production') {
 // Test mode disables external side effects
 
 const isTest = process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID;
-const testState = { panic: false, reason: '' };
+const testState = { paused: false, panicReason: null };
 
 let redis;
 let pool;
@@ -155,20 +156,34 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
 
 
   api.get('/system/status', async () => ({
-    panic: testState.panic,
-    reason: testState.reason,
+    paused: testState.paused,
+    panic_reason: testState.panicReason,
   }));
 
     if (isTest) {
-      api.post('/test/panic', async () => {
-        testState.panic = true;
+      api.post('/test/panic', async (req, reply) => {
+        if (process.env.MODE !== 'dry-run') {
+          reply.code(403);
+          return { error: 'forbidden' };
+        }
+        testState.paused = true;
+        testState.panicReason = req.body?.type || null;
         await redis.publish('control-feed', 'halt');
         await sendAlert('email', 'Panic brake triggered (test mode)');
         return { triggered: true };
       });
 
-      api.post('/test/resume', async () => {
-        testState.panic = false;
+      api.post('/test/resume', async (_req, reply) => {
+        if (process.env.MODE !== 'dry-run') {
+          reply.code(403);
+          return { error: 'forbidden' };
+        }
+        if (!testState.paused) {
+          reply.code(400);
+          return { error: 'not paused' };
+        }
+        testState.paused = false;
+        testState.panicReason = null;
         await redis.publish('control-feed', 'resume');
         return { resumed: true };
       });
@@ -183,6 +198,7 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
   api.register(userRoutes, { prefix: '/users' });
   api.register(infraRoutes, { redis, pool });
   api.register(modelRoutes, { pool });
+  api.register(configRoutes);
   api.register(resumeRoutes, { redis, testState });
   api.register(metricsRoutes, { testState });
   api.register(analyticsRoutes, { pool });

--- a/api/routes/config.js
+++ b/api/routes/config.js
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { requireAdmin } from '../middleware/auth.js';
+
+export const config = {
+  maxLoss: 5,
+  maxLatency: 500,
+};
+
+export default async function configRoutes(app) {
+  const schema = z
+    .object({
+      maxLoss: z.number().min(0).max(25).optional(),
+      maxLatency: z.number().min(100).max(5000).optional(),
+    })
+    .strict();
+
+  app.get('/config', async () => config);
+
+  app.post('/config', { preHandler: requireAdmin }, async (req, reply) => {
+    const result = schema.safeParse(req.body);
+    if (!result.success || Object.keys(result.data).length === 0) {
+      reply.code(400);
+      return { error: 'invalid config' };
+    }
+    Object.assign(config, result.data);
+    return { saved: true };
+  });
+}

--- a/api/routes/metrics.js
+++ b/api/routes/metrics.js
@@ -19,7 +19,7 @@ export default async function metricsRoutes(app, { testState } = {}) {
   const fetchMetrics = async (req, mode) => {
     const execMode = mode || getExecutionMode(req);
     if (execMode === 'sandbox' || process.env.NODE_ENV === 'test') {
-      return { ...seeded, panicActive: testState?.panic ?? false };
+      return { ...seeded, panicActive: testState?.paused ?? false };
     }
 
     const promUrl = execMode === 'live' ? PROM_LIVE_URL : PROM_SANDBOX_URL;

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -3,8 +3,15 @@ import { requireAdmin } from '../middleware/auth.js';
 export default async function resumeRoutes(app, opts) {
   const { redis, testState } = opts;
 
-  app.post('/resume', { preHandler: requireAdmin }, async () => {
-    if (testState) testState.panic = false;
+  app.post('/resume', { preHandler: requireAdmin }, async (_req, reply) => {
+    if (testState && !testState.paused) {
+      reply.code(400);
+      return { error: 'not paused' };
+    }
+    if (testState) {
+      testState.paused = false;
+      testState.panicReason = null;
+    }
     await redis.publish('control-feed', 'resume');
     return { resumed: true };
   });


### PR DESCRIPTION
## Summary
- add new `/config` route with input validation
- track paused state and panic reason
- gate test panic/resume routes by `MODE`
- validate resume only when paused
- cover new logic with Jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687ead36b7dc832c951381ef4248047c