### PR TITLE
Update docs and env examples for new deployment flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Global environment example for infrastructure automation
-# StatusCake credentials used by Terraform or scripts
+# API token for StatusCake uptime monitoring (optional)
 STATUSCAKE_API_TOKEN=
+# Contact group ID for StatusCake alerts
 STATUSCAKE_CONTACT_GROUP=

--- a/.env.sandbox.example
+++ b/.env.sandbox.example
@@ -1,3 +1,3 @@
-API_KEY=your_value_here
-REDIS_URL=your_url_here
+API_KEY=dry_run_key
+REDIS_URL=redis://localhost:6379
 EXECUTION_MODE=sandbox

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
 
 ## Overview
 
-**Crypto Arbitrage** is an audited multi-agent platform that executes cross-exchange trades.  A feed aggregator publishes order books to Redis, a Java executor reacts to spreads, and supporting services expose APIs, analytics, and a real‑time operator dashboard.  The system can run in `live` or `sandbox` mode on the same host.  Sandbox mode performs every action except fund movement so strategies can be tested safely.
-
-For a guided sandbox walkthrough see [docs/sandbox.md](docs/sandbox.md).
+**Crypto Arbitrage** is an audited multi-agent platform that scans multiple exchanges and executes trades automatically. A feed aggregator publishes order books to Redis, a Java executor reacts to spreads, and supporting services expose APIs, analytics, and a responsive operator dashboard. Running in `sandbox` mode performs every action except fund movement so strategies can be tested safely.
 
 ---
 
@@ -20,13 +18,10 @@ For a guided sandbox walkthrough see [docs/sandbox.md](docs/sandbox.md).
 - WebSocket feed aggregation across 14 venues
 - Sub‑60µs Java trade executor
 - REST API secured by JWTs and an admin token
-- React dashboard with persistent system status banner
+- React dashboard with mode toggle, loss cap control, and panic resume
 - Predictive analytics with optional GPU acceleration
-- Panic brake halts trading on loss, latency, or win‑rate breaches
-- Resume only succeeds when heartbeat checks pass and the cold sweeper is idle
-- Mode specific Redis channels `control-feed-live` and `control-feed-sandbox`
-- Dry‑run behavior via `ExecutionMode.SANDBOX` with logs like `[DRY-RUN] Skipping cold wallet transfer`
-- Container builds produce SBOMs and are scanned by Trivy during CI
+- SealedSecrets for production credentials
+- Dry‑run logs marked with `[DRY-RUN]`
 
 ---
 
@@ -43,171 +38,107 @@ graph TD
   Executor --> Postgres[(PostgreSQL)]
 ```
 
-## Folder Structure
-
-- `api/` – Fastify API server
-- `dashboard/` – React frontend
-- `analytics/` – Python ML service
-- `executor/` – Java trading engine
-- `feed-aggregator/` – order book collector
-- `scripts/` – CLI helpers and ops tools
-- `infra/` – Kubernetes Helm charts
-
 ---
 
 ## Required Tools
 
-The git hooks run tests across all languages. Install the following before contributing:
-
 - **Node.js 20** and `npm`
 - **Python 3.10** and `pytest`
 - **Java 17** and `gradle`
-- **Podman** for container builds
+- **Podman** with **Colima** on macOS
 - **Helm** and `kubectl` for Kubernetes
 
-Enable the hooks once by running:
-
+Enable git hooks once by running:
 ```bash
 git config core.hooksPath githooks
 ```
 
 ---
 
-## Dev Setup
+## Deployment Phases
 
-1. Start the local container runtime:
+### Phase 1 – Local Dry‑Run (Colima)
+
+1. Start Colima with Kubernetes support:
    ```bash
-   colima start --runtime podman
+   colima start --with-kubernetes --runtime containerd
    ```
-2. Install dependencies and charts:
+2. Clone the repo and install dependencies:
    ```bash
+   git clone https://github.com/prism-arbitrage/crypto-arbitrage.git
+   cd crypto-arbitrage
    npm install
    npm install --prefix api
    npm install --prefix dashboard
    pip install -r requirements.txt
    helm dependency update infra/helm
-   helm install arb infra/helm
    ```
-3. Copy any `*.env.example` file to `.env` and adjust for your environment.  For demos, create `.env.sandbox` and run `./scripts/start-sandbox.sh`.
+3. Copy environment samples and edit for dry‑run:
+   ```bash
+   cp api/.env.example api/.env
+   cp dashboard/.env.example dashboard/.env
+   cp executor/.env.example executor/.env
+   cp analytics/.env.example analytics/.env
+   ```
+   All defaults are safe for sandbox testing.
+4. Deploy the stack locally:
+   ```bash
+   helm install prism ./infra/helm
+   ```
+5. Verify pods and open the dashboard at <http://localhost:3000>.
+
+### Phase 2 – Proxmox Server Deploy
+
+1. Provision an Ubuntu 22.04 VM in Proxmox (10 cores, 32 GB RAM).
+2. Install Kubernetes, Helm and the SealedSecrets controller on the VM.
+3. Clone the repo on the VM and create sealed secrets for all `.env` files.
+4. Deploy with Helm:
+   ```bash
+   helm install prism ./infra/helm
+   ```
+5. Expose the dashboard via ingress or port‑forward and confirm login works.
+
+### Phase 3 – Post‑Deploy Validation
+
+1. Confirm all pods show `Running`:
+   ```bash
+   kubectl get pods
+   ```
+2. Ensure the NVIDIA device plugin reports a GPU if one is present.
+3. Trigger a panic test to verify alerts:
+   ```bash
+   curl -X POST http://localhost:8080/api/test/panic
+   ```
+   ⚠️ **Test endpoints operate only in sandbox mode.**
+4. Use the dashboard **Resume Trading** button to clear the panic state and check logs for `[RESUME SIGNAL RECEIVED]`.
+5. Validate Prometheus and Grafana dashboards if installed.
 
 ---
 
 ## Environment & Secrets
 
-All production credentials are stored as SealedSecrets.  Never commit plain `.env` files.  `test/verify-env.sh` fails if unsealed secrets or `.env.sandbox` exist in the repository.
-
-To seal a new secret:
-
+Never commit plain `.env` files. Use [SealedSecrets](https://github.com/bitnami-labs/sealed-secrets) to encrypt credentials:
 ```bash
-kubectl create secret generic api-keys --from-literal=API_KEY=abc123 \
+kubectl create secret generic api-secrets --from-env-file=api/.env \
   --dry-run=client -o yaml > secret.yaml
-kubeseal < secret.yaml > sealed-secret.yaml
-```
-
-Commit the sealed file and apply it during deployment:
-
-```bash
-kubectl apply -f sealed-secret.yaml
+kubeseal < secret.yaml > sealed-api.yaml
+kubectl apply -f sealed-api.yaml
 ```
 
 ---
 
-## Running Tests
+## Testing
 
 Run all mocked tests locally:
 ```bash
 ./test/run-local.sh
 ```
-For the optional live dry‑run suite:
-```bash
-./test/run-live.sh
-```
-
-Individual service tests can be run with `npm test`, `pytest`, or `./gradlew test`.
-
----
-
-## Continuous Integration
-
-GitHub Actions enforces safety gates:
-
-1. `test/verify-env.sh` blocks plaintext secrets or unsealed manifests.
-2. Each service runs unit tests and ESLint/flake8 checks.
-3. Containers build with Podman and are scanned by Trivy.
-4. Kubernetes manifests are validated with kubeconform and a dry‑run apply.
-5. All Actions are pinned to commit SHAs for reproducibility.
-
-Run `bash test/verify-env.sh` before pushing to mirror the CI checks.
-
----
-
-## Live Trade Simulation
-
-Enable ghost mode in settings or run:
-```bash
-node scripts/mock-ghost-feed.js --pair BTC-USD
-```
-Trades stream through Redis and appear on the dashboard.  Disable ghost mode for real trading.
-
----
-
-## Monitoring
-
-- **Sentry** captures runtime exceptions.
-- **Prometheus** scrapes `/metrics/live` or `/metrics/sandbox`.
-- **StatusCake** monitors public endpoints using the API token and contact group defined in `.env.example`.
-
-Port‑forward services locally to inspect metrics:
-```bash
-kubectl -n arbitrage port-forward svc/api 9100:8080 &
-kubectl -n arbitrage port-forward svc/executor 9200:9100 &
-kubectl -n arbitrage port-forward svc/analytics 9300:5000 &
-
-curl http://localhost:9100/api/metrics/live
-curl http://localhost:9100/api/metrics/sandbox
-curl http://localhost:9200/metrics
-curl http://localhost:9300/metrics
-```
-
----
-
-## ML Training Pipeline
-
-1. Export features:
-   ```bash
-   python analytics/train/export_features.py
-   ```
-2. Retrain the LSTM model:
-   ```bash
-   python analytics/train/retrain.py --epochs 10
-   ```
-3. Swap to a previous model if required:
-   ```bash
-   python analytics/model_swap.py --version <hash>
-   ```
-
-Model versions are stored in `analytics/models/archive` and tracked via SHA256 hashes.
-
----
-
-## Deployment
-
-Deploy or upgrade services using Helm:
-```bash
-./scripts/ops-tools.sh start
-```
-Check pod status:
-```bash
-./scripts/ops-tools.sh status
-```
-
-See [docs/ops/helm-rollback-guide.MD](docs/ops/helm-rollback-guide.MD) for rollback instructions.
 
 ---
 
 ## System Documentation
 
-Additional architecture, strategy, and operations guides are in the [`docs/`](docs/) directory.
+Additional guides are located in the [`docs/`](docs/) directory, including [dashboard instructions](docs/dashboard.md), [SMTP setup](docs/smtp_setup.md), and [Telegram setup](docs/telegram_setup.md).
 
 ## License
 

--- a/analytics/.env.example
+++ b/analytics/.env.example
@@ -1,6 +1,6 @@
 # Flask environment mode (development | production)
 FLASK_ENV=development
-# Path to machine learning model (can be .h5 or .joblib)
+# Path to machine learning model
 MODEL_PATH=model.h5
 # Path to optional shadow model
 MODEL_SHADOW_PATH=model_shadow.h5
@@ -9,7 +9,7 @@ MODEL_SHADOW_PATH=model_shadow.h5
 PGHOST=localhost
 PGPORT=5432
 PGUSER=postgres
-PGPASSWORD=
+PGPASSWORD=postgres
 PGDATABASE=arbdb
 
 # Log level for analytics service

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,28 +1,27 @@
 # Secret used to sign JWT tokens
-JWT_SECRET=
+JWT_SECRET=local_secret
 # Token required for admin endpoints
-ADMIN_TOKEN=
+ADMIN_TOKEN=local_admin
 
 # Database host
-PGHOST=
+PGHOST=localhost
 # Database port
 PGPORT=5432
 # Database user
-PGUSER=
+PGUSER=postgres
 # Database password
-PGPASSWORD=
+PGPASSWORD=postgres
 # Database name
-PGDATABASE=
+PGDATABASE=arbdb
 
 # SMTP server host (defaults to smtp.gmail.com)
-SMTP_HOST=
-
+SMTP_HOST=smtp.gmail.com
 # SMTP username for outgoing mail
-SMTP_USER=
-# SMTP password for outgoing mail
+SMTP_USER=alerts@example.com
+# SMTP password for outgoing mail (use Gmail app password)
 SMTP_PASS=
 # Email recipient for alerts
-ALERT_RECIPIENT=
+ALERT_RECIPIENT=ops@example.com
 
 # Telegram bot token
 TELEGRAM_TOKEN=
@@ -35,21 +34,20 @@ WEBHOOK_URL=
 # Sentry DSN for error tracking
 SENTRY_DSN=
 
-# Redis connection
+# Redis connection host
 REDIS_HOST=127.0.0.1
+# Redis connection port
 REDIS_PORT=6379
 # WebSocket server port
 WS_PORT=8070
 # Prometheus base URL
 PROM_URL=http://prometheus:9090
-# Logging level (info, debug)
+# Logging level (info or debug)
 LOG_LEVEL=info
 
 # Enable sandbox login mode (true/false)
-SANDBOX_MODE=
-
+SANDBOX_MODE=true
 # Node.js runtime mode (development, production, test)
-NODE_ENV=
-
+NODE_ENV=development
 # Test suite environment (local, live)
-TEST_ENV=
+TEST_ENV=local

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -2,3 +2,5 @@
 VITE_ENABLE_SENTRY=false
 # Sentry DSN for React errors
 VITE_SENTRY_DSN=
+# API endpoint base URL
+VITE_API_URL=http://localhost:8080

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,34 @@
+# Dashboard Operations Guide
+
+The Prism dashboard is a mobile-friendly React application served from the API service. Operators use it to view metrics and control trading.
+
+## Key Features
+
+- **Mode Toggle** – switch between `live` and `sandbox` execution.
+- **Loss Cap Control** – adjust the daily loss percentage cap.
+- **Resume Trading Button** – clears any panic state and restarts trading once risks are resolved.
+
+The banner at the top of the UI shows the current mode and whether the panic brake is active.
+
+## Usage Steps
+
+1. Open the dashboard at `http://<server-ip>:3000` and log in with your account.
+2. Confirm the banner color:
+   - Green = trading live
+   - Orange = sandbox (dry-run)
+   - Red = panic brake engaged
+3. Use the **Settings** panel to change personality mode or update the loss cap. Saving pushes settings to the API.
+4. If a panic event occurs, a **Resume Trading** button appears. Investigate logs, then click the button to send `POST /api/resume`.
+5. The banner returns to green or orange once the API acknowledges the resume signal.
+
+## Recovery Notes
+
+If the dashboard becomes unresponsive:
+
+1. Check pod status with `kubectl get pods` and ensure `api` and `dashboard` are healthy.
+2. You can trigger a resume manually:
+   ```bash
+   curl -X POST http://<server-ip>:8080/api/test/resume
+   ```
+   ⚠️ **Test endpoints only work in dry-run mode.**
+3. Reload the page. If the banner stays red, verify the executor logs for `[RESUME-BLOCKED]` messages.

--- a/docs/smtp_setup.md
+++ b/docs/smtp_setup.md
@@ -1,0 +1,36 @@
+# SMTP Alert Setup
+
+This guide configures email alerts through Gmail. Use an application password and store it securely via SealedSecrets.
+
+## Steps
+
+1. Create a Gmail app password for your account.
+2. Copy `api/.env.example` to `api/.env` and set:
+   ```env
+   SMTP_HOST=smtp.gmail.com
+   SMTP_USER=<your address>
+   SMTP_PASS=<app password>
+   ALERT_RECIPIENT=<destination address>
+   ```
+3. Seal the secret before committing:
+   ```bash
+   kubectl create secret generic smtp-creds \
+     --from-env-file=api/.env \
+     --dry-run=client -o yaml > secret.yaml
+   kubeseal < secret.yaml > sealed-smtp.yaml
+   rm secret.yaml
+   ```
+4. Apply the sealed secret during deployment:
+   ```bash
+   kubectl apply -f sealed-smtp.yaml
+   ```
+
+## Test the Alert
+
+Trigger a test alert once the API is running:
+```bash
+curl -X POST http://localhost:8080/api/test/panic
+```
+⚠️ **The `/api/test/panic` endpoint only functions in dry-run mode.**
+
+Check the logs for `Sending panic alert` and confirm the email arrived.

--- a/docs/telegram_setup.md
+++ b/docs/telegram_setup.md
@@ -1,0 +1,35 @@
+# Telegram Alert Setup
+
+Use a Telegram bot to receive panic and resume notifications.
+
+## Steps
+
+1. Create a new bot with [@BotFather](https://t.me/botfather) and copy the token.
+2. Obtain your chat ID by messaging the bot and visiting:
+   ```bash
+   curl https://api.telegram.org/bot<token>/getUpdates
+   ```
+3. Set the following in `api/.env`:
+   ```env
+   TELEGRAM_TOKEN=<bot token>
+   TELEGRAM_CHAT_ID=<chat id>
+   ```
+4. Seal the values as a secret:
+   ```bash
+   kubectl create secret generic telegram-creds \
+     --from-env-file=api/.env \
+     --dry-run=client -o yaml > tg.yaml
+   kubeseal < tg.yaml > sealed-telegram.yaml
+   rm tg.yaml
+   kubectl apply -f sealed-telegram.yaml
+   ```
+
+## Send a Test Message
+
+Run the API locally and trigger an alert:
+```bash
+curl -X POST http://localhost:8080/api/test/panic
+```
+⚠️ **Test endpoints are disabled in production mode.**
+
+Check Telegram for the "Trading Paused" notification.

--- a/executor/.env.example
+++ b/executor/.env.example
@@ -14,7 +14,7 @@ LATENCY_MAX_MS=250
 WIN_RATE_THRESHOLD=0.5
 
 # Prediction service endpoint
-PREDICT_URL=
+PREDICT_URL=http://localhost:5000/predict
 # Circuit breaker thresholds
 CB_WIN_RATE_THRESHOLD=0.35
 CB_MAX_DRAWDOWN_PCT=5.0
@@ -23,7 +23,7 @@ MAX_OPEN_TRADES=5
 # Feature flags
 CANARY_MODE=false
 GHOST_MODE=false
-SANDBOX_MODE=false
+SANDBOX_MODE=true
 USE_ENSEMBLE=true
 
 # Sandbox exchange settings
@@ -37,7 +37,7 @@ TEST_COLD_WALLET_ADDRESS=test_wallet_addr
 PGHOST=localhost
 PGPORT=5432
 PGUSER=postgres
-PGPASSWORD=
+PGPASSWORD=postgres
 PGDATABASE=arbdb
 DB_RETRIES=3
 DB_RETRY_DELAY_MS=2000


### PR DESCRIPTION
## Summary
- rewrite README with phased deployment instructions and links to new guides
- document dashboard usage and recovery controls
- add SMTP and Telegram setup guides
- provide dry-run defaults in all `.env.example` files

## Testing
- `bash test/run-local.sh`

------
https://chatgpt.com/codex/tasks/task_b_687ec5738da8832cb8df16d625a0549e