### PR TITLE
PR-Fix-24: add /alert/panic secure route

### DIFF
--- a/api/__tests__/alert.panic.test.js
+++ b/api/__tests__/alert.panic.test.js
@@ -1,0 +1,40 @@
+import request from 'supertest';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+let buildApp;
+let app;
+let cookie;
+
+beforeAll(async () => {
+  ({ buildApp } = await import('../index.js'));
+  app = buildApp();
+  await app.listen({ port: 0 });
+  const login = await request(app.server)
+    .post('/api/login')
+    .send({ email: 'user', password: 'pass' });
+  cookie = login.headers['set-cookie'][0].split(';')[0];
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describeLocal('alert panic endpoint', () => {
+  test('requires auth', async () => {
+    const res = await request(app.server).post('/api/alert/panic');
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('triggers pause with source', async () => {
+    const res = await request(app.server)
+      .post('/api/alert/panic')
+      .set('Cookie', cookie)
+      .send({ source: 'trading-bot-1' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.paused).toBe(true);
+    expect(res.body.triggeredBy).toBe('trading-bot-1');
+    expect(res.body).toHaveProperty('timestamp');
+  });
+});

--- a/api/index.js
+++ b/api/index.js
@@ -18,6 +18,7 @@ import analyticsRoutes from './routes/analytics.js';
 import cgtRoutes from './routes/cgt.js';
 import resumeRoutes from './routes/resume.js';
 import panicRoutes from './routes/panic.js';
+import alertRoutes from './routes/alert.js';
 import configRoutes from './routes/config.js';
 import opportunitiesRoutes from './routes/opportunities.js';
 import { getControlChannel } from './config/settings.js';
@@ -218,6 +219,8 @@ async function apiRoutes(api, { redis, pool, panicState }) {
     paused: await getPauseState(redis),
     panic_reason: panicState.reason,
   }));
+
+  api.register(alertRoutes, { redis });
 
     if (isTest) {
       api.register(panicRoutes, { redis, panicState });

--- a/api/routes/alert.js
+++ b/api/routes/alert.js
@@ -1,0 +1,25 @@
+import { getControlChannel } from '../config/settings.js';
+import logger from '../services/logger.js';
+import { PAUSE_KEY } from '../services/pauseState.js';
+
+export default async function alertRoutes(app, { redis }) {
+  app.post('/alert/panic', async (req, reply) => {
+    const source = req.body?.source || 'unknown';
+    const timestamp = new Date().toISOString();
+
+    try {
+      const val = await redis.get(PAUSE_KEY);
+      const alreadyPaused = val === 'true';
+      if (!alreadyPaused) {
+        await redis.set(PAUSE_KEY, 'true');
+        await redis.publish(getControlChannel(), 'halt');
+      }
+      logger.warn(`[ALERT] Panic triggered via /alert/panic by ${source} at ${timestamp}`);
+      return { paused: true, triggeredBy: source, timestamp };
+    } catch (err) {
+      logger.error('[REDIS ERROR] Could not set pause state from alert trigger');
+      reply.code(503);
+      return { error: 'service unavailable' };
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- implement `api/routes/alert.js` new route `/alert/panic`
- register the new alert route in `api/index.js`
- add test coverage for panic alert route

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_688081f42240832ca169a1304a6c4cd7