### PR TITLE
Add metadata annotations for SealedSecrets

### DIFF
--- a/infra/helm/templates/sealed-secret.yaml
+++ b/infra/helm/templates/sealed-secret.yaml
@@ -5,6 +5,10 @@ kind: SealedSecret
 metadata:
   name: api-secrets
   namespace: default
+  annotations:
+    prism.one/commit: "{{ .Values.gitCommit }}"
+    prism.one/env: "{{ .Values.environment }}"
+    prism.one/createdBy: "prism-seal"
 spec:
   encryptedData:
     binanceKey: AgFAKEENCRYPTEDBINANCEKEY
@@ -16,6 +20,10 @@ kind: SealedSecret
 metadata:
   name: prod-secrets
   namespace: default
+  annotations:
+    prism.one/commit: "{{ .Values.gitCommit }}"
+    prism.one/env: "{{ .Values.environment }}"
+    prism.one/createdBy: "prism-seal"
 spec:
   encryptedData:
     PGHOST: AgFAKEENCRYPTEDPGHOST

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -1,5 +1,7 @@
 # Helm default values for Kubernetes deployment
 replicaCount: 1
+gitCommit: "unset"
+environment: "unset"
 # SealedSecrets required — CI fails if plain Secrets are used
 secrets:
   useSealed: true  # must remain true; unsealed secrets are rejected in CI


### PR DESCRIPTION
## Summary
- annotate helm `SealedSecret` templates with commit, env and createdBy
- allow overriding metadata via new `gitCommit` and `environment` values

## Testing
- `npm --prefix dashboard test -- --runInBand` *(fails: ResumeButton.test)*
- `npm --prefix api test -- --runInBand`
- `pytest`
- `executor/gradlew test -p executor -PtestEnv=local`


------
https://chatgpt.com/codex/tasks/task_b_687ed448d520832c955da443430c532d