### PR TITLE
[PR 20] Hardened secrets handling, SMTP alert logging, and persistent logs

### DIFF
--- a/analytics/logger.py
+++ b/analytics/logger.py
@@ -2,5 +2,14 @@ import logging
 import os
 
 level = os.getenv("LOG_LEVEL", "INFO").upper()
-logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(message)s")
+log_dir = os.getenv("LOG_DIR", "/var/log/prism-arbitrage")
+os.makedirs(log_dir, exist_ok=True)
+logging.basicConfig(
+    level=level,
+    format="%(asctime)s %(levelname)s %(message)s",
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(os.path.join(log_dir, "analytics.log")),
+    ],
+)
 logger = logging.getLogger("analytics")

--- a/api/index.js
+++ b/api/index.js
@@ -92,6 +92,9 @@ function buildApp() {
 const app = buildApp();
 
 logger.info('API initialized');
+['BINANCE_KEY', 'SMTP_USER', 'SMTP_PASS'].forEach(key => {
+  logger.info(`${key} present: ${process.env[key] ? 'true' : 'false'}`);
+});
 
 const alertSettings = {
   smtp_user: '',

--- a/api/services/alertManager.js
+++ b/api/services/alertManager.js
@@ -21,14 +21,14 @@ async function sendAlert(type, message) {
   switch (type) {
     case 'email':
       if (!hasEmailConfig()) {
-        logger.warn('Email alert skipped: missing SMTP config');
+        logger.error('[ALERT FAILURE] Panic alert email failed to send: missing SMTP config');
         return;
       }
       try {
         await sendEmail('Crypto Alert', message);
         logger.info('Email alert sent');
       } catch (err) {
-        logger.error(`Email alert failed: ${err.message}`);
+        logger.error(`[ALERT FAILURE] Panic alert email failed to send: ${err.message}`);
         throw err;
       }
       break;

--- a/api/services/emailAlert.js
+++ b/api/services/emailAlert.js
@@ -18,7 +18,9 @@ const transporter = nodemailer.createTransport({
 
 async function sendEmail(subject, body) {
   if (!user || !pass || !recipient) {
-    throw new Error('SMTP credentials not set');
+    const reason = 'SMTP credentials not set';
+    logger.error(`[ALERT FAILURE] Panic alert email failed to send: ${reason}`);
+    throw new Error(reason);
   }
 
   const mailOptions = {
@@ -32,7 +34,7 @@ async function sendEmail(subject, body) {
       await transporter.sendMail(mailOptions);
       logger.info('Email alert sent');
     } catch (error) {
-      logger.error(`Failed to send email alert: ${error.message}`);
+      logger.error(`[ALERT FAILURE] Panic alert email failed to send: ${error.message}`);
       throw error;
     }
 }

--- a/api/services/logger.js
+++ b/api/services/logger.js
@@ -1,4 +1,10 @@
 import winston from 'winston';
+import fs from 'fs';
+
+const logDir = process.env.LOG_DIR || '/var/log/prism-arbitrage';
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir, { recursive: true });
+}
 
 const service = process.env.SERVICE_NAME || 'api';
 
@@ -10,7 +16,10 @@ const logger = winston.createLogger({
       `${timestamp} ${level} [${service}] ${message}`
     )
   ),
-  transports: [new winston.transports.Console()],
+  transports: [
+    new winston.transports.Console(),
+    new winston.transports.File({ filename: `${logDir}/${service}.log` }),
+  ],
 });
 
 export default logger;

--- a/feed-aggregator/index.js
+++ b/feed-aggregator/index.js
@@ -5,6 +5,11 @@ const winston = require("winston");
 const fs = require("fs");
 const normalize = require("./lib/normalize");
 
+const logDir = process.env.LOG_DIR || "/var/log/prism-arbitrage";
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir, { recursive: true });
+}
+
 const FEED_URL = process.env.FEED_URL || "wss://example.com/feed";
 const CHANNEL = process.env.ORDERBOOK_CHANNEL || "orderbook";
 const REDIS_HOST = process.env.REDIS_HOST || "127.0.0.1";
@@ -28,7 +33,10 @@ const logger = winston.createLogger({
       `${timestamp} ${level} [${service}] ${message}`
     )
   ),
-  transports: [new winston.transports.Console()],
+  transports: [
+    new winston.transports.Console(),
+    new winston.transports.File({ filename: `${logDir}/${service}.log` }),
+  ],
 });
 
 const redis = process.env.MOCK_REDIS
@@ -40,7 +48,7 @@ const lastAlertTimes = {};
 
 function fallbackAlert(payload) {
   fs.appendFile(
-    "alerts-fallback.log",
+    `${logDir}/alerts-fallback.log`,
     `${new Date().toISOString()} ${payload}\n`,
     (err) => {
       if (err) logger.error("Failed to write fallback alert", err);

--- a/infra/helm/templates/analytics-deployment.yaml
+++ b/infra/helm/templates/analytics-deployment.yaml
@@ -23,7 +23,10 @@ spec:
           resources: {{- toYaml .Values.analytics.resources | nindent 12 }}
           envFrom:
             - secretRef:
-                name: analytics-secrets
+                name: prod-secrets
+          volumeMounts:
+            - name: prism-logs
+              mountPath: /var/log/prism-arbitrage
           readinessProbe:
             httpGet:
               path: /ping
@@ -36,6 +39,11 @@ spec:
               port: {{ .Values.analytics.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
+      volumes:
+        - name: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/infra/helm/templates/api-deployment.yaml
+++ b/infra/helm/templates/api-deployment.yaml
@@ -24,6 +24,9 @@ spec:
           envFrom:
             - secretRef:
                 name: api-secrets
+          volumeMounts:
+            - name: prism-logs
+              mountPath: /var/log/prism-arbitrage
           readinessProbe:
             httpGet:
               path: /api/metrics
@@ -36,6 +39,11 @@ spec:
               port: {{ .Values.api.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
+      volumes:
+        - name: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/infra/helm/templates/dashboard-deployment.yaml
+++ b/infra/helm/templates/dashboard-deployment.yaml
@@ -23,7 +23,10 @@ spec:
           resources: {{- toYaml .Values.dashboard.resources | nindent 12 }}
           envFrom:
             - secretRef:
-                name: dashboard-secrets
+                name: prod-secrets
+          volumeMounts:
+            - name: prism-logs
+              mountPath: /var/log/prism-arbitrage
           readinessProbe:
             httpGet:
               path: /
@@ -36,6 +39,11 @@ spec:
               port: {{ .Values.dashboard.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
+      volumes:
+        - name: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/infra/helm/templates/executor-deployment.yaml
+++ b/infra/helm/templates/executor-deployment.yaml
@@ -21,7 +21,10 @@ spec:
           resources: {{- toYaml .Values.executor.resources | nindent 12 }}
           envFrom:
             - secretRef:
-                name: executor-secrets
+                name: prod-secrets
+          volumeMounts:
+            - name: prism-logs
+              mountPath: /var/log/prism-arbitrage
           readinessProbe:
             exec:
               command: ["pgrep", "-f", "Executor"]
@@ -32,3 +35,8 @@ spec:
               command: ["pgrep", "-f", "Executor"]
             initialDelaySeconds: 10
             periodSeconds: 10
+      volumes:
+        - name: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate

--- a/infra/helm/templates/feed-aggregator-deployment.yaml
+++ b/infra/helm/templates/feed-aggregator-deployment.yaml
@@ -23,7 +23,10 @@ spec:
           resources: {{- toYaml .Values.feedAggregator.resources | nindent 12 }}
           envFrom:
             - secretRef:
-                name: feed-aggregator-secrets
+                name: prod-secrets
+          volumeMounts:
+            - name: prism-logs
+              mountPath: /var/log/prism-arbitrage
           readinessProbe:
             httpGet:
               path: /health
@@ -36,6 +39,11 @@ spec:
               port: {{ .Values.feedAggregator.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
+      volumes:
+        - name: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/infra/helm/templates/sealed-secret.yaml
+++ b/infra/helm/templates/sealed-secret.yaml
@@ -14,7 +14,7 @@ spec:
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: analytics-secrets
+  name: prod-secrets
   namespace: default
 spec:
   encryptedData:
@@ -22,48 +22,14 @@ spec:
     PGUSER: AgFAKEENCRYPTEDPGUSER
     PGPASSWORD: AgFAKEENCRYPTEDPGPASSWORD
     PGDATABASE: AgFAKEENCRYPTEDPGDATABASE
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: dashboard-secrets
-  namespace: default
-spec:
-  encryptedData:
     PUBLIC_URL: AgFAKEDASHBOARDURL
     NODE_ENV: AgFAKEDASHBOARDENV
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: executor-secrets
-  namespace: default
-spec:
-  encryptedData:
     REDIS_HOST: AgFAKEREDISHOST
     REDIS_PORT: AgFAKEREDISPORT
     ANALYTICS_URL: AgFAKEANALYTICSURL
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: postgres-secrets
-  namespace: default
-spec:
-  encryptedData:
+    FEED_URL: AgFAKEFEEDURL
+    ORDERBOOK_CHANNEL: AgFAKEORDERBOOKCHANNEL
+    ALERT_CHANNEL: AgFAKEALERTCHANNEL
     POSTGRES_USER: AgFAKEENCRYPTEDPGUSER
     POSTGRES_PASSWORD: AgFAKEENCRYPTEDPGPASSWORD
     POSTGRES_DB: AgFAKEENCRYPTEDPGDATABASE
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: feed-aggregator-secrets
-  namespace: default
-spec:
-  encryptedData:
-    FEED_URL: AgFAKEFEEDURL
-    REDIS_HOST: AgFAKEREDISHOST
-    REDIS_PORT: AgFAKEREDISPORT
-    ORDERBOOK_CHANNEL: AgFAKEORDERBOOKCHANNEL
-    ALERT_CHANNEL: AgFAKEALERTCHANNEL

--- a/infra/k8s/analytics.yaml
+++ b/infra/k8s/analytics.yaml
@@ -44,7 +44,15 @@ spec:
               nvidia.com/gpu: "1"
           envFrom:
             - secretRef:
-                name: analytics-secrets
+                name: prod-secrets
+          volumeMounts:
+            - name: prism-logs
+              mountPath: /var/log/prism-arbitrage
+      volumes:
+        - name: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/api.yaml
+++ b/infra/k8s/api.yaml
@@ -22,7 +22,7 @@ spec:
             - containerPort: 8080
           volumeMounts:
             - name: prism-logs
-              mountPath: /var/log/prism
+              mountPath: /var/log/prism-arbitrage
           livenessProbe:
             httpGet:
               path: /api/metrics
@@ -49,8 +49,9 @@ spec:
                 name: api-secrets
       volumes:
         - name: prism-logs
-          persistentVolumeClaim:
-            claimName: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/dashboard.yaml
+++ b/infra/k8s/dashboard.yaml
@@ -35,7 +35,10 @@ spec:
             failureThreshold: 3
           envFrom:
             - secretRef:
-                name: dashboard-secrets
+                name: prod-secrets
+          volumeMounts:
+            - name: prism-logs
+              mountPath: /var/log/prism-arbitrage
           resources:
             requests:
               cpu: "100m"
@@ -43,6 +46,11 @@ spec:
             limits:
               cpu: "200m"
               memory: "256Mi"
+      volumes:
+        - name: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/executor.yaml
+++ b/infra/k8s/executor.yaml
@@ -24,7 +24,10 @@ spec:
               cpu: "500m"
           envFrom:
             - secretRef:
-                name: executor-secrets
+                name: prod-secrets
+          volumeMounts:
+            - name: prism-logs
+              mountPath: /var/log/prism-arbitrage
           readinessProbe:
             exec:
               command: ["pgrep", "-f", "Executor"]
@@ -35,3 +38,8 @@ spec:
               command: ["pgrep", "-f", "Executor"]
             initialDelaySeconds: 10
             periodSeconds: 10
+      volumes:
+        - name: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate

--- a/infra/k8s/feed-aggregator.yaml
+++ b/infra/k8s/feed-aggregator.yaml
@@ -28,7 +28,10 @@ spec:
               memory: "256Mi"
           envFrom:
             - secretRef:
-                name: feed-aggregator-secrets
+                name: prod-secrets
+          volumeMounts:
+            - name: prism-logs
+              mountPath: /var/log/prism-arbitrage
           readinessProbe:
             httpGet:
               path: /health
@@ -41,6 +44,11 @@ spec:
               port: 8090
             initialDelaySeconds: 10
             periodSeconds: 10
+      volumes:
+        - name: prism-logs
+          hostPath:
+            path: /var/log/prism-arbitrage
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/sealed-secret.yaml
+++ b/infra/k8s/sealed-secret.yaml
@@ -12,7 +12,7 @@ spec:
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: analytics-secrets
+  name: prod-secrets
   namespace: default
 spec:
   encryptedData:
@@ -20,48 +20,14 @@ spec:
     PGUSER: AgFAKEENCRYPTEDPGUSER
     PGPASSWORD: AgFAKEENCRYPTEDPGPASSWORD
     PGDATABASE: AgFAKEENCRYPTEDPGDATABASE
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: dashboard-secrets
-  namespace: default
-spec:
-  encryptedData:
     PUBLIC_URL: AgFAKEDASHBOARDURL
     NODE_ENV: AgFAKEDASHBOARDENV
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: executor-secrets
-  namespace: default
-spec:
-  encryptedData:
     REDIS_HOST: AgFAKEREDISHOST
     REDIS_PORT: AgFAKEREDISPORT
     ANALYTICS_URL: AgFAKEANALYTICSURL
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: postgres-secrets
-  namespace: default
-spec:
-  encryptedData:
+    FEED_URL: AgFAKEFEEDURL
+    ORDERBOOK_CHANNEL: AgFAKEORDERBOOKCHANNEL
+    ALERT_CHANNEL: AgFAKEALERTCHANNEL
     POSTGRES_USER: AgFAKEENCRYPTEDPGUSER
     POSTGRES_PASSWORD: AgFAKEENCRYPTEDPGPASSWORD
     POSTGRES_DB: AgFAKEENCRYPTEDPGDATABASE
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: feed-aggregator-secrets
-  namespace: default
-spec:
-  encryptedData:
-    FEED_URL: AgFAKEFEEDURL
-    REDIS_HOST: AgFAKEREDISHOST
-    REDIS_PORT: AgFAKEREDISPORT
-    ORDERBOOK_CHANNEL: AgFAKEORDERBOOKCHANNEL
-    ALERT_CHANNEL: AgFAKEALERTCHANNEL


### PR DESCRIPTION
## Summary
- enforce sealed-secret usage across pods via `envFrom.secretRef`
- combine pod secrets into `prod-secrets`
- mount `/var/log/prism-arbitrage` hostPath for persistent logs
- log SMTP failures with `[ALERT FAILURE]` messages
- confirm secrets loaded at runtime in API

## Testing
- `bash test/verify-env.sh`
- `bash -x test/run-local.sh` *(fails: curl to localhost 8080)*


------
https://chatgpt.com/codex/tasks/task_b_687eb68aa504832c8806931116e87c17