### PR TITLE
Add readiness/liveness probes

### DIFF
--- a/infra/helm/templates/api-deployment.yaml
+++ b/infra/helm/templates/api-deployment.yaml
@@ -29,15 +29,15 @@ spec:
               mountPath: /var/log/prism-arbitrage
           readinessProbe:
             httpGet:
-              path: /api/metrics
+              path: /health
               port: {{ .Values.api.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: 5
+            periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /api/metrics
+              path: /health
               port: {{ .Values.api.port }}
-            initialDelaySeconds: 10
+            failureThreshold: 3
             periodSeconds: 10
       volumes:
         - name: prism-logs

--- a/infra/helm/templates/gpu-plugin-daemonset.yaml
+++ b/infra/helm/templates/gpu-plugin-daemonset.yaml
@@ -29,6 +29,16 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+        readinessProbe:
+          exec:
+            command: ["nvidia-smi"]
+          initialDelaySeconds: 10
+          periodSeconds: 20
+        livenessProbe:
+          exec:
+            command: ["nvidia-smi"]
+          failureThreshold: 5
+          periodSeconds: 30
         volumeMounts:
           - name: device-plugin
             mountPath: /var/lib/kubelet/device-plugins

--- a/infra/helm/templates/postgres.yaml
+++ b/infra/helm/templates/postgres.yaml
@@ -24,15 +24,15 @@ spec:
           envFrom:
             - secretRef:
                 name: postgres-secrets
-          livenessProbe:
-            tcpSocket:
-              port: 5432
-            initialDelaySeconds: 10
-            periodSeconds: 10
           readinessProbe:
-            tcpSocket:
-              port: 5432
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
             initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            failureThreshold: 3
             periodSeconds: 10
           resources:
             requests:

--- a/infra/helm/templates/redis.yaml
+++ b/infra/helm/templates/redis.yaml
@@ -21,15 +21,15 @@ spec:
           image: redis:7.2-alpine
           ports:
             - containerPort: 6379
-          livenessProbe:
-            tcpSocket:
-              port: 6379
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
             initialDelaySeconds: 5
             periodSeconds: 10
-          readinessProbe:
-            tcpSocket:
-              port: 6379
-            initialDelaySeconds: 5
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            failureThreshold: 3
             periodSeconds: 10
           resources:
             requests:


### PR DESCRIPTION
## Summary
- configure HTTP health checks for the API service
- use exec `redis-cli ping` probes for Redis
- add `pg_isready` probes for Postgres
- add `nvidia-smi` probes for GPU plugin daemonset

## Testing
- `npm --prefix dashboard test -- --runInBand` *(fails: button disabled with tooltip when resume blocked)*
- `npm --prefix api test -- --runInBand`
- `executor/gradlew test -PtestEnv=local`
- `pytest -m env\("local"\)` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_687ed72dcd38832ca14171205ea8e072