### PR TITLE
Fix dashboard polling, pause/resume controls, live metrics, and API sync (Batch 6)

### DIFF
--- a/dashboard/src/components/SystemStatusBanner.jsx
+++ b/dashboard/src/components/SystemStatusBanner.jsx
@@ -7,8 +7,8 @@ export default function SystemStatusBanner() {
 
   async function loadStatus() {
     try {
-      const data = await fetchSystemStatus(mode);
-      setMode(data.mode);
+      const data = await fetchSystemStatus();
+      if (data.mode) setMode(data.mode);
       setPanic(Boolean(data.panic));
     } catch (err) {
       console.error('Failed to fetch system status', err);

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -67,3 +67,15 @@ button:focus-visible {
   }
 }
 
+@media (max-width: 768px) {
+  body {
+    @apply p-2;
+  }
+}
+
+@media (min-width: 768px) {
+  body {
+    @apply p-4;
+  }
+}
+

--- a/dashboard/src/pages/Dashboard.jsx
+++ b/dashboard/src/pages/Dashboard.jsx
@@ -1,33 +1,55 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSystemStatus } from '../context/SystemStatusContext.jsx';
 import LiveMetrics from '../../components/LiveMetrics.jsx';
+import ResumeButton from '../components/ResumeButton.jsx';
+import { fetchSystemStatus, fetchWalletBalance } from '../utils/api.js';
 
 export default function Dashboard() {
   const [mode, setMode] = useState('auto');
-  const [status] = useState('green');
-  const walletBalance = '$0.00';
-  const { panic, reason, refreshStatus } = useSystemStatus();
+  const [walletBalance, setWalletBalance] = useState(null);
+  const [metrics, setMetrics] = useState({ equityCurve: [], latency: [], openTrades: [], winRate: [] });
+  const { panic, refreshStatus } = useSystemStatus();
 
-  async function handleResume() {
-    try {
-      const res = await fetch('/api/resume', { method: 'POST' });
-      if (res.ok) {
-        await refreshStatus();
+  useEffect(() => {
+    async function load() {
+      try {
+        const balance = await fetchWalletBalance();
+        setWalletBalance(balance.balance);
+      } catch (err) {
+        console.error('Failed to fetch wallet balance', err);
       }
-    } catch (err) {
-      console.error('Failed to resume trading', err);
+      try {
+        const status = await fetchSystemStatus();
+        if (status.mode) setMode(status.mode);
+      } catch (err) {
+        console.error('Failed to fetch status', err);
+      }
+      try {
+        const res = await fetch('/api/metrics');
+        if (res.ok) {
+          const data = await res.json();
+          setMetrics(data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch metrics', err);
+      }
+      refreshStatus();
     }
-  }
+    load();
+  }, [refreshStatus]);
 
   return (
     <div className="p-4 space-y-4 text-text">
       <h1 className="text-2xl font-bold">Arbitrage Summary</h1>
       <div className="bg-surface p-4 rounded shadow">
-        <LiveMetrics />
+        <LiveMetrics equity={metrics.equityCurve} latency={metrics.latency} />
       </div>
       <div className="bg-surface p-4 rounded shadow space-y-4">
         <div>
-          Wallet Balance: <span data-testid="wallet-balance">{walletBalance}</span>
+          Wallet Balance: <span data-testid="wallet-balance">{walletBalance ?? 'N/A'}</span>
+        </div>
+        <div>
+          Open Trades: {metrics.openTrades ? metrics.openTrades.length : 0}
         </div>
         <div className="space-x-2">
           {['auto', 'realistic', 'aggressive'].map((m) => (
@@ -44,21 +66,29 @@ export default function Dashboard() {
           System Status:
           <span
             data-testid="system-status"
-            className={`ml-2 font-semibold ${
-              status === 'green' ? 'text-green-600' : status === 'yellow' ? 'text-yellow-400' : 'text-red-600'
-            }`}
+            className={`ml-2 font-semibold ${panic ? 'text-red-600' : 'text-green-600'}`}
           >
-            {status}
+            {panic ? 'paused' : 'active'}
           </span>
+          {panic && <span className="ml-1 text-red-600">⚠️</span>}
         </div>
-        <button
-          className="bg-green-600 text-white px-3 py-1 rounded disabled:bg-gray-300 disabled:text-gray-500"
-          disabled={!panic}
-          title={`Panic triggered: ${reason} — click to resume`}
-          onClick={handleResume}
-        >
-          Resume Trading
-        </button>
+        <div className="space-x-2">
+          <button
+            className="bg-red-600 text-white px-3 py-1 rounded disabled:bg-gray-300 disabled:text-gray-500"
+            disabled={panic}
+            onClick={async () => {
+              try {
+                await fetch('/api/panic', { method: 'POST' });
+                await refreshStatus();
+              } catch (err) {
+                console.error('Failed to trigger panic', err);
+              }
+            }}
+          >
+            Pause Trading
+          </button>
+          <ResumeButton />
+        </div>
       </div>
     </div>
   );

--- a/dashboard/src/pages/Settings.jsx
+++ b/dashboard/src/pages/Settings.jsx
@@ -1,5 +1,5 @@
 // UI for adjusting trading personality mode
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 // PATCH selected mode to API
 async function saveSettings(mode) {
@@ -19,6 +19,23 @@ async function saveSettings(mode) {
 
 export default function Settings() {
   const [mode, setMode] = useState('auto');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings');
+        if (res.ok) {
+          const data = await res.json();
+          if (data.personality_mode) {
+            setMode(data.personality_mode.toLowerCase());
+          }
+        }
+      } catch (err) {
+        console.error('Failed to fetch settings', err);
+      }
+    }
+    load();
+  }, []);
 
   return (
     <div className="p-4 space-y-4 text-text">

--- a/dashboard/src/utils/api.js
+++ b/dashboard/src/utils/api.js
@@ -1,7 +1,15 @@
-export async function fetchSystemStatus(mode = 'live') {
-  const res = await fetch(`/status?mode=${mode}`);
+export async function fetchSystemStatus() {
+  const res = await fetch('/api/system/status');
   if (!res.ok) {
     throw new Error('Failed to fetch system status');
+  }
+  return res.json();
+}
+
+export async function fetchWalletBalance() {
+  const res = await fetch('/api/wallet/balance');
+  if (!res.ok) {
+    throw new Error('Failed to fetch wallet balance');
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- fix system banner polling endpoint
- add responsive layout
- sync live wallet balance and status from API
- connect dashboard metrics to Prometheus
- pause trading UI and icon for panic state
- fetch personality mode from backend

## Testing
- `npm test` within `dashboard`
- `npm test` within `api`

------
https://chatgpt.com/codex/tasks/task_b_687fd4721ca0832cacc7907e971037c7