### PR TITLE
PR-Fix-23: resume logic now uses persistent Redis key

### DIFF
--- a/api/__tests__/api.test.js
+++ b/api/__tests__/api.test.js
@@ -6,11 +6,10 @@ process.env.ADMIN_TOKEN = 'testadmintoken';
 process.env.JWT_SECRET = 'testsecret';
 process.env.SANDBOX_MODE = 'true';
 let buildApp;
-let testState;
 let app;
 
 beforeAll(async () => {
-  ({ buildApp, testState } = await import('../index.js'));
+  ({ buildApp } = await import('../index.js'));
   app = buildApp();
   await app.listen({ port: 8080 });
 });
@@ -66,7 +65,7 @@ describeLocal('API authentication', () => {
       .post('/api/login')
       .send({ email: 'user', password: 'pass' });
     const cookie = login.headers['set-cookie'][0].split(';')[0];
-    testState.paused = true;
+    await request(app.server).post('/api/test/panic');
     const authRes = await request(app.server)
       .post('/api/resume')
       .set('Cookie', cookie);

--- a/api/__tests__/panicResume.test.js
+++ b/api/__tests__/panicResume.test.js
@@ -5,13 +5,17 @@ process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'testsecret';
 process.env.SANDBOX_MODE = 'true';
 let buildApp;
-let testState;
 let app;
+let cookie;
 
 beforeAll(async () => {
-  ({ buildApp, testState } = await import('../index.js'));
+  ({ buildApp } = await import('../index.js'));
   app = buildApp();
   await app.listen({ port: 0 });
+  const login = await request(app.server)
+    .post('/api/login')
+    .send({ email: 'user', password: 'pass' });
+  cookie = login.headers['set-cookie'][0].split(';')[0];
 });
 
 afterAll(async () => {
@@ -24,14 +28,20 @@ describeLocal('panic resume cycle', () => {
       .post('/api/test/panic')
       .send({ type: 'loss' });
     expect(panicRes.statusCode).toBe(200);
-    expect(testState.paused).toBe(true);
+    const status1 = await request(app.server)
+      .get('/api/system/status')
+      .set('Cookie', cookie);
+    expect(status1.body.paused).toBe(true);
 
     const metrics1 = await request(app.server).get('/api/metrics/sandbox');
     expect(metrics1.body.panicActive).toBe(true);
 
     const resumeRes = await request(app.server).post('/api/test/resume');
     expect(resumeRes.statusCode).toBe(200);
-    expect(testState.paused).toBe(false);
+    const status2 = await request(app.server)
+      .get('/api/system/status')
+      .set('Cookie', cookie);
+    expect(status2.body.paused).toBe(false);
 
     const metrics2 = await request(app.server).get('/api/metrics/sandbox');
     expect(metrics2.body.panicActive).toBe(false);

--- a/api/__tests__/resume.auth.test.js
+++ b/api/__tests__/resume.auth.test.js
@@ -5,13 +5,13 @@ import logger from '../services/logger.js';
 const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
 let buildApp;
-let testState;
 let app;
 let warnSpy;
 
 beforeAll(async () => {
-  ({ buildApp, testState } = await import('../index.js'));
+  ({ buildApp } = await import('../index.js'));
   app = buildApp();
   await app.listen({ port: 0 });
 });
@@ -31,7 +31,7 @@ afterEach(() => {
 
 describeLocal('resume endpoint auth', () => {
   test('200 with admin token', async () => {
-    testState.paused = true;
+    await request(app.server).post('/api/test/panic');
     const token = app.jwt.sign({ id: 1, role: 'admin' }, { algorithm: 'HS256' });
     const res = await request(app.server)
       .post('/api/resume')
@@ -45,7 +45,7 @@ describeLocal('resume endpoint auth', () => {
   });
 
   test('logs rejection for non-admin', async () => {
-    testState.paused = true;
+    await request(app.server).post('/api/test/panic');
     const token = app.jwt.sign({ id: 2, role: 'user' }, { algorithm: 'HS256' });
     const res = await request(app.server)
       .post('/api/resume')
@@ -56,7 +56,7 @@ describeLocal('resume endpoint auth', () => {
 
   test('200 in sandbox without token', async () => {
     process.env.EXECUTION_MODE = 'sandbox';
-    testState.paused = true;
+    await request(app.server).post('/api/test/panic');
     const res = await request(app.server).post('/api/resume');
     expect(res.statusCode).toBe(200);
   });

--- a/api/__tests__/system.status.test.js
+++ b/api/__tests__/system.status.test.js
@@ -7,12 +7,11 @@ process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'testsecret';
 process.env.SANDBOX_MODE = 'true';
 let buildApp;
-let testState;
 let app;
 let cookie;
 
 beforeAll(async () => {
-  ({ buildApp, testState } = await import('../index.js'));
+  ({ buildApp } = await import('../index.js'));
   app = buildApp();
   await app.listen({ port: 0 });
   const login = await request(app.server)

--- a/api/index.js
+++ b/api/index.js
@@ -17,6 +17,7 @@ import metricsRoutes from './routes/metrics.js';
 import analyticsRoutes from './routes/analytics.js';
 import cgtRoutes from './routes/cgt.js';
 import resumeRoutes from './routes/resume.js';
+import panicRoutes from './routes/panic.js';
 import configRoutes from './routes/config.js';
 import opportunitiesRoutes from './routes/opportunities.js';
 import { getControlChannel } from './config/settings.js';
@@ -25,6 +26,7 @@ import { sendAlert } from '../alerts/alertAgent.js';
 import { sendEmail } from '../alerts/emailAlert.js';
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
 import { start as startWsServer } from './services/wsServer.js';
+import { getPauseState, setPauseState } from './services/pauseState.js';
 
 const { Pool } = pg;
 // Hard stop if credentials or mode are misconfigured
@@ -48,7 +50,7 @@ if (process.env.NODE_ENV === 'production') {
 // Test mode disables external side effects
 
 const isTest = process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID;
-const testState = { paused: false, panicReason: null };
+const panicState = { reason: null };
 
 let redis;
 let pool;
@@ -71,9 +73,11 @@ function buildApp() {
     });
 
     if (isTest) {
+      const store = { 'arb:paused_state': 'false' };
       redis = {
         publish: async () => 1,
-        get: async () => '[]'
+        get: async key => store[key],
+        set: async (key, val) => { store[key] = val; return 'OK'; }
       };
     } else {
       // Redis connection parameters via env vars
@@ -83,7 +87,7 @@ function buildApp() {
       });
     }
 
-    app.register(apiRoutes, { prefix: '/api', testState, redis, pool });
+    app.register(apiRoutes, { prefix: '/api', redis, pool, panicState });
 
     // Ensure external connections close gracefully when the server shuts down
     app.addHook('onClose', async () => {
@@ -110,7 +114,7 @@ const alertSettings = {
   webhook_url: '',
 };
 
-async function apiRoutes(api, { testState, redis, pool }) {
+async function apiRoutes(api, { redis, pool, panicState }) {
   api.register(loginRoute);
   api.register(authRoute);
   api.register(settingsRoutes, { redis });
@@ -211,34 +215,26 @@ async function apiRoutes(api, { testState, redis, pool }) {
 
 
   api.get('/system/status', async () => ({
-    paused: testState.paused,
-    panic_reason: testState.panicReason,
+    paused: await getPauseState(redis),
+    panic_reason: panicState.reason,
   }));
 
     if (isTest) {
-      api.post('/test/panic', async (req, reply) => {
-        if (process.env.SANDBOX_MODE !== 'true') {
-          return reply.code(403).send();
-        }
-        testState.paused = true;
-        testState.panicReason = req.body?.type || null;
-        await redis.publish(getControlChannel(), 'halt');
-        await sendAlert('email', 'Panic brake triggered (test mode)');
-        return { triggered: true };
-      });
-
+      api.register(panicRoutes, { redis, panicState });
       api.post('/test/resume', async (_req, reply) => {
         if (process.env.SANDBOX_MODE !== 'true') {
           return reply.code(403).send();
         }
-        if (!testState.paused) {
+        const paused = await getPauseState(redis);
+        if (!paused) {
           reply.code(400);
           return { error: 'not paused' };
         }
-        testState.paused = false;
-        testState.panicReason = null;
+        await setPauseState(redis, false);
+        panicState.reason = null;
         await redis.publish(getControlChannel(), 'resume');
-        return { resumed: true };
+        logger.info('[RESUME] Trading re-enabled by operator');
+        return { paused: false, source: 'manual' };
       });
 
       api.post('/test/sweep', async (_req, reply) => {
@@ -255,8 +251,8 @@ async function apiRoutes(api, { testState, redis, pool }) {
   api.register(infraRoutes, { redis, pool });
   api.register(modelRoutes, { pool });
   api.register(configRoutes);
-  api.register(resumeRoutes, { redis, testState });
-  api.register(metricsRoutes, { testState });
+  api.register(resumeRoutes, { redis, panicState });
+  api.register(metricsRoutes, { redis });
   api.register(analyticsRoutes, { pool });
   api.register(cgtRoutes, { pool });
 }
@@ -273,4 +269,4 @@ if (!isTest) {
 }
 
 export default app;
-export { buildApp, logReplayCLI, testState };
+export { buildApp, logReplayCLI };

--- a/api/middleware/validate.js
+++ b/api/middleware/validate.js
@@ -10,16 +10,16 @@ export function requireFields(fields) {
   };
 }
 
-export function ensurePaused(testState) {
-  return async function(_req, reply) {
-    if (testState && !testState.paused) {
+import { getPauseState, setPauseState } from '../services/pauseState.js';
+
+export function ensurePaused(redis) {
+  return async function (_req, reply) {
+    const paused = await getPauseState(redis);
+    if (!paused) {
       reply.code(400);
       reply.send({ error: 'not paused' });
       return;
     }
-    if (testState) {
-      testState.paused = false;
-      testState.panicReason = null;
-    }
+    await setPauseState(redis, false);
   };
 }

--- a/api/routes/metrics.js
+++ b/api/routes/metrics.js
@@ -6,7 +6,9 @@ import { getExecutionMode } from '../config/settings.js';
 const PROM_LIVE_URL = process.env.PROM_LIVE_URL || process.env.PROM_URL || 'http://prometheus:9090';
 const PROM_SANDBOX_URL = process.env.PROM_SANDBOX_URL || 'http://prometheus-sandbox:9090';
 
-export default async function metricsRoutes(app, { testState } = {}) {
+import { getPauseState } from '../services/pauseState.js';
+
+export default async function metricsRoutes(app, { redis } = {}) {
   const seeded = {
     equityCurve: Array.from({ length: 20 }, (_, i) => i * 5),
     latency: Array.from({ length: 20 }, () => 30 + Math.random() * 10),
@@ -19,7 +21,8 @@ export default async function metricsRoutes(app, { testState } = {}) {
   const fetchMetrics = async (req, mode) => {
     const execMode = mode || getExecutionMode(req);
     if (execMode === 'sandbox' || process.env.NODE_ENV === 'test') {
-      return { ...seeded, panicActive: testState?.paused ?? false };
+      const paused = await getPauseState(redis);
+      return { ...seeded, panicActive: paused };
     }
 
     const promUrl = execMode === 'live' ? PROM_LIVE_URL : PROM_SANDBOX_URL;

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -1,0 +1,22 @@
+import { getControlChannel } from '../config/settings.js';
+import { sendAlert } from '../../alerts/alertAgent.js';
+import logger from '../services/logger.js';
+import { setPauseState } from '../services/pauseState.js';
+
+export default async function panicRoutes(app, { redis, panicState }) {
+  app.post('/test/panic', async (req, reply) => {
+    if (process.env.SANDBOX_MODE !== 'true') {
+      return reply.code(403).send();
+    }
+    await setPauseState(redis, true);
+    panicState.reason = req.body?.type || null;
+    await redis.publish(getControlChannel(), 'halt');
+    logger.warn('[PAUSE] Trading halted via panic brake');
+    try {
+      await sendAlert('email', 'Panic brake triggered (test mode)');
+    } catch (err) {
+      logger.error('[ALERT FAILURE] Panic alert email failed to send: missing SMTP config');
+    }
+    return { paused: true, source: 'manual' };
+  });
+}

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -2,16 +2,20 @@ import { requireAdmin } from '../middleware/auth.js';
 import { sendAlert } from '../../alerts/alertAgent.js';
 import { getControlChannel } from '../config/settings.js';
 import { ensurePaused } from '../middleware/validate.js';
+import logger from '../services/logger.js';
+import { setPauseState } from '../services/pauseState.js';
 
 export default async function resumeRoutes(app, opts) {
-  const { redis, testState } = opts;
+  const { redis, panicState } = opts;
 
   app.post(
     '/resume',
-    { preHandler: [requireAdmin, ensurePaused(testState)] },
+    { preHandler: [requireAdmin, ensurePaused(redis)] },
     async (req, reply) => {
     const channel = getControlChannel();
     await redis.publish(channel, 'resume');
+    await setPauseState(redis, false);
+    panicState.reason = null;
     const user = req.user?.email || 'unknown';
     const msg = `Trading resumed by ${user} at ${new Date().toISOString()}`;
     await redis.publish('alerts', msg);
@@ -24,6 +28,7 @@ export default async function resumeRoutes(app, opts) {
     } else {
       req.log.info(`[DRY-RUN] Resume alert: ${msg}`);
     }
+    logger.info('[RESUME] Trading re-enabled by operator');
     return { resumed: true };
   }
   );

--- a/api/services/pauseState.js
+++ b/api/services/pauseState.js
@@ -1,0 +1,21 @@
+import logger from './logger.js';
+
+export const PAUSE_KEY = 'arb:paused_state';
+
+export async function setPauseState(redis, value) {
+  try {
+    await redis.set(PAUSE_KEY, value ? 'true' : 'false');
+  } catch (err) {
+    logger.warn('[REDIS ERROR] Cannot access paused state — defaulting to safe paused mode');
+  }
+}
+
+export async function getPauseState(redis) {
+  try {
+    const val = await redis.get(PAUSE_KEY);
+    return val === 'true';
+  } catch (err) {
+    logger.warn('[REDIS ERROR] Cannot access paused state — defaulting to safe paused mode');
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- support persistent paused state in Redis
- update panic/resume routes to set `arb:paused_state`
- add Redis-backed pause state helpers
- adjust tests for new pause handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688012170b84832c9797c2b83e5a794c