### PR TITLE
PR-Fix-26: reinforce cold wallet sweep safety

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -29,6 +29,7 @@ import { sendEmail } from '../alerts/emailAlert.js';
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
 import { start as startWsServer } from './services/wsServer.js';
 import { getPauseState, setPauseState } from './services/pauseState.js';
+import { redisReachable, fetchBalances } from './services/balances.js';
 
 const { Pool } = pg;
 // Hard stop if credentials or mode are misconfigured
@@ -248,9 +249,27 @@ async function apiRoutes(api, { redis, pool, panicState }) {
         if (process.env.SANDBOX_MODE !== 'true') {
           return reply.code(403).send();
         }
-        logger.info('[DRY-RUN MODE] Cold wallet sweep logic verified. No assets moved.');
+
+        const timestamp = new Date().toISOString();
+
+        const redisOk = await redisReachable(redis);
+        if (!redisOk) {
+          logger.error('[SWEEP] Redis unavailable – aborting sweep for safety');
+          return { sweepInitiated: false, reason: 'Redis unavailable', timestamp };
+        }
+
+        const { balances, complete } = await fetchBalances(pool, redis);
+        const assetCount = balances.length;
+        const total = balances.reduce((sum, b) => sum + (b.usd_value || 0), 0);
+        const totalStr = total.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+        logger.info(`[SWEEP] Simulated sweep of ${assetCount} assets totaling $${totalStr} (dry-run only)`);
+        if (!complete) {
+          logger.warn('[SWEEP WARNING] Balance source incomplete – operator review recommended');
+        }
+
         await redis.publish(getControlChannel(), 'sweep');
-        return { swept: true };
+        return { sweepInitiated: true, timestamp };
       });
     }
 

--- a/api/services/balances.js
+++ b/api/services/balances.js
@@ -1,0 +1,36 @@
+import logger from './logger.js';
+
+export async function redisReachable(redis) {
+  try {
+    await redis.ping();
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+export async function fetchBalances(pool, redis) {
+  let balances = [];
+  let source = 'postgres';
+  let complete = true;
+  try {
+    const { rows } = await pool.query('SELECT asset, usd_value FROM wallet_balances');
+    balances = rows || [];
+    if (balances.length === 0) complete = false;
+  } catch (err) {
+    logger.warn('[SWEEP] Postgres unavailable, falling back to Redis');
+    source = 'redis';
+    complete = false;
+    try {
+      const data = await redis.hgetall('wallet_balances');
+      balances = Object.entries(data).map(([asset, val]) => ({ asset, usd_value: parseFloat(val) }));
+      if (Object.keys(data).length > 0) complete = true;
+    } catch (err2) {
+      // ignore, handled by incomplete flag
+    }
+  }
+  if (!complete) {
+    logger.warn('[SWEEP WARNING] Balance source incomplete – operator review recommended');
+  }
+  return { balances, source, complete };
+}


### PR DESCRIPTION
## Summary
- add Redis reachability and balance fetch helpers
- harden `/api/test/sweep` endpoint with Redis safety and balance verification

## Testing
- `npm install --prefix api`
- `npm install`
- `npm test --prefix api`

------
https://chatgpt.com/codex/tasks/task_b_68808bb6a378832cb8aa750ca5ab7400