### PR TITLE
Fix default thresholds, retry Redis publish, resume safety, and hot-reload risk config (Batch 10)

### DIFF
--- a/api/routes/settings.js
+++ b/api/routes/settings.js
@@ -134,9 +134,19 @@ export default async function settingsRoutes(app, opts) {
     }
     if (typeof req.body.maxLossPct === "number") {
       settings.maxLossPct = req.body.maxLossPct;
+      try {
+        await redis.publish(getControlChannel(), `lossCap:${req.body.maxLossPct}`);
+      } catch (err) {
+        logger.error('Failed to publish lossCap update', err);
+      }
     }
     if (typeof req.body.latencyMaxMs === "number") {
       settings.latencyMaxMs = req.body.latencyMaxMs;
+      try {
+        await redis.publish(getControlChannel(), `latency:${req.body.latencyMaxMs}`);
+      } catch (err) {
+        logger.error('Failed to publish latency update', err);
+      }
     }
     return { saved: true };
   };

--- a/executor/src/main/java/ColdSweeper.java
+++ b/executor/src/main/java/ColdSweeper.java
@@ -19,6 +19,7 @@ public class ColdSweeper {
     private final SweepLogger sweepLogger;
     private final Config config;
     private final boolean isDryRun;
+    private final java.util.concurrent.atomic.AtomicBoolean busy = new java.util.concurrent.atomic.AtomicBoolean(false);
 
     /**
      * Default: sweep when profit ≥ $5,000 or ≥ 30% of capital.
@@ -68,6 +69,11 @@ public class ColdSweeper {
         this.isDryRun = configObj != null && configObj.isDryRun();
     }
 
+    /** @return true if a sweep is currently in progress */
+    public boolean isBusy() {
+        return busy.get();
+    }
+
     private String maskAddress(String address) {
         if (address == null || address.length() <= 10) {
             return "********";
@@ -102,6 +108,7 @@ public class ColdSweeper {
      * Uses the address from {@link ColdSweeperConfig}.
      */
     public void sweepToColdWallet(double amountUsd) {
+        busy.set(true);
         String address = sweeperConfig.getTestColdWalletAddress();
         logger.info("Cold wallet sweep triggered for: {} amount {}", maskAddress(address), amountUsd);
         if (isDryRun) {
@@ -113,6 +120,7 @@ public class ColdSweeper {
         if (sweepLogger != null) {
             sweepLogger.logSweep(amountUsd, address, "auto");
         }
+        busy.set(false);
     }
 
     /**
@@ -122,6 +130,7 @@ public class ColdSweeper {
      * @param amountUsd amount to sweep
      */
     public void sweepToColdWallet(String address, double amountUsd) {
+        busy.set(true);
         logger.info("Cold wallet sweep triggered for: {} amount {}", maskAddress(address), amountUsd);
         if (isDryRun) {
             logger.info("[DRY-RUN] Skipping cold wallet transfer");
@@ -132,5 +141,6 @@ public class ColdSweeper {
         if (sweepLogger != null) {
             sweepLogger.logSweep(amountUsd, address, "manual");
         }
+        busy.set(false);
     }
 }

--- a/executor/src/main/java/Config.java
+++ b/executor/src/main/java/Config.java
@@ -3,13 +3,34 @@ package executor;
 /** Configuration object supplying runtime execution mode. */
 public class Config {
     private final ExecutionMode executionMode;
+    private final double lossCapPct;
+    private final double latencyMaxMs;
+    private final double winRateThreshold;
 
     public Config(ExecutionMode mode) {
         this.executionMode = mode;
+        this.lossCapPct = Double.parseDouble(
+                System.getenv().getOrDefault("LOSS_CAP_PCT", "5.0"));
+        this.latencyMaxMs = Double.parseDouble(
+                System.getenv().getOrDefault("LATENCY_MAX_MS", "250"));
+        this.winRateThreshold = Double.parseDouble(
+                System.getenv().getOrDefault("WIN_RATE_THRESHOLD", "0.5"));
     }
 
     public ExecutionMode getExecutionMode() {
         return executionMode;
+    }
+
+    public double getLossCapPct() {
+        return lossCapPct;
+    }
+
+    public double getLatencyMaxMs() {
+        return latencyMaxMs;
+    }
+
+    public double getWinRateThreshold() {
+        return winRateThreshold;
     }
 
     /**

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -183,6 +183,27 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
                 String newMode = msg.substring(5).trim();
                 logger.info("[MODE-UPDATE] source=control value={}", newMode);
                 riskFilter.setMode(newMode);
+            } else if (msg != null && msg.startsWith("lossCap:")) {
+                try {
+                    double v = Double.parseDouble(msg.substring(8));
+                    riskFilter.setLossCap(v);
+                } catch (NumberFormatException ignore) {
+                    logger.warn("Invalid lossCap update: {}", msg);
+                }
+            } else if (msg != null && msg.startsWith("latency:")) {
+                try {
+                    int v = Integer.parseInt(msg.substring(8));
+                    riskFilter.setLatencyMax(v);
+                } catch (NumberFormatException ignore) {
+                    logger.warn("Invalid latency update: {}", msg);
+                }
+            } else if (msg != null && msg.startsWith("winRate:")) {
+                try {
+                    double v = Double.parseDouble(msg.substring(8));
+                    riskFilter.setWinRateThreshold(v);
+                } catch (NumberFormatException ignore) {
+                    logger.warn("Invalid winRate update: {}", msg);
+                }
             }
         });
     }
@@ -449,6 +470,13 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         } else {
             logger.warn("[RESUME IGNORED] already active");
         }
+    }
+
+    /**
+     * @return true if panic brake is currently active
+     */
+    public boolean isPanicActive() {
+        return isPanic.get();
     }
 
     /**

--- a/executor/src/main/java/PanicBrake.java
+++ b/executor/src/main/java/PanicBrake.java
@@ -3,7 +3,9 @@ package executor;
 
 /**
  * Utility class that determines when trading should halt based on a few
- * safety thresholds.  All thresholds are fixed and checked in the static
+ * safety thresholds. Default values are 5% daily loss, 250&nbsp;ms latency
+ * and a 50% win rate. Thresholds may be overridden via {@link Config}
+ * or environment variables and are checked in the static
  * {@link #shouldHalt(RedisClient, Config, double, double, double)} method.
  */
 import org.slf4j.Logger;
@@ -24,33 +26,42 @@ public class PanicBrake {
      * @return {@code true} if trading should halt
      */
 
-    private static double getLossCapPct() {
+    private static double getLossCapPct(Config config) {
+        if (config != null) {
+            return config.getLossCapPct();
+        }
         String val = System.getProperty("LOSS_CAP_PCT",
-                System.getenv().getOrDefault("LOSS_CAP_PCT", "3.0"));
+                System.getenv().getOrDefault("LOSS_CAP_PCT", "5.0"));
         try {
             return Double.parseDouble(val);
         } catch (NumberFormatException e) {
-            return 3.0;
+            return 5.0;
         }
     }
 
-    private static double getLatencyMaxMs() {
+    private static double getLatencyMaxMs(Config config) {
+        if (config != null) {
+            return config.getLatencyMaxMs();
+        }
         String val = System.getProperty("LATENCY_MAX_MS",
-                System.getenv().getOrDefault("LATENCY_MAX_MS", "500.0"));
+                System.getenv().getOrDefault("LATENCY_MAX_MS", "250"));
         try {
             return Double.parseDouble(val);
         } catch (NumberFormatException e) {
-            return 500.0;
+            return 250.0;
         }
     }
 
-    private static double getWinRateThreshold() {
+    private static double getWinRateThreshold(Config config) {
+        if (config != null) {
+            return config.getWinRateThreshold();
+        }
         String val = System.getProperty("WIN_RATE_THRESHOLD",
-                System.getenv().getOrDefault("WIN_RATE_THRESHOLD", "0.4"));
+                System.getenv().getOrDefault("WIN_RATE_THRESHOLD", "0.5"));
         try {
             return Double.parseDouble(val);
         } catch (NumberFormatException e) {
-            return 0.4;
+            return 0.5;
         }
     }
 
@@ -66,9 +77,9 @@ public class PanicBrake {
 
     public static boolean shouldHalt(RedisClient redis, Config config,
                                      double dailyLossPct, double avgLatencyMs, double winRate) {
-        double lossCap = getLossCapPct();
-        double latencyCap = getLatencyMaxMs();
-        double winRateThresh = getWinRateThreshold();
+        double lossCap = getLossCapPct(config);
+        double latencyCap = getLatencyMaxMs(config);
+        double winRateThresh = getWinRateThreshold(config);
         double profitTarget = getProfitTargetUsd();
         double profitSoFar = ProfitTracker.getCumulativeProfit();
 

--- a/executor/src/main/java/RedisClient.java
+++ b/executor/src/main/java/RedisClient.java
@@ -80,25 +80,42 @@ public class RedisClient extends Thread {
      * @param channel redis channel
      * @param message payload to publish
      */
-    public void publish(String channel, String message) {
-        try (Jedis jedis = new Jedis(host, port)) {
-            jedis.publish(channel, message);
-        } catch (Exception e) {
-            logger.error("Redis publish failed: {}", e.getMessage());
+    public boolean publish(String channel, String message) {
+        int attempts = 0;
+        while (attempts < 3) {
+            try (Jedis jedis = new Jedis(host, port)) {
+                jedis.publish(channel, message);
+                return true;
+            } catch (Exception e) {
+                attempts++;
+                long delay = Math.min(maxDelayMs, (1L << (attempts - 1)) * baseDelayMs);
+                logger.error("Redis publish failed (attempt {}): {}", attempts, e.getMessage());
+                if (attempts >= 3) {
+                    logger.error("Redis publish giving up after {} attempts", attempts);
+                    break;
+                }
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
         }
+        return false;
     }
 
     /**
      * Publish a message to the control channel derived from execution mode.
      */
-    public void publishControl(Config config, String message) {
+    public boolean publishControl(Config config, String message) {
         String channel;
         if (config == null) {
             channel = getControlChannel();
         } else {
             channel = getControlChannel();
         }
-        publish(channel, message);
+        return publish(channel, message);
     }
 
     /**

--- a/executor/src/main/java/RiskFilter.java
+++ b/executor/src/main/java/RiskFilter.java
@@ -16,6 +16,12 @@ public class RiskFilter {
     private long maxLatencyMs;
     private double maxSlippagePct = Double.parseDouble(
         System.getenv().getOrDefault("MAX_SLIPPAGE_PCT", "1.0"));
+    private double lossCapPct = Double.parseDouble(
+        System.getenv().getOrDefault("LOSS_CAP_PCT", "5.0"));
+    private int latencyMax = Integer.parseInt(
+        System.getenv().getOrDefault("LATENCY_MAX_MS", "250"));
+    private double winRateThreshold = Double.parseDouble(
+        System.getenv().getOrDefault("WIN_RATE_THRESHOLD", "0.5"));
     private String mode;
 
     /** Construct using the default personality mode. */
@@ -76,6 +82,24 @@ public class RiskFilter {
             }
         }
         logger.info("RiskFilter mode set to {} (minEdge={}, latency={})", this.mode, this.minEdge, this.maxLatencyMs);
+    }
+
+    /** Update loss cap percentage at runtime. */
+    public void setLossCap(double pct) {
+        this.lossCapPct = pct;
+        logger.info("[SETTINGS] lossCapPct updated to {}", pct);
+    }
+
+    /** Update latency max threshold at runtime. */
+    public void setLatencyMax(int ms) {
+        this.latencyMax = ms;
+        logger.info("[SETTINGS] latencyMax updated to {}ms", ms);
+    }
+
+    /** Update win rate threshold at runtime. */
+    public void setWinRateThreshold(double threshold) {
+        this.winRateThreshold = threshold;
+        logger.info("[SETTINGS] winRateThreshold updated to {}", threshold);
     }
 
     /**

--- a/executor/src/main/java/SystemHealthChecker.java
+++ b/executor/src/main/java/SystemHealthChecker.java
@@ -1,21 +1,51 @@
 package executor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+
 /**
  * Performs runtime checks to verify whether it is safe to resume trading.
  */
 public class SystemHealthChecker {
+    private static final Logger logger = LoggerFactory.getLogger(SystemHealthChecker.class);
+
+    private final Executor executor;
+    private final ColdSweeper sweeper;
+
+    public SystemHealthChecker() {
+        this(null, null);
+    }
+
+    public SystemHealthChecker(Executor executor, ColdSweeper sweeper) {
+        this.executor = executor;
+        this.sweeper = sweeper;
+    }
+
     /** Check that heartbeat monitor is alive. */
     public boolean isHeartbeatAlive() {
-        return true;
+        String host = System.getenv().getOrDefault("REDIS_HOST", "localhost");
+        int port = Integer.parseInt(System.getenv().getOrDefault("REDIS_PORT", "6379"));
+        try (Jedis jedis = new Jedis(host, port)) {
+            String ts = jedis.get("executor:heartbeat");
+            if (ts == null) {
+                return false;
+            }
+            long last = Long.parseLong(ts);
+            return System.currentTimeMillis() - last < 10000;
+        } catch (Exception e) {
+            logger.error("Heartbeat check failed", e);
+            return false;
+        }
     }
 
     /** Check that the cold sweeper is not actively running. */
     public boolean isColdSweeperIdle() {
-        return true;
+        return sweeper == null || !sweeper.isBusy();
     }
 
     /** Check that panic flag has been cleared. */
     public boolean isPanicStateCleared() {
-        return true;
+        return executor == null || !executor.isPanicActive();
     }
 }

--- a/executor/src/test/java/CircuitBreakerTest.java
+++ b/executor/src/test/java/CircuitBreakerTest.java
@@ -12,7 +12,7 @@ public class CircuitBreakerTest {
         String message;
         DummyRedisClient() { super("localhost", 6379, "chan", (c,m)->{}); }
         @Override public void start() {}
-        @Override public void publish(String ch, String msg) { channel = ch; message = msg; }
+        @Override public boolean publish(String ch, String msg) { channel = ch; message = msg; return true; }
     }
 
     @Test

--- a/executor/src/test/java/ExecutorCanaryModeTest.java
+++ b/executor/src/test/java/ExecutorCanaryModeTest.java
@@ -14,7 +14,7 @@ public class ExecutorCanaryModeTest {
         @Override
         public void start() {}
         @Override
-        public void publish(String channel, String message) {}
+        public boolean publish(String channel, String message) { return true; }
     }
 
     static class DummyExecutor extends Executor {

--- a/executor/src/test/java/ExecutorDryRunModeTest.java
+++ b/executor/src/test/java/ExecutorDryRunModeTest.java
@@ -14,7 +14,7 @@ public class ExecutorDryRunModeTest {
             super("localhost", 6379, "chan", (c,m)->{});
         }
         @Override public void start() {}
-        @Override public void publish(String ch, String msg) { this.channel = ch; this.message = msg; }
+        @Override public boolean publish(String ch, String msg) { this.channel = ch; this.message = msg; return true; }
     }
 
     static class DummyExecutor extends Executor {

--- a/executor/src/test/java/ExecutorGhostModeTest.java
+++ b/executor/src/test/java/ExecutorGhostModeTest.java
@@ -16,9 +16,10 @@ public class ExecutorGhostModeTest {
         @Override
         public void start() {}
         @Override
-        public void publish(String channel, String message) {
+        public boolean publish(String channel, String message) {
             this.publishedChannel = channel;
             this.publishedMessage = message;
+            return true;
         }
     }
 

--- a/executor/src/test/java/ExecutorMaxOpenTradesTest.java
+++ b/executor/src/test/java/ExecutorMaxOpenTradesTest.java
@@ -11,7 +11,7 @@ public class ExecutorMaxOpenTradesTest {
     static class DummyRedisClient extends RedisClient {
         DummyRedisClient() { super("localhost", 6379, "chan", (c,m) -> {}); }
         @Override public void start() {}
-        @Override public void publish(String channel, String message) {}
+        @Override public boolean publish(String channel, String message) { return true; }
     }
 
     static class DummyExecutor extends Executor {

--- a/executor/src/test/java/ExecutorSandboxModeTest.java
+++ b/executor/src/test/java/ExecutorSandboxModeTest.java
@@ -19,9 +19,10 @@ public class ExecutorSandboxModeTest {
         @Override
         public void start() {}
         @Override
-        public void publish(String ch, String msg) {
+        public boolean publish(String ch, String msg) {
             this.channel = ch;
             this.message = msg;
+            return true;
         }
     }
 

--- a/executor/src/test/java/LatencyBypassBugTest.java
+++ b/executor/src/test/java/LatencyBypassBugTest.java
@@ -10,7 +10,7 @@ public class LatencyBypassBugTest {
     static class DummyRedis extends RedisClient {
         DummyRedis() { super("localhost", 6379, "chan", (c,m)->{}); }
         @Override public void start() {}
-        @Override public void publish(String c, String m) {}
+        @Override public boolean publish(String c, String m) { return true; }
     }
 
     static class CaptureLogger extends NearMissLogger {

--- a/executor/src/test/java/PanicBrakeTest.java
+++ b/executor/src/test/java/PanicBrakeTest.java
@@ -16,12 +16,12 @@ public class PanicBrakeTest {
         String message;
         DummyRedis() { super("localhost", 6379, "chan", (c,m)->{}); }
         @Override public void start() {}
-        @Override public void publish(String ch, String msg) { this.channel = ch; this.message = msg; }
+        @Override public boolean publish(String ch, String msg) { this.channel = ch; this.message = msg; return true; }
     }
 
     @Test
     void triggersOnHighLoss() {
-        assertTrue(PanicBrake.shouldHalt(null, new Config(ExecutionMode.LIVE), 4.0, 100.0, 0.8));
+        assertTrue(PanicBrake.shouldHalt(null, new Config(ExecutionMode.LIVE), 6.0, 100.0, 0.8));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class PanicBrakeTest {
     void doesNotPublishPauseInDryRun() {
         DummyRedis redis = new DummyRedis();
         Config config = new Config(ExecutionMode.SANDBOX);
-        assertTrue(PanicBrake.shouldHalt(redis, config, 4.0, 100.0, 0.8));
+        assertTrue(PanicBrake.shouldHalt(redis, config, 6.0, 100.0, 0.8));
         assertNull(redis.channel);
         assertNull(redis.message);
     }

--- a/executor/src/test/java/SandboxExchangeAdapterTest.java
+++ b/executor/src/test/java/SandboxExchangeAdapterTest.java
@@ -17,7 +17,7 @@ public class SandboxExchangeAdapterTest {
         String message;
         DummyRedis() { super("localhost", 6379, "chan", (c,m)->{}); }
         @Override public void start() {}
-        @Override public void publish(String ch, String msg) { this.channel = ch; this.message = msg; }
+        @Override public boolean publish(String ch, String msg) { this.channel = ch; this.message = msg; return true; }
     }
 
     @Test

--- a/executor/src/test/java/SimulatedPublisherTest.java
+++ b/executor/src/test/java/SimulatedPublisherTest.java
@@ -20,9 +20,10 @@ public class SimulatedPublisherTest {
         @Override
         public void start() {}
         @Override
-        public void publish(String ch, String msg) {
+        public boolean publish(String ch, String msg) {
             this.channel = ch;
             this.message = msg;
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary
- align panic brake threshold defaults with `.env`
- add retry+backoff to `RedisClient.publish`
- make `RiskFilter` thresholds hot reloadable from settings
- check heartbeat and panic flag before resuming

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_b_687fea7a0224832ca12aae8b5c4993b6