### PR TITLE
Sync mode toggle, fix panic state, document secrets, enable log forwarding (Batch 7)

### DIFF
--- a/.env.sandbox.example
+++ b/.env.sandbox.example
@@ -1,3 +1,5 @@
 API_KEY=dry_run_key
+BINANCE_KEY=dummy123
+BINANCE_SECRET=dummy123
 REDIS_URL=redis://localhost:6379
 EXECUTION_MODE=sandbox

--- a/api/.env.example
+++ b/api/.env.example
@@ -2,6 +2,11 @@
 JWT_SECRET=local_secret
 # Token required for admin endpoints
 ADMIN_TOKEN=local_admin
+# API key for programmatic access
+API_KEY=dummy123
+# Binance API credentials
+BINANCE_KEY=dummy123
+BINANCE_SECRET=dummy123
 
 # Database host
 PGHOST=localhost

--- a/api/routes/settings.js
+++ b/api/routes/settings.js
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import logger from "../services/logger.js";
+import { setMode as setRiskFilterMode } from "../services/riskFilter.js";
 
 export let settings = {
   schema_version: 1,
@@ -110,7 +111,10 @@ export default async function settingsRoutes(app) {
       }
     }
     if (typeof req.body.personality_mode === "string") {
-      settings.personality_mode = req.body.personality_mode;
+      if (req.body.personality_mode !== settings.personality_mode) {
+        settings.personality_mode = req.body.personality_mode;
+        setRiskFilterMode(req.body.personality_mode);
+      }
     }
     if (typeof req.body.sweep_cadence === "string") {
       const allowed = ["Daily", "Monthly", "None"];

--- a/api/services/riskFilter.js
+++ b/api/services/riskFilter.js
@@ -1,0 +1,10 @@
+let currentMode = 'Realistic';
+
+export function setMode(mode) {
+  currentMode = mode;
+  console.log(`[RiskFilter] mode updated to ${mode}`);
+}
+
+export function getMode() {
+  return currentMode;
+}

--- a/dashboard/__tests__/Dashboard.test.jsx
+++ b/dashboard/__tests__/Dashboard.test.jsx
@@ -19,7 +19,13 @@ describeLocal('dashboard basics', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ panic: false, reason: 'loss limit' }),
+        json: () =>
+          Promise.resolve({
+            paused: false,
+            panic_reason: 'loss limit',
+            sandbox_mode: false,
+            balance: 1000,
+          }),
       })
     );
     await act(async () => {

--- a/dashboard/src/__tests__/SystemStatusBanner.test.jsx
+++ b/dashboard/src/__tests__/SystemStatusBanner.test.jsx
@@ -3,13 +3,17 @@ import { render, screen, act, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SystemStatusBanner from '../components/SystemStatusBanner.jsx';
 
-async function setup(response) {
-  global.fetch = jest.fn(() =>
-    Promise.resolve({
+async function setup({ paused, mode }) {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve(response),
+      json: () => Promise.resolve({ paused, panic_reason: null }),
     })
-  );
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ sandbox_mode: mode === 'sandbox' }),
+    });
   await act(async () => {
     render(<SystemStatusBanner />);
   });
@@ -20,7 +24,7 @@ afterEach(() => {
 });
 
 test('shows live active state', async () => {
-  await setup({ mode: 'live', panic: false });
+  await setup({ mode: 'live', paused: false });
   const banner = await screen.findByTestId('system-status-banner');
   expect(banner).toHaveTextContent('Live - Trading Active');
   expect(banner).toHaveClass('bg-green-600');
@@ -28,21 +32,21 @@ test('shows live active state', async () => {
 });
 
 test('shows live panic state', async () => {
-  await setup({ mode: 'live', panic: true });
+  await setup({ mode: 'live', paused: true });
   const banner = await screen.findByTestId('system-status-banner');
   expect(banner).toHaveTextContent('Panic Mode - Trading Halted');
   expect(banner).toHaveClass('bg-red-600');
 });
 
 test('shows sandbox active state', async () => {
-  await setup({ mode: 'sandbox', panic: false });
+  await setup({ mode: 'sandbox', paused: false });
   const banner = await screen.findByTestId('system-status-banner');
   expect(banner).toHaveTextContent('Sandbox Mode - Simulation Running');
   expect(banner).toHaveClass('bg-orange-500');
 });
 
 test('shows sandbox panic state', async () => {
-  await setup({ mode: 'sandbox', panic: true });
+  await setup({ mode: 'sandbox', paused: true });
   const banner = await screen.findByTestId('system-status-banner');
   expect(banner).toHaveTextContent('Sandbox Panic - Simulating Failure State');
   expect(banner).toHaveClass('bg-red-900');

--- a/dashboard/src/components/SystemStatusBanner.jsx
+++ b/dashboard/src/components/SystemStatusBanner.jsx
@@ -8,10 +8,19 @@ export default function SystemStatusBanner() {
   async function loadStatus() {
     try {
       const data = await fetchSystemStatus();
-      if (data.mode) setMode(data.mode);
-      setPanic(Boolean(data.panic));
+      setPanic(Boolean(data.paused));
     } catch (err) {
       console.error('Failed to fetch system status', err);
+    }
+
+    try {
+      const res = await fetch('/api/settings');
+      if (res.ok) {
+        const cfg = await res.json();
+        setMode(cfg.sandbox_mode ? 'sandbox' : 'live');
+      }
+    } catch (err) {
+      console.error('Failed to fetch mode', err);
     }
   }
 

--- a/dashboard/src/context/SystemStatusContext.jsx
+++ b/dashboard/src/context/SystemStatusContext.jsx
@@ -1,5 +1,6 @@
 // Shares panic brake status across components
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { fetchSystemStatus } from '../utils/api.js';
 
 const SystemStatusContext = createContext({ panic: false, reason: '' });
 
@@ -14,12 +15,9 @@ export function SystemStatusProvider({ children }) {
   // Poll API for current panic state
   async function fetchStatus() {
     try {
-      const res = await fetch('/api/system/status');
-      if (res.ok) {
-        const data = await res.json();
-        setPanic(Boolean(data.panic));
-        setReason(data.reason || '');
-      }
+      const data = await fetchSystemStatus();
+      setPanic(Boolean(data.paused));
+      setReason(data.panic_reason || '');
     } catch (err) {
       console.error('Failed to fetch system status', err);
     }

--- a/dashboard/src/pages/Settings.jsx
+++ b/dashboard/src/pages/Settings.jsx
@@ -1,13 +1,13 @@
 // UI for adjusting trading personality mode
 import React, { useEffect, useState } from 'react';
 
-// PATCH selected mode to API
-async function saveSettings(mode) {
+// PATCH selected settings to API
+async function saveSettings(values) {
   try {
     const res = await fetch('/api/settings', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ personality_mode: mode }),
+      body: JSON.stringify(values),
     });
     if (!res.ok) {
       throw new Error('Failed to save');
@@ -19,9 +19,11 @@ async function saveSettings(mode) {
 
 export default function Settings() {
   const [mode, setMode] = useState('auto');
+  const [lossCapPct, setLossCapPct] = useState(0);
+  const [latencyMaxMs, setLatencyMaxMs] = useState(250);
 
   useEffect(() => {
-    async function load() {
+    async function fetchSettings() {
       try {
         const res = await fetch('/api/settings');
         if (res.ok) {
@@ -29,12 +31,18 @@ export default function Settings() {
           if (data.personality_mode) {
             setMode(data.personality_mode.toLowerCase());
           }
+          if (typeof data.maxLossPct === 'number') {
+            setLossCapPct(data.maxLossPct);
+          }
+          if (typeof data.latencyMaxMs === 'number') {
+            setLatencyMaxMs(data.latencyMaxMs);
+          }
         }
       } catch (err) {
         console.error('Failed to fetch settings', err);
       }
     }
-    load();
+    fetchSettings();
   }, []);
 
   return (
@@ -52,9 +60,40 @@ export default function Settings() {
           </button>
         ))}
       </div>
+      <div>
+        <label className="block">
+          Loss Cap %: <span data-testid="loss-cap">{lossCapPct}</span>
+        </label>
+        <input
+          type="range"
+          min="0"
+          max="20"
+          value={lossCapPct}
+          onChange={(e) => setLossCapPct(Number(e.target.value))}
+        />
+      </div>
+      <div>
+        <label className="block">
+          Max Latency (ms): <span data-testid="latency-cap">{latencyMaxMs}</span>
+        </label>
+        <input
+          type="range"
+          min="50"
+          max="1000"
+          step="50"
+          value={latencyMaxMs}
+          onChange={(e) => setLatencyMaxMs(Number(e.target.value))}
+        />
+      </div>
       <button
         className="bg-blue-600 text-white px-3 py-1 rounded"
-        onClick={() => saveSettings(mode)}
+        onClick={() =>
+          saveSettings({
+            personality_mode: mode,
+            maxLossPct: lossCapPct,
+            latencyMaxMs,
+          })
+        }
       >
         Save
       </button>

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -54,6 +54,8 @@ Lists environment variables used across services.
 | `ALERT_RECIPIENT` | Email address for alerts |
 | `TELEGRAM_TOKEN` / `TELEGRAM_CHAT_ID` | Telegram alert settings |
 | `WEBHOOK_URL` | Generic alert webhook |
+| `API_KEY` | Required for API access (e.g., `dummy123`) |
+| `BINANCE_KEY` / `BINANCE_SECRET` | Exchange credentials (defaults `dummy123`) |
 | `WS_PORT` | WebSocket server port |
 | `LOG_LEVEL` | Log level for API service |
 | `NODE_ENV` | Node runtime mode |

--- a/docs/ops/log-forwarder-guide.MD
+++ b/docs/ops/log-forwarder-guide.MD
@@ -4,14 +4,19 @@ This guide explains how to forward container logs to Loki for centralized monito
 
 ## Enabling Fluent Bit
 
-1. Edit `infra/helm/values.yaml` and set:
-   ```yaml
-   logForwarder:
-     enabled: true
-     image: grafana/fluent-bit-plugin-loki:latest
-   ```
-2. Deploy the log forwarder:
+Fluent Bit is enabled by default in `infra/helm/values.yaml`:
+```yaml
+logForwarder:
+  enabled: true
+  image: grafana/fluent-bit-plugin-loki:latest
+```
+
+1. Deploy the log forwarder:
    ```bash
    helm upgrade --install arb infra/helm -f infra/helm/values.yaml
    ```
-3. Access Loki through Grafana to search logs across all services.
+2. Access Loki through Grafana to search logs across all services.
+
+> **Warning**: Running without external storage like Loki will cause logs to
+> accumulate locally and may exhaust disk space.
+

--- a/executor/.env.example
+++ b/executor/.env.example
@@ -2,6 +2,9 @@
 PERSONALITY_MODE=AUTO
 # Start cash balance for risk model
 STARTING_BALANCE=10000
+# Binance API credentials
+BINANCE_KEY=dummy123
+BINANCE_SECRET=dummy123
 # Max % of NAV per coin
 COIN_CAP_PCT=10
 # Max order book depth in USD

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -99,3 +99,8 @@ postgres:
   storage: 10Gi
   storageClass: standard
   accessMode: ReadWriteOnce
+
+logForwarder:
+  enabled: true
+  image: grafana/fluent-bit-plugin-loki:latest
+


### PR DESCRIPTION
## Summary
- sync personality mode from `/api/settings`
- poll `/api/system/status` with paused/panic_reason fields
- hot-reload RiskFilter via `setMode` hook
- add UI sliders for loss cap and latency
- document API_KEY and exchange keys
- enable Fluent Bit in Helm chart
- update dashboard tests

## Testing
- `npm test` in `dashboard`
- `npm test` in `api` *(fails: Cannot find module 'winston')*

------
https://chatgpt.com/codex/tasks/task_b_687fd9bf40e0832c8a0f44ab23031e31