### PR TITLE
Resume alerting, Redis fix, secure login, log persistence, SMTP check (Batch 4)

### DIFF
--- a/analytics/conftest.py
+++ b/analytics/conftest.py
@@ -31,6 +31,7 @@ def analytics_app(monkeypatch):
     prom.CollectorRegistry = lambda: None
     prom.Counter = lambda *a, **kw: types.SimpleNamespace(inc=lambda *args: None)
     prom.Histogram = lambda *a, **kw: types.SimpleNamespace(observe=lambda *args: None)
+    prom.Gauge = lambda *a, **kw: types.SimpleNamespace(set=lambda *args: None)
     prom.ProcessCollector = lambda *a, **kw: None
     prom.GCCollector = lambda *a, **kw: None
     prom.generate_latest = lambda reg=None: b""

--- a/analytics/logger.py
+++ b/analytics/logger.py
@@ -1,15 +1,21 @@
 import logging
+import logging.handlers
 import os
+import urllib.parse
 
 level = os.getenv("LOG_LEVEL", "INFO").upper()
 log_dir = os.getenv("LOG_DIR", "/var/log/prism-arbitrage")
 os.makedirs(log_dir, exist_ok=True)
-logging.basicConfig(
-    level=level,
-    format="%(asctime)s %(levelname)s %(message)s",
-    handlers=[
-        logging.StreamHandler(),
-        logging.FileHandler(os.path.join(log_dir, "analytics.log")),
-    ],
-)
+handlers = [
+    logging.StreamHandler(),
+    logging.FileHandler(os.path.join(log_dir, "analytics.log")),
+]
+forward_url = os.getenv("LOKI_URL") or os.getenv("LOG_FORWARD_URL")
+if forward_url:
+    parsed = urllib.parse.urlparse(forward_url)
+    handlers.append(
+        logging.handlers.HTTPHandler(parsed.netloc, parsed.path, method="POST")
+    )
+
+logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(message)s", handlers=handlers)
 logger = logging.getLogger("analytics")

--- a/api/__tests__/alertManager.test.js
+++ b/api/__tests__/alertManager.test.js
@@ -1,12 +1,12 @@
 import { jest } from '@jest/globals';
 
-jest.mock('../alerts/emailAlert.js', () => ({
+jest.mock('../../alerts/emailAlert.js', () => ({
   sendEmail: jest.fn(() => {
     throw new Error('fail');
   })
 }));
 
-import { sendAlert } from '../alerts/alertAgent.js';
+import { sendAlert } from '../../alerts/alertAgent.js';
 
 describe('sendAlert error handling', () => {
   beforeEach(() => {

--- a/api/__tests__/api.test.js
+++ b/api/__tests__/api.test.js
@@ -196,6 +196,7 @@ describeLocal('API authentication', () => {
     });
 
   test('POST /alerts/test/email returns 200', async () => {
+    process.env.SANDBOX_MODE = 'true';
     const login = await request(app.server)
       .post('/api/login')
       .send({ email: 'user', password: 'pass' });
@@ -204,6 +205,20 @@ describeLocal('API authentication', () => {
       .post('/api/alerts/test/email')
       .set('Cookie', cookie);
     expect(res.statusCode).toBe(200);
+    delete process.env.SANDBOX_MODE;
+  });
+
+  test('GET /alerts/verify returns 200', async () => {
+    process.env.SANDBOX_MODE = 'true';
+    const login = await request(app.server)
+      .post('/api/login')
+      .send({ email: 'user', password: 'pass' });
+    const cookie = login.headers['set-cookie'][0].split(';')[0];
+    const res = await request(app.server)
+      .get('/api/alerts/verify')
+      .set('Cookie', cookie);
+    expect(res.statusCode).toBe(200);
+    delete process.env.SANDBOX_MODE;
   });
 
   test('/infra/status returns infra summary', async () => {

--- a/api/config/settings.js
+++ b/api/config/settings.js
@@ -30,4 +30,8 @@ export function getExecutionMode(req) {
   return settings.sandbox_mode ? ExecutionMode.SANDBOX : ExecutionMode.LIVE;
 }
 
+export function getControlChannel() {
+  return `control-feed-${process.env.NODE_ENV || 'development'}`;
+}
+
 export default settings;

--- a/api/index.js
+++ b/api/index.js
@@ -18,8 +18,10 @@ import analyticsRoutes from './routes/analytics.js';
 import cgtRoutes from './routes/cgt.js';
 import resumeRoutes from './routes/resume.js';
 import configRoutes from './routes/config.js';
+import { getControlChannel } from './config/settings.js';
 import { baseOpenPaths } from './lib/constants.js';
 import { sendAlert } from '../alerts/alertAgent.js';
+import { sendEmail } from '../alerts/emailAlert.js';
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
 import { start as startWsServer } from './services/wsServer.js';
 
@@ -181,6 +183,21 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
     }
   });
 
+  api.get('/alerts/verify', async (req, reply) => {
+    if (process.env.SANDBOX_MODE !== 'true') {
+      return reply.code(403).send();
+    }
+    try {
+      await sendAlert('email', 'Alert verification');
+      req.log.info('SMTP verification sent');
+      return { sent: true };
+    } catch (err) {
+      req.log.error('SMTP verify failed', err);
+      reply.code(500);
+      return { error: 'failed' };
+    }
+  });
+
 
   api.post('/logout', async (req, reply) => {
     reply.clearCookie('token');
@@ -200,7 +217,7 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
         }
         testState.paused = true;
         testState.panicReason = req.body?.type || null;
-        await redis.publish('control-feed', 'halt');
+        await redis.publish(getControlChannel(), 'halt');
         await sendAlert('email', 'Panic brake triggered (test mode)');
         return { triggered: true };
       });
@@ -215,7 +232,7 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
         }
         testState.paused = false;
         testState.panicReason = null;
-        await redis.publish('control-feed', 'resume');
+        await redis.publish(getControlChannel(), 'resume');
         return { resumed: true };
       });
 
@@ -224,7 +241,7 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
           return reply.code(403).send();
         }
         logger.info('[DRY-RUN MODE] Cold wallet sweep logic verified. No assets moved.');
-        await redis.publish('control-feed', 'sweep');
+        await redis.publish(getControlChannel(), 'sweep');
         return { swept: true };
       });
     }

--- a/api/middleware/validate.js
+++ b/api/middleware/validate.js
@@ -1,0 +1,25 @@
+export function requireFields(fields) {
+  return async function(req, reply) {
+    for (const field of fields) {
+      if (!req.body || req.body[field] === undefined || req.body[field] === '') {
+        reply.code(400);
+        reply.send({ error: `${field} required` });
+        return;
+      }
+    }
+  };
+}
+
+export function ensurePaused(testState) {
+  return async function(_req, reply) {
+    if (testState && !testState.paused) {
+      reply.code(400);
+      reply.send({ error: 'not paused' });
+      return;
+    }
+    if (testState) {
+      testState.paused = false;
+      testState.panicReason = null;
+    }
+  };
+}

--- a/api/routes/login.js
+++ b/api/routes/login.js
@@ -13,8 +13,13 @@ export default async function loginRoutes(app) {
   app.post('/login', async (req, reply) => {
     const { email, password } = req.body;
 
+    const cookieOpts = { httpOnly: true };
+    if (process.env.NODE_ENV === 'production') {
+      cookieOpts.secure = true;
+    }
+
     if (sandboxMode && email === SANDBOX_EMAIL && password === SANDBOX_PASS) {
-      reply.setCookie('token', HARD_CODED_JWT, { httpOnly: true });
+      reply.setCookie('token', HARD_CODED_JWT, cookieOpts);
       return { token: HARD_CODED_JWT };
     }
 
@@ -28,7 +33,7 @@ export default async function loginRoutes(app) {
         role: user?.isAdmin ? 'admin' : 'user',
       };
       const token = app.jwt.sign(payload, { algorithm: 'HS256' });
-      reply.setCookie('token', token, { httpOnly: true });
+      reply.setCookie('token', token, cookieOpts);
       return { token };
     }
 

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -1,18 +1,30 @@
 import { requireAdmin } from '../middleware/auth.js';
+import { sendAlert } from '../../alerts/alertAgent.js';
+import { getControlChannel } from '../config/settings.js';
+import { ensurePaused } from '../middleware/validate.js';
 
 export default async function resumeRoutes(app, opts) {
   const { redis, testState } = opts;
 
-  app.post('/resume', { preHandler: requireAdmin }, async (_req, reply) => {
-    if (testState && !testState.paused) {
-      reply.code(400);
-      return { error: 'not paused' };
+  app.post(
+    '/resume',
+    { preHandler: [requireAdmin, ensurePaused(testState)] },
+    async (req, reply) => {
+    const channel = getControlChannel();
+    await redis.publish(channel, 'resume');
+    const user = req.user?.email || 'unknown';
+    const msg = `Trading resumed by ${user} at ${new Date().toISOString()}`;
+    await redis.publish('alerts', msg);
+    if (process.env.SANDBOX_MODE !== 'true') {
+      try {
+        await sendAlert('email', msg);
+      } catch (err) {
+        req.log.error('Resume alert failed', err);
+      }
+    } else {
+      req.log.info(`[DRY-RUN] Resume alert: ${msg}`);
     }
-    if (testState) {
-      testState.paused = false;
-      testState.panicReason = null;
-    }
-    await redis.publish('control-feed', 'resume');
     return { resumed: true };
-  });
+  }
+  );
 }

--- a/api/routes/users.js
+++ b/api/routes/users.js
@@ -1,4 +1,5 @@
 import { listUsers, addUser, updatePassword, removeUser } from './userStore.js';
+import { requireFields } from '../middleware/validate.js';
 
 export default async function userRoutes(app) {
   app.addHook('preHandler', async (req, reply) => {
@@ -9,23 +10,15 @@ export default async function userRoutes(app) {
 
   app.get('/', async () => listUsers());
 
-  app.post('/', async (req, reply) => {
+  app.post('/', { preHandler: requireFields(['email', 'password']) }, async (req) => {
     const { email, password, isAdmin } = req.body;
-    if (!email || !password) {
-      reply.code(400);
-      return { error: 'email and password required' };
-    }
     const user = await addUser(email, password, !!isAdmin);
     return user;
   });
 
-  app.put('/:id', async (req, reply) => {
+  app.put('/:id', { preHandler: requireFields(['password']) }, async (req, reply) => {
     const { id } = req.params;
     const { password } = req.body;
-    if (!password) {
-      reply.code(400);
-      return { error: 'password required' };
-    }
     const updated = await updatePassword(id, password);
     if (!updated) {
       reply.code(404);

--- a/api/services/logger.js
+++ b/api/services/logger.js
@@ -1,4 +1,5 @@
 import winston from 'winston';
+import axios from 'axios';
 import fs from 'fs';
 
 const logDir = process.env.LOG_DIR || '/var/log/prism-arbitrage';
@@ -8,6 +9,26 @@ if (!fs.existsSync(logDir)) {
 
 const service = process.env.SERVICE_NAME || 'api';
 
+class HttpTransport extends winston.Transport {
+  constructor(opts) {
+    super(opts);
+    this.url = opts.url;
+  }
+  log(info, callback) {
+    axios.post(this.url, info).catch(() => {});
+    callback();
+  }
+}
+
+const transports = [
+  new winston.transports.Console(),
+  new winston.transports.File({ filename: `${logDir}/${service}.log` }),
+];
+const forwardUrl = process.env.LOKI_URL || process.env.LOG_FORWARD_URL;
+if (forwardUrl) {
+  transports.push(new HttpTransport({ url: forwardUrl }));
+}
+
 const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
   format: winston.format.combine(
@@ -16,10 +37,7 @@ const logger = winston.createLogger({
       `${timestamp} ${level} [${service}] ${message}`
     )
   ),
-  transports: [
-    new winston.transports.Console(),
-    new winston.transports.File({ filename: `${logDir}/${service}.log` }),
-  ],
+  transports,
 });
 
 export default logger;

--- a/executor/src/main/java/CircuitBreaker.java
+++ b/executor/src/main/java/CircuitBreaker.java
@@ -33,7 +33,7 @@ public class CircuitBreaker {
             logger.error("CIRCUIT BREAKER TRIPPED winRate={} drawdownPct={}", winRate, drawdownPct);
             AlertManager.sendAlert("CIRCUIT BREAKER TRIPPED");
             redisClient.publish("alerts", "CIRCUIT BREAKER TRIPPED");
-            redisClient.publish("control-feed", "halt");
+            redisClient.publish(RedisClient.getControlChannel(), "halt");
         }
     }
 

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -11,6 +11,7 @@ import executor.ConfigValidator;
 import executor.CircuitBreaker;
 import executor.Config;
 import executor.ExecutionMode;
+import executor.RedisClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
@@ -85,7 +86,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         this.redisHost = redisHost;
         this.redisPort = redisPort;
         this.config = config == null ? new Config(ExecutionMode.LIVE) : config;
-        this.controlChannel = this.config.getExecutionMode() == ExecutionMode.LIVE ? "control-feed-live" : "control-feed-sandbox";
+        this.controlChannel = RedisClient.getControlChannel();
         this.riskFilter = riskFilter;
         this.nearMissLogger = nearMissLogger;
         this.scoringEngine = new ScoringEngine();
@@ -384,7 +385,10 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     public void resumeTrading() {
         if (isPanic.compareAndSet(true, false)) {
             circuitBreaker.reset();
-            logger.info("[RESUME SIGNAL RECEIVED] reason=manual ts={}", System.currentTimeMillis());
+            long ts = System.currentTimeMillis();
+            logger.info("[RESUME SIGNAL RECEIVED] reason=manual ts={}", ts);
+            AlertManager.sendAlert("Trading resumed at " + ts);
+            redisClient.publish("alerts", "Trading resumed at " + ts);
         } else {
             logger.warn("[RESUME IGNORED] already active");
         }
@@ -396,7 +400,10 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     public void resumeFromPanic() {
         if (isPanic.compareAndSet(true, false)) {
             circuitBreaker.reset();
-            logger.info("[RESUME SIGNAL RECEIVED] reason=control ts={}", System.currentTimeMillis());
+            long ts = System.currentTimeMillis();
+            logger.info("[RESUME SIGNAL RECEIVED] reason=control ts={}", ts);
+            AlertManager.sendAlert("Trading resumed at " + ts);
+            redisClient.publish("alerts", "Trading resumed at " + ts);
         } else {
             logger.warn("[RESUME IGNORED] already active");
         }

--- a/executor/src/main/java/RedisClient.java
+++ b/executor/src/main/java/RedisClient.java
@@ -69,6 +69,11 @@ public class RedisClient extends Thread {
         }
     }
 
+    static String getControlChannel() {
+        String env = System.getenv().getOrDefault("NODE_ENV", "development");
+        return "control-feed-" + env;
+    }
+
     /**
      * Publish a message to the given channel.
      *
@@ -87,12 +92,12 @@ public class RedisClient extends Thread {
      * Publish a message to the control channel derived from execution mode.
      */
     public void publishControl(Config config, String message) {
+        String channel;
         if (config == null) {
-            publish("control-feed-live", message);
-            return;
+            channel = getControlChannel();
+        } else {
+            channel = getControlChannel();
         }
-        String channel = config.getExecutionMode() == ExecutionMode.LIVE
-                ? "control-feed-live" : "control-feed-sandbox";
         publish(channel, message);
     }
 
@@ -141,12 +146,12 @@ public class RedisClient extends Thread {
      * Subscribe to the control channel derived from execution mode.
      */
     public void subscribeControl(Config config, Consumer<String> handler) {
+        String channel;
         if (config == null) {
-            subscribe("control-feed-live", handler);
-            return;
+            channel = getControlChannel();
+        } else {
+            channel = getControlChannel();
         }
-        String channel = config.getExecutionMode() == ExecutionMode.LIVE
-                ? "control-feed-live" : "control-feed-sandbox";
         subscribe(channel, handler);
     }
 

--- a/executor/src/main/java/ResumeHandler.java
+++ b/executor/src/main/java/ResumeHandler.java
@@ -2,6 +2,7 @@ package executor;
 
 
 import executor.Executor;
+import executor.RedisClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,7 +11,7 @@ import org.slf4j.LoggerFactory;
  * associated executor when trading should continue.
  */
 public class ResumeHandler {
-    private static final String CHANNEL = "control-feed";
+    private static final String CHANNEL = RedisClient.getControlChannel();
      private static final Logger logger = LoggerFactory.getLogger(ResumeHandler.class);
 
     private final Object redis;

--- a/executor/src/main/java/SweepHandler.java
+++ b/executor/src/main/java/SweepHandler.java
@@ -2,12 +2,13 @@ package executor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import executor.RedisClient;
 
 /**
  * Listens for "sweep" commands on a Redis channel and triggers the cold wallet sweep.
  */
 public class SweepHandler {
-    private static final String CHANNEL = "control-feed";
+    private static final String CHANNEL = RedisClient.getControlChannel();
     private static final Logger logger = LoggerFactory.getLogger(SweepHandler.class);
 
     private final Object redis;

--- a/executor/src/test/java/CircuitBreakerTest.java
+++ b/executor/src/test/java/CircuitBreakerTest.java
@@ -21,7 +21,7 @@ public class CircuitBreakerTest {
         CircuitBreaker cb = new CircuitBreaker(client, 0.5, 5.0);
         cb.check(0.4, 1.0);
         assertTrue(cb.isTripped());
-        assertEquals("control-feed", client.channel);
+        assertEquals(RedisClient.getControlChannel(), client.channel);
         assertEquals("halt", client.message);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.10.0",
-        "ioredis": "^5.6.1",
-        "minimist": "^1.2.8",
-        "pg": "^8.16.3"
+        "axios": "1.10.0",
+        "ioredis": "5.6.1",
+        "minimist": "1.2.8",
+        "nodemailer": "7.0.5",
+        "pg": "8.16.3"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -379,6 +380,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/pg": {
       "version": "8.16.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "1.10.0",
     "minimist": "1.2.8",
     "pg": "8.16.3",
-    "ioredis": "5.6.1"
+    "ioredis": "5.6.1",
+    "nodemailer": "7.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- enforce secure cookie flag for login
- alert operators on resume and unify control channel
- share request validation middleware
- add `/alerts/verify` endpoint for SMTP testing
- optionally forward logs to persistent or remote collector

## Testing
- `npm test`
- `pytest -q`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_687fcbb4c254832cb7c73a29d0c5bf8e