### PR TITLE
Add latency and loss cap sliders to settings, and live trade status to dashboard (Batch 13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ __pycache__/
 
 # Gradle wrapper binary
 executor/gradle/wrapper/gradle-wrapper.jar
+.venv/

--- a/dashboard/src/pages/Dashboard.jsx
+++ b/dashboard/src/pages/Dashboard.jsx
@@ -8,7 +8,20 @@ export default function Dashboard() {
   const [mode, setMode] = useState('auto');
   const [walletBalance, setWalletBalance] = useState(null);
   const [metrics, setMetrics] = useState({ equityCurve: [], latency: [], openTrades: [], winRate: [] });
+  const [tradeStatus, setTradeStatus] = useState([]);
   const { panic, refreshStatus } = useSystemStatus();
+
+  const renderTradeStatus = () => {
+    if (!tradeStatus.length) return 'No open trades';
+    const info = tradeStatus
+      .map((t) => {
+        const pair = t.pair || t.symbol;
+        const sec = t.duration || t.seconds || 0;
+        return `${pair} (${sec}s)`;
+      })
+      .join(', ');
+    return `${tradeStatus.length} trades open: ${info}`;
+  };
 
   useEffect(() => {
     async function load() {
@@ -38,6 +51,25 @@ export default function Dashboard() {
     load();
   }, [refreshStatus]);
 
+  useEffect(() => {
+    async function fetchTradeStatus() {
+      try {
+        const res = await fetch('/api/trades/status');
+        if (res.ok) {
+          const data = await res.json();
+          setTradeStatus(data.trades || []);
+        } else {
+          setTradeStatus([]);
+        }
+      } catch (err) {
+        console.error('Failed to fetch trade status', err);
+      }
+    }
+    fetchTradeStatus();
+    const id = setInterval(fetchTradeStatus, 5000);
+    return () => clearInterval(id);
+  }, []);
+
   return (
     <div className="p-4 space-y-4 text-text">
       <h1 className="text-2xl font-bold">Arbitrage Summary</h1>
@@ -48,9 +80,7 @@ export default function Dashboard() {
         <div>
           Wallet Balance: <span data-testid="wallet-balance">{walletBalance ?? 'N/A'}</span>
         </div>
-        <div>
-          Open Trades: {metrics.openTrades ? metrics.openTrades.length : 0}
-        </div>
+        <div data-testid="trade-status">{renderTradeStatus()}</div>
         <div className="space-x-2">
           {['auto', 'realistic', 'aggressive'].map((m) => (
             <button

--- a/dashboard/src/pages/Settings.jsx
+++ b/dashboard/src/pages/Settings.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 
 // PATCH selected settings to API
-async function saveSettings(values) {
+async function patchSettings(values) {
   try {
     const res = await fetch('/api/settings', {
       method: 'PATCH',
@@ -31,11 +31,11 @@ export default function Settings() {
           if (data.personality_mode) {
             setMode(data.personality_mode.toLowerCase());
           }
-          if (typeof data.maxLossPct === 'number') {
-            setLossCapPct(data.maxLossPct);
+          if (typeof data.loss_cap_pct === 'number') {
+            setLossCapPct(data.loss_cap_pct);
           }
-          if (typeof data.latencyMaxMs === 'number') {
-            setLatencyMaxMs(data.latencyMaxMs);
+          if (typeof data.latency_max_ms === 'number') {
+            setLatencyMaxMs(data.latency_max_ms);
           }
         }
       } catch (err) {
@@ -66,8 +66,9 @@ export default function Settings() {
         </label>
         <input
           type="range"
-          min="0"
-          max="20"
+          min="1"
+          max="10"
+          step="0.5"
           value={lossCapPct}
           onChange={(e) => setLossCapPct(Number(e.target.value))}
         />
@@ -82,16 +83,20 @@ export default function Settings() {
           max="1000"
           step="50"
           value={latencyMaxMs}
-          onChange={(e) => setLatencyMaxMs(Number(e.target.value))}
+          onChange={async (e) => {
+            const val = Number(e.target.value);
+            setLatencyMaxMs(val);
+            await patchSettings({ latency_max_ms: val });
+          }}
         />
       </div>
       <button
         className="bg-blue-600 text-white px-3 py-1 rounded"
         onClick={() =>
-          saveSettings({
+          patchSettings({
             personality_mode: mode,
-            maxLossPct: lossCapPct,
-            latencyMaxMs,
+            loss_cap_pct: lossCapPct,
+            latency_max_ms: latencyMaxMs,
           })
         }
       >


### PR DESCRIPTION
## Summary
- add latency slider bound to `latency_max_ms` and patch on change
- add loss cap slider with 1-10% range bound to `loss_cap_pct`
- show active trade status on dashboard

## Testing
- `test/run-local.sh` *(fails: Environment verified but subsequent steps not shown)*

------
https://chatgpt.com/codex/tasks/task_b_687ffe631bb8832c978167e1501447b9