### PR TITLE
Add dry-run tests, enable live mode switching, and integrate executor alerts (Batch 8)

### DIFF
--- a/api/routes/settings.js
+++ b/api/routes/settings.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import logger from "../services/logger.js";
 import { setMode as setRiskFilterMode } from "../services/riskFilter.js";
+import { getControlChannel } from "../config/settings.js";
 
 export let settings = {
   schema_version: 1,
@@ -16,7 +17,8 @@ export let settings = {
   latencyMaxMs: 250,
 };
 
-export default async function settingsRoutes(app) {
+export default async function settingsRoutes(app, opts) {
+  const { redis } = opts;
   app.get("/settings", async () => settings);
 
   const schema = z
@@ -114,6 +116,11 @@ export default async function settingsRoutes(app) {
       if (req.body.personality_mode !== settings.personality_mode) {
         settings.personality_mode = req.body.personality_mode;
         setRiskFilterMode(req.body.personality_mode);
+        try {
+          await redis.publish(getControlChannel(), `mode:${req.body.personality_mode}`);
+        } catch (err) {
+          logger.error('Failed to publish mode update', err);
+        }
       }
     }
     if (typeof req.body.sweep_cadence === "string") {

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -8,7 +8,7 @@ Follow these steps to run the platform in sandbox mode without exposing real cre
 cp .env.sandbox.example .env.sandbox
 ```
 
-Edit `.env.sandbox` and provide test-safe values. This file contains:
+Edit `.env.sandbox` and provide test-safe values. Ensure `EXECUTION_MODE` is set so the executor runs in dry-run mode:
 
 ```env
 API_KEY=your_value_here

--- a/docs/strategy-modes.md
+++ b/docs/strategy-modes.md
@@ -16,4 +16,4 @@ In Auto mode the system evaluates market volatility and win rate every minute. H
 
 ## Hot Reload
 
-Operators can switch modes from the dashboard settings panel. Updates are applied instantly without restarting services.
+Operators can switch modes from the dashboard settings panel. The API publishes a `mode:<value>` message on the control feed so the executor updates thresholds immediately without restarting services.

--- a/executor/build.gradle
+++ b/executor/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     // ✅ Redis
     implementation 'redis.clients:jedis:6.0.0'
 
+    // ✅ SMTP
+    implementation 'com.sun.mail:jakarta.mail:2.0.1'
+
     // ✅ JSON parsing
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.19.0'
 

--- a/executor/src/main/java/AlertManager.java
+++ b/executor/src/main/java/AlertManager.java
@@ -2,17 +2,60 @@ package executor;
 
 /**
  * Simple utility used to dispatch alerts to operators.
- * Currently this just writes to stdout but can be
- * extended to integrate with email or chat services.
+ * Alerts are published to Redis and optionally sent via SMTP.
  */
 public class AlertManager {
 
     /**
-     * Send an alert message to the configured channel.
+     * Publish an alert to Redis and send via SMTP if configured.
      *
+     * @param type    alert type/category
      * @param message alert text
      */
-    public static void sendAlert(String message) {
-        System.out.println("ALERT: " + message);
+    public static void sendAlert(String type, String message) {
+        String ts = java.time.Instant.now().toString();
+        String payload = String.format("[%s][executor][%s] %s", ts, type, message);
+
+        // Redis publish
+        String redisHost = System.getenv().getOrDefault("REDIS_HOST", "localhost");
+        int redisPort = Integer.parseInt(System.getenv().getOrDefault("REDIS_PORT", "6379"));
+        try (redis.clients.jedis.Jedis jedis = new redis.clients.jedis.Jedis(redisHost, redisPort)) {
+            jedis.publish("alerts", payload);
+        } catch (Exception e) {
+            System.err.println("Redis alert publish failed: " + e.getMessage());
+        }
+
+        // Email send
+        String user = System.getenv("SMTP_USER");
+        String pass = System.getenv("SMTP_PASS");
+        String recipient = System.getenv("ALERT_RECIPIENT");
+        String host = System.getenv().getOrDefault("SMTP_HOST", "smtp.gmail.com");
+        if (user != null && pass != null && recipient != null) {
+            java.util.Properties props = new java.util.Properties();
+            props.put("mail.smtp.auth", "true");
+            props.put("mail.smtp.starttls.enable", "true");
+            props.put("mail.smtp.host", host);
+            props.put("mail.smtp.port", "587");
+            jakarta.mail.Session session = jakarta.mail.Session.getInstance(props,
+                    new jakarta.mail.Authenticator() {
+                        @Override
+                        protected jakarta.mail.PasswordAuthentication getPasswordAuthentication() {
+                            return new jakarta.mail.PasswordAuthentication(user, pass);
+                        }
+                    });
+            try {
+                jakarta.mail.Message msg = new jakarta.mail.internet.MimeMessage(session);
+                msg.setFrom(new jakarta.mail.internet.InternetAddress(user));
+                msg.setRecipients(jakarta.mail.Message.RecipientType.TO,
+                        jakarta.mail.internet.InternetAddress.parse(recipient));
+                msg.setSubject("Crypto Alert - " + type);
+                msg.setText(payload);
+                jakarta.mail.Transport.send(msg);
+            } catch (Exception e) {
+                System.err.println("Email alert failed: " + e.getMessage());
+            }
+        }
+
+        System.out.println("ALERT: " + payload);
     }
 }

--- a/executor/src/main/java/CircuitBreaker.java
+++ b/executor/src/main/java/CircuitBreaker.java
@@ -31,7 +31,7 @@ public class CircuitBreaker {
         if (!tripped.get() && (winRate < minWinRate || drawdownPct > maxDrawdownPct)) {
             tripped.set(true);
             logger.error("CIRCUIT BREAKER TRIPPED winRate={} drawdownPct={}", winRate, drawdownPct);
-            AlertManager.sendAlert("CIRCUIT BREAKER TRIPPED");
+            AlertManager.sendAlert("CIRCUIT", "CIRCUIT BREAKER TRIPPED");
             redisClient.publish("alerts", "CIRCUIT BREAKER TRIPPED");
             redisClient.publish(RedisClient.getControlChannel(), "halt");
         }

--- a/executor/src/main/java/ColdSweepScheduler.java
+++ b/executor/src/main/java/ColdSweepScheduler.java
@@ -80,6 +80,8 @@ public class ColdSweepScheduler {
         if (sweeper.shouldSweep(profit, capital)) {
             logger.info("Cold sweep triggered");
             sweeper.sweepToColdWallet(profit);
+            String summary = String.format("profit=%.2f capital=%.2f", profit, capital);
+            AlertManager.sendAlert("SWEEP", summary);
         }
     }
 

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -99,7 +99,9 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         this.circuitBreaker = new CircuitBreaker(redisClient, cbWinRate, cbDrawdown);
         this.canaryMode = Boolean.parseBoolean(System.getenv().getOrDefault("CANARY_MODE", "false"));
         this.ghostMode = Boolean.parseBoolean(System.getenv().getOrDefault("GHOST_MODE", "false"));
-        boolean envDryRun = "dry-run".equalsIgnoreCase(System.getenv().getOrDefault("MODE", ""));
+        String envMode = System.getenv().getOrDefault("EXECUTION_MODE",
+                System.getenv().getOrDefault("MODE", ""));
+        boolean envDryRun = envMode.equalsIgnoreCase("sandbox") || envMode.equalsIgnoreCase("dry-run");
         this.sandboxMode = this.config.isDryRun() || envDryRun;
         this.maxOpenTrades = Integer.parseInt(System.getenv().getOrDefault("MAX_OPEN_TRADES", "5"));
     }
@@ -177,6 +179,9 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             if ("resume".equalsIgnoreCase(msg)) {
                 logger.info("Resume signal received on {}", controlChannel);
                 resumeFromPanic();
+            } else if (msg != null && msg.startsWith("mode:")) {
+                String newMode = msg.substring(5).trim();
+                riskFilter.setMode(newMode);
             }
         });
     }
@@ -327,7 +332,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         if (PanicBrake.shouldHalt(redisClient, config, dailyLossPct, avgLatencyMs, winRate)) {
             if (isPanic.compareAndSet(false, true)) {
                 logger.error("PANIC BRAKE TRIGGERED - trading paused");
-                AlertManager.sendAlert("PANIC BRAKE TRIGGERED");
+                AlertManager.sendAlert("PANIC", "BRAKE TRIGGERED");
                 redisClient.publish("alerts", "PANIC BRAKE TRIGGERED");
             }
         }
@@ -387,7 +392,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             circuitBreaker.reset();
             long ts = System.currentTimeMillis();
             logger.info("[RESUME SIGNAL RECEIVED] reason=manual ts={}", ts);
-            AlertManager.sendAlert("Trading resumed at " + ts);
+            AlertManager.sendAlert("RESUME", "Trading resumed at " + ts);
             redisClient.publish("alerts", "Trading resumed at " + ts);
         } else {
             logger.warn("[RESUME IGNORED] already active");
@@ -402,7 +407,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             circuitBreaker.reset();
             long ts = System.currentTimeMillis();
             logger.info("[RESUME SIGNAL RECEIVED] reason=control ts={}", ts);
-            AlertManager.sendAlert("Trading resumed at " + ts);
+            AlertManager.sendAlert("RESUME", "Trading resumed at " + ts);
             redisClient.publish("alerts", "Trading resumed at " + ts);
         } else {
             logger.warn("[RESUME IGNORED] already active");

--- a/executor/src/main/java/RedisClient.java
+++ b/executor/src/main/java/RedisClient.java
@@ -180,7 +180,7 @@ public class RedisClient extends Thread {
             } catch (Exception e) {
                 long delay = Math.min(maxDelayMs, (1L << attempt) * baseDelayMs);
                 logger.error("Redis connection failed: {}", e.getMessage());
-                AlertManager.sendAlert("Redis connection lost: " + e.getMessage());
+                AlertManager.sendAlert("REDIS", "connection lost: " + e.getMessage());
                 try {
                     Thread.sleep(delay);
                 } catch (InterruptedException ie) {

--- a/executor/src/test/java/ExecutorDryRunModeTest.java
+++ b/executor/src/test/java/ExecutorDryRunModeTest.java
@@ -1,0 +1,40 @@
+package executor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class ExecutorDryRunModeTest {
+    static class DummyRedisClient extends RedisClient {
+        String channel;
+        String message;
+        DummyRedisClient() {
+            super("localhost", 6379, "chan", (c,m)->{});
+        }
+        @Override public void start() {}
+        @Override public void publish(String ch, String msg) { this.channel = ch; this.message = msg; }
+    }
+
+    static class DummyExecutor extends Executor {
+        DummyRedisClient client;
+        DummyExecutor(DummyRedisClient c) {
+            super(c, "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.SANDBOX));
+            this.client = c;
+        }
+        @Override public void start() {}
+    }
+
+    @Test
+    void noTradeExecutedWhenDryRun() throws Exception {
+        ProfitTracker.init(10000, "http://localhost");
+        ProfitTracker.resetCumulativeProfit();
+        DummyRedisClient client = new DummyRedisClient();
+        DummyExecutor exec = new DummyExecutor(client);
+        String msg = "{\"pair\":\"BTC/USDT\",\"buyExchange\":\"A\",\"sellExchange\":\"B\",\"grossEdge\":1.0,\"netEdge\":1.0}";
+        exec.handleMessage(msg);
+        assertEquals("ghost_feed", client.channel);
+        assertEquals(0.0, ProfitTracker.getGlobalTotal(), 1e-9);
+    }
+}


### PR DESCRIPTION
## Summary
- document EXECUTION_MODE usage in sandbox guide
- allow runtime personality mode updates via Redis
- add unit test for dry-run execution path
- publish alerts via Redis and SMTP
- notify on cold sweeps

## Testing
- `./gradlew test -PtestEnv=local`
- `npm test -- --runInBand` *(fails: Cannot find module 'winston')*

------
https://chatgpt.com/codex/tasks/task_b_687fdf8e7050832c8db4f01f205580eb