### PR TITLE
Convert Redis and Postgres to Helm StatefulSets with persistence

### DIFF
--- a/infra/helm/templates/postgres.yaml
+++ b/infra/helm/templates/postgres.yaml
@@ -1,11 +1,13 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: postgres
+  name: {{ .Release.Name }}-postgres
   labels:
     app: postgres
+    {{- include "crypto-arbitrage.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  serviceName: {{ .Release.Name }}-postgres
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: postgres
@@ -19,9 +21,6 @@ spec:
           image: postgres:16-alpine
           ports:
             - containerPort: 5432
-          volumeMounts:
-            - name: postgres-data
-              mountPath: /var/lib/postgresql/data
           envFrom:
             - secretRef:
                 name: postgres-secrets
@@ -42,15 +41,24 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
-      volumes:
-        - name: postgres-data
-          persistentVolumeClaim:
-            claimName: postgres-data
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - {{ .Values.postgres.accessMode }}
+        storageClassName: {{ .Values.postgres.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres
+  name: {{ .Release.Name }}-postgres
   labels:
     app: postgres
 spec:

--- a/infra/helm/templates/redis.yaml
+++ b/infra/helm/templates/redis.yaml
@@ -1,11 +1,13 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: redis
+  name: {{ .Release.Name }}-redis
   labels:
     app: redis
+    {{- include "crypto-arbitrage.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  serviceName: {{ .Release.Name }}-redis
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: redis
@@ -36,11 +38,24 @@ spec:
             limits:
               cpu: "100m"
               memory: "128Mi"
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes:
+          - {{ .Values.redis.accessMode }}
+        storageClassName: {{ .Values.redis.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis
+  name: {{ .Release.Name }}-redis
   labels:
     app: redis
 spec:

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -87,3 +87,13 @@ feedAggregator:
     # REDIS_PORT: "6379"
     # ORDERBOOK_CHANNEL: "orderbook"
     # ALERT_CHANNEL: "alerts"
+
+redis:
+  storage: 5Gi
+  storageClass: standard
+  accessMode: ReadWriteOnce
+
+postgres:
+  storage: 10Gi
+  storageClass: standard
+  accessMode: ReadWriteOnce


### PR DESCRIPTION
## Summary
- deploy Redis via Helm-managed StatefulSet with PVC
- deploy Postgres via Helm-managed StatefulSet with PVC
- add storage defaults for Redis and Postgres in `values.yaml`
- remove old `infra/k8s` Redis and Postgres manifests

## Testing
- `helm lint infra/helm` *(fails: Chart.yaml apiVersion is required)*

------
https://chatgpt.com/codex/tasks/task_b_687ed21c8f84832c83d0cd6fbc296ddf