### PR TITLE
Fix executor panic/resume guardrails and enforce latency cap

### DIFF
--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -98,7 +98,8 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         this.circuitBreaker = new CircuitBreaker(redisClient, cbWinRate, cbDrawdown);
         this.canaryMode = Boolean.parseBoolean(System.getenv().getOrDefault("CANARY_MODE", "false"));
         this.ghostMode = Boolean.parseBoolean(System.getenv().getOrDefault("GHOST_MODE", "false"));
-        this.sandboxMode = this.config.isDryRun();
+        boolean envDryRun = "dry-run".equalsIgnoreCase(System.getenv().getOrDefault("MODE", ""));
+        this.sandboxMode = this.config.isDryRun() || envDryRun;
         this.maxOpenTrades = Integer.parseInt(System.getenv().getOrDefault("MAX_OPEN_TRADES", "5"));
     }
 
@@ -210,6 +211,13 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         logger.debug("Received message: {}", message);
         SpreadOpportunity opp = SpreadOpportunity.fromJson(message);
         logger.debug("Parsed opportunity: {}", opp);
+        long delay = Math.max(0L, System.currentTimeMillis() - opp.getTimestamp());
+        long totalLatency = opp.getRoundTripLatencyMs() + delay;
+        if (totalLatency > riskFilter.getMaxLatencyMs()) {
+            logger.warn("[QUEUE-LATENCY] Dropping {} due to total latency {}ms > {}", opp.getPair(), totalLatency, riskFilter.getMaxLatencyMs());
+            nearMissLogger.log(opp, "queue_latency");
+            return;
+        }
 
         double predictedProb = fetchModelScore(opp);
         logger.info("Model score for {}: {}", opp.getPair(), predictedProb);
@@ -374,18 +382,24 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
      * Manually resume trading after a user initiated halt.
      */
     public void resumeTrading() {
-        isPanic.set(false);
-        circuitBreaker.reset();
-        logger.info("Trading manually resumed.");
+        if (isPanic.compareAndSet(true, false)) {
+            circuitBreaker.reset();
+            logger.info("[RESUME SIGNAL RECEIVED] reason=manual ts={}", System.currentTimeMillis());
+        } else {
+            logger.warn("[RESUME IGNORED] already active");
+        }
     }
 
     /**
      * Resume trading after a panic brake was triggered.
      */
     public void resumeFromPanic() {
-        isPanic.set(false);
-        circuitBreaker.reset();
-        logger.info("PANIC RESUME SIGNAL RECEIVED");
+        if (isPanic.compareAndSet(true, false)) {
+            circuitBreaker.reset();
+            logger.info("[RESUME SIGNAL RECEIVED] reason=control ts={}", System.currentTimeMillis());
+        } else {
+            logger.warn("[RESUME IGNORED] already active");
+        }
     }
 
     /**

--- a/executor/src/main/java/PanicBrake.java
+++ b/executor/src/main/java/PanicBrake.java
@@ -73,22 +73,24 @@ public class PanicBrake {
         double profitSoFar = ProfitTracker.getCumulativeProfit();
 
         boolean triggered = false;
+        String reason = null;
 
         if (dailyLossPct > lossCap) {
-            logger.warn("PANIC BRAKE TRIGGERED: loss {}% > {}%", dailyLossPct, lossCap);
-            triggered = true;
+            reason = "LOSS_CAP";
         } else if (avgLatencyMs > latencyCap) {
-            logger.warn("PANIC BRAKE TRIGGERED: latency {}ms > {}ms", avgLatencyMs, latencyCap);
-            triggered = true;
+            reason = "LATENCY_CAP";
         } else if (winRate < winRateThresh) {
-            logger.warn("PANIC BRAKE TRIGGERED: winRate {} < {}", winRate, winRateThresh);
-            triggered = true;
+            reason = "WIN_RATE";
         } else if (profitTarget > 0 && profitSoFar >= profitTarget) {
-            logger.warn("PANIC BRAKE TRIGGERED: profit {} >= target {}", profitSoFar, profitTarget);
+            reason = "PROFIT_TARGET";
+        }
+
+        if (reason != null) {
+            logger.error("[PANIC TRIGGERED] reason={} ts={}", reason, System.currentTimeMillis());
             triggered = true;
         }
 
-        if (triggered && redis != null) {
+        if (triggered && redis != null && config != null && !config.isDryRun()) {
             redis.publishControl(config, "pause");
         }
 

--- a/executor/src/main/java/RiskFilter.java
+++ b/executor/src/main/java/RiskFilter.java
@@ -85,6 +85,13 @@ public class RiskFilter {
     }
 
     /**
+     * @return maximum allowed latency in milliseconds
+     */
+    public long getMaxLatencyMs() {
+        return maxLatencyMs;
+    }
+
+    /**
      * Evaluate a full spread opportunity.
      *
      * @param opportunity spread opportunity

--- a/executor/src/main/java/SpreadOpportunity.java
+++ b/executor/src/main/java/SpreadOpportunity.java
@@ -17,6 +17,7 @@ public class SpreadOpportunity {
   private long roundTripLatencyMs;
   private long latencyMicros;
   private long roundTripLatencyMicros;
+  private long timestamp;
 
   /**
    * Factory method for creating exchange adapters. Allows tests to override with custom behaviour.
@@ -33,6 +34,18 @@ public class SpreadOpportunity {
       double grossEdge,
       double netEdge,
       long latencyMs) {
+    this(pair, buyExchange, sellExchange, grossEdge, netEdge, latencyMs,
+        System.currentTimeMillis());
+  }
+
+  public SpreadOpportunity(
+      String pair,
+      String buyExchange,
+      String sellExchange,
+      double grossEdge,
+      double netEdge,
+      long latencyMs,
+      long timestamp) {
     this.pair = pair;
     this.buyExchange = buyExchange;
     this.sellExchange = sellExchange;
@@ -42,6 +55,7 @@ public class SpreadOpportunity {
     this.roundTripLatencyMs = latencyMs;
     this.latencyMicros = latencyMs * 1000;
     this.roundTripLatencyMicros = latencyMs * 1000;
+    this.timestamp = timestamp;
   }
 
   /** Parse an opportunity from a JSON payload. */
@@ -50,13 +64,16 @@ public class SpreadOpportunity {
       ObjectMapper mapper = new ObjectMapper();
       JsonNode node = mapper.readTree(json);
       long latency = node.has("latencyMs") ? node.get("latencyMs").asLong() : 0L;
+      long ts = node.has("timestamp") ? node.get("timestamp").asLong()
+                                        : System.currentTimeMillis();
       return new SpreadOpportunity(
           node.get("pair").asText(),
           node.get("buyExchange").asText(),
           node.get("sellExchange").asText(),
           node.get("grossEdge").asDouble(),
           node.get("netEdge").asDouble(),
-          latency);
+          latency,
+          ts);
     } catch (Exception e) {
       throw new IllegalArgumentException("Invalid opportunity JSON", e);
     }
@@ -66,7 +83,13 @@ public class SpreadOpportunity {
   public static SpreadOpportunity fromSpread(Spread spread) {
     SpreadOpportunity opp =
         new SpreadOpportunity(
-            "", "", "", spread.getEdge(), spread.getEdge(), spread.getLatencyMs());
+            "",
+            "",
+            "",
+            spread.getEdge(),
+            spread.getEdge(),
+            spread.getLatencyMs(),
+            System.currentTimeMillis());
     opp.roundTripLatencyMs = spread.getLatencyMs();
     opp.latencyMicros = spread.getLatencyMs() * 1000;
     opp.roundTripLatencyMicros = spread.getLatencyMs() * 1000;
@@ -205,6 +228,13 @@ public class SpreadOpportunity {
     return roundTripLatencyMicros;
   }
 
+  /**
+   * @return creation timestamp of the opportunity
+   */
+  public long getTimestamp() {
+    return timestamp;
+  }
+
   @Override
   public String toString() {
     return "SpreadOpportunity{"
@@ -223,6 +253,8 @@ public class SpreadOpportunity {
         + netEdge
         + ", latencyMs="
         + latencyMs
+        + ", timestamp="
+        + timestamp
         + '}';
   }
 }

--- a/executor/src/main/java/TriangularArbDetector.java
+++ b/executor/src/main/java/TriangularArbDetector.java
@@ -199,6 +199,7 @@ public class TriangularArbDetector {
                         node.put("sellExchange", "triangular");
                         node.put("grossEdge", grossEdge);
                         node.put("netEdge", netEdge);
+                        node.put("timestamp", System.currentTimeMillis());
                         bestMessage = node.toString();
                     }
                 }

--- a/executor/src/test/java/DryRunPanicResumeTest.java
+++ b/executor/src/test/java/DryRunPanicResumeTest.java
@@ -1,0 +1,33 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class DryRunPanicResumeTest {
+    static class DummyRedis extends RedisClient {
+        DummyRedis() { super("localhost", 6379, "chan", (c,m)->{}); }
+        @Override public void start() {}
+    }
+
+    static class DummyExecutor extends Executor {
+        DummyExecutor() {
+            super(new DummyRedis(), "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.SANDBOX));
+        }
+        @Override public void start() {}
+    }
+
+    @Test
+    void resumeClearsPanicFlag() throws Exception {
+        DummyExecutor exec = new DummyExecutor();
+        Field f = Executor.class.getDeclaredField("isPanic");
+        f.setAccessible(true);
+        ((java.util.concurrent.atomic.AtomicBoolean)f.get(exec)).set(true);
+        exec.resumeFromPanic();
+        assertFalse(((java.util.concurrent.atomic.AtomicBoolean)f.get(exec)).get());
+    }
+}

--- a/executor/src/test/java/LatencyBypassBugTest.java
+++ b/executor/src/test/java/LatencyBypassBugTest.java
@@ -1,0 +1,39 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class LatencyBypassBugTest {
+    static class DummyRedis extends RedisClient {
+        DummyRedis() { super("localhost", 6379, "chan", (c,m)->{}); }
+        @Override public void start() {}
+        @Override public void publish(String c, String m) {}
+    }
+
+    static class CaptureLogger extends NearMissLogger {
+        String reason;
+        CaptureLogger() { super(null); }
+        @Override public void log(SpreadOpportunity opp, String reason) { this.reason = reason; }
+    }
+
+    static class DummyExecutor extends Executor {
+        DummyExecutor(CaptureLogger nl) {
+            super(new DummyRedis(), "localhost", 6379, new RiskFilter(0.0, 100, 1.0), nl);
+        }
+        @Override public void start() {}
+    }
+
+    @Test
+    void dropsStaleOpportunityOnQueueFlush() {
+        ProfitTracker.init(10000, "http://localhost");
+        CaptureLogger nl = new CaptureLogger();
+        DummyExecutor exec = new DummyExecutor(nl);
+        long ts = System.currentTimeMillis() - 200;
+        String msg = "{\"pair\":\"BTC/USDT\",\"buyExchange\":\"A\",\"sellExchange\":\"B\",\"grossEdge\":2.0,\"netEdge\":2.0,\"latencyMs\":50,\"timestamp\":" + ts + "}";
+        exec.handleMessage(msg);
+        assertEquals("queue_latency", nl.reason);
+    }
+}

--- a/executor/src/test/java/PanicBrakeTest.java
+++ b/executor/src/test/java/PanicBrakeTest.java
@@ -66,11 +66,11 @@ public class PanicBrakeTest {
     }
 
     @Test
-    void publishesPauseToSandboxChannel() {
+    void doesNotPublishPauseInDryRun() {
         DummyRedis redis = new DummyRedis();
         Config config = new Config(ExecutionMode.SANDBOX);
         assertTrue(PanicBrake.shouldHalt(redis, config, 4.0, 100.0, 0.8));
-        assertEquals("control-feed-sandbox", redis.channel);
-        assertEquals("pause", redis.message);
+        assertNull(redis.channel);
+        assertNull(redis.message);
     }
 }

--- a/executor/src/test/java/ResumeGuardTest.java
+++ b/executor/src/test/java/ResumeGuardTest.java
@@ -1,0 +1,38 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class ResumeGuardTest {
+    static class DummyRedis extends RedisClient {
+        DummyRedis() { super("localhost", 6379, "chan", (c,m)->{}); }
+        @Override public void start() {}
+    }
+
+    static class DummyExecutor extends Executor {
+        DummyExecutor() {
+            super(new DummyRedis(), "localhost", 6379, new RiskFilter(), new NearMissLogger(null));
+        }
+        @Override public void start() {}
+    }
+
+    @Test
+    void warnsWhenAlreadyResumed() {
+        DummyExecutor exec = new DummyExecutor();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream orig = System.err;
+        System.setErr(new PrintStream(err));
+        try {
+            exec.resumeFromPanic();
+        } finally {
+            System.setErr(orig);
+        }
+        assertTrue(err.toString().contains("RESUME IGNORED"));
+    }
+}


### PR DESCRIPTION
## Summary
- prevent dry-run environment from publishing pause signals
- add queue latency checks in executor
- guard repeated resume attempts with warning logs
- log panic and resume events with reason codes
- support timestamped opportunities and add latency enforcement
- unit tests for panic/resume dry-run logic, latency cap enforcement and resume guard

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_687eb22bc8b0832ca153891121260f28