### PR TITLE
PR-Fix-22: fix /opportunities API response bug

### DIFF
--- a/api/__tests__/api.test.js
+++ b/api/__tests__/api.test.js
@@ -51,6 +51,11 @@ describeLocal('API authentication', () => {
       .get('/api/opportunities')
       .set('Cookie', cookie);
     expect(authRes.statusCode).toBe(200);
+    expect(authRes.body).toEqual({
+      opportunities: [],
+      dryRun: true,
+      timestamp: expect.any(String)
+    });
   });
 
   test('/resume requires auth and publishes message', async () => {

--- a/api/index.js
+++ b/api/index.js
@@ -18,6 +18,7 @@ import analyticsRoutes from './routes/analytics.js';
 import cgtRoutes from './routes/cgt.js';
 import resumeRoutes from './routes/resume.js';
 import configRoutes from './routes/config.js';
+import opportunitiesRoutes from './routes/opportunities.js';
 import { getControlChannel } from './config/settings.js';
 import { baseOpenPaths } from './lib/constants.js';
 import { sendAlert } from '../alerts/alertAgent.js';
@@ -70,7 +71,10 @@ function buildApp() {
     });
 
     if (isTest) {
-      redis = { publish: async () => 1 };
+      redis = {
+        publish: async () => 1,
+        get: async () => '[]'
+      };
     } else {
       // Redis connection parameters via env vars
       redis = new Redis({
@@ -106,9 +110,11 @@ const alertSettings = {
   webhook_url: '',
 };
 
-async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginRoute);
+async function apiRoutes(api, { testState, redis, pool }) {
+  api.register(loginRoute);
   api.register(authRoute);
   api.register(settingsRoutes, { redis });
+  api.register(opportunitiesRoutes, { redis });
   api.register(auditLogger, { pool });
 
   api.addHook('onRequest', async (req, reply) => {
@@ -162,7 +168,6 @@ async function apiRoutes(api, { testState, redis, pool }) {  api.register(loginR
     Sentry.captureException(error);
   });
 
-  api.get('/opportunities', async () => []);
 
   api.get('/alerts', async () => alertSettings);
   api.post('/alerts', async req => {

--- a/api/routes/opportunities.js
+++ b/api/routes/opportunities.js
@@ -1,0 +1,43 @@
+import logger from '../services/logger.js';
+
+export default async function opportunitiesRoutes(app, opts) {
+  const { redis } = opts;
+  const KEY = 'arb:spread:opportunities';
+
+  app.get('/opportunities', async (req) => {
+    try {
+      const cached = await redis.get(KEY);
+      if (!cached) {
+        req.log.info('[API] No opportunities available or Redis cache empty');
+        return {
+          opportunities: [],
+          dryRun: true,
+          timestamp: new Date().toISOString()
+        };
+      }
+      let opportunities = [];
+      try {
+        opportunities = JSON.parse(cached);
+      } catch (err) {
+        logger.error(`[REDIS] Failed to read opportunities: ${err.message}`);
+        return {
+          opportunities: [],
+          dryRun: true,
+          timestamp: new Date().toISOString()
+        };
+      }
+      return {
+        opportunities,
+        dryRun: true,
+        timestamp: new Date().toISOString()
+      };
+    } catch (err) {
+      logger.error(`[REDIS] Failed to read opportunities: ${err.message}`);
+      return {
+        opportunities: [],
+        dryRun: true,
+        timestamp: new Date().toISOString()
+      };
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- restore `/opportunities` endpoint
- serve cached opportunities from Redis
- add dry-run fallback when Redis key missing
- update tests for new payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688010323368832cab1d07bf98651819