### PR TITLE
PR-Fix-29: structured logging for panic/resume events

### DIFF
--- a/api/routes/alert.js
+++ b/api/routes/alert.js
@@ -14,7 +14,15 @@ export default async function alertRoutes(app, { redis }) {
         await redis.set(PAUSE_KEY, 'true');
         await redis.publish(getControlChannel(), 'halt');
       }
-      logger.warn(`[ALERT] Panic triggered via /alert/panic by ${source} at ${timestamp}`);
+      logger.warn(
+        JSON.stringify({
+          timestamp,
+          event: 'panic_triggered',
+          component: 'api',
+          source: 'alert_api',
+          operator: source,
+        }),
+      );
       return { paused: true, triggeredBy: source, timestamp };
     } catch (err) {
       logger.error('[REDIS ERROR] Could not set pause state from alert trigger');

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -11,7 +11,15 @@ export default async function panicRoutes(app, { redis, panicState }) {
     await setPauseState(redis, true);
     panicState.reason = req.body?.type || null;
     await redis.publish(getControlChannel(), 'halt');
-    logger.warn('[PAUSE] Trading halted via panic brake');
+    logger.warn(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        event: 'panic_triggered',
+        component: 'api',
+        source: 'dashboard',
+        operator: req.user?.email || 'unknown',
+      }),
+    );
     try {
       await sendAlert('email', 'Panic brake triggered (test mode)');
     } catch (err) {

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -28,7 +28,15 @@ export default async function resumeRoutes(app, opts) {
     } else {
       req.log.info(`[DRY-RUN] Resume alert: ${msg}`);
     }
-    logger.info('[RESUME] Trading re-enabled by operator');
+    logger.info(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        event: 'resume_triggered',
+        component: 'api',
+        source: 'dashboard',
+        operator: user,
+      }),
+    );
     return { resumed: true };
   }
   );

--- a/executor/src/main/java/CircuitBreaker.java
+++ b/executor/src/main/java/CircuitBreaker.java
@@ -3,6 +3,7 @@ package executor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 /**
  * Global circuit breaker monitoring win rate and account drawdown.
@@ -30,7 +31,16 @@ public class CircuitBreaker {
     public void check(double winRate, double drawdownPct) {
         if (!tripped.get() && (winRate < minWinRate || drawdownPct > maxDrawdownPct)) {
             tripped.set(true);
-            logger.error("CIRCUIT BREAKER TRIPPED winRate={} drawdownPct={}", winRate, drawdownPct);
+            logger.error(
+                    com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
+                            .createObjectNode()
+                            .put("timestamp", java.time.Instant.now().toString())
+                            .put("event", "panic_triggered")
+                            .put("component", "executor")
+                            .put("source", "internal")
+                            .put("operator", "system")
+                            .put("reason", "CIRCUIT_BREAKER")
+                            .toString());
             AlertManager.sendAlert("CIRCUIT", "CIRCUIT BREAKER TRIPPED");
             redisClient.publish("alerts", "CIRCUIT BREAKER TRIPPED");
             redisClient.publish(RedisClient.getControlChannel(), "halt");

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -14,6 +14,7 @@ import executor.ExecutionMode;
 import executor.RedisClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -455,7 +456,15 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         if (isPanic.compareAndSet(true, false)) {
             circuitBreaker.reset();
             long ts = System.currentTimeMillis();
-            logger.info("[RESUME SIGNAL RECEIVED] reason=manual ts={}", ts);
+            logger.info(
+                    com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
+                            .createObjectNode()
+                            .put("timestamp", java.time.Instant.now().toString())
+                            .put("event", "resume_triggered")
+                            .put("component", "executor")
+                            .put("source", "dashboard")
+                            .put("operator", "system")
+                            .toString());
             AlertManager.send("RESUME", "Trading resumed at " + ts);
             redisClient.publish("alerts", "Trading resumed at " + ts);
             redisClient.publish(controlChannel, "resume:" + ts);
@@ -475,7 +484,15 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         if (isPanic.compareAndSet(true, false)) {
             circuitBreaker.reset();
             long ts = System.currentTimeMillis();
-            logger.info("[RESUME SIGNAL RECEIVED] reason=control ts={}", ts);
+            logger.info(
+                    com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
+                            .createObjectNode()
+                            .put("timestamp", java.time.Instant.now().toString())
+                            .put("event", "resume_triggered")
+                            .put("component", "executor")
+                            .put("source", "redis")
+                            .put("operator", "system")
+                            .toString());
             AlertManager.send("RESUME", "Trading resumed at " + ts);
             redisClient.publish("alerts", "Trading resumed at " + ts);
             redisClient.publish(controlChannel, "resume:" + ts);

--- a/executor/src/main/java/PanicBrake.java
+++ b/executor/src/main/java/PanicBrake.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import executor.ProfitTracker;
 import executor.RedisClient;
 import executor.Config;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class PanicBrake {
     private static final Logger logger = LoggerFactory.getLogger(PanicBrake.class);
@@ -97,7 +98,16 @@ public class PanicBrake {
         }
 
         if (reason != null) {
-            logger.error("[PANIC TRIGGERED] reason={} ts={}", reason, System.currentTimeMillis());
+            logger.error(
+                    com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
+                            .createObjectNode()
+                            .put("timestamp", java.time.Instant.now().toString())
+                            .put("event", "panic_triggered")
+                            .put("component", "executor")
+                            .put("source", "internal")
+                            .put("operator", "system")
+                            .put("reason", reason)
+                            .toString());
             triggered = true;
         }
 

--- a/executor/src/main/java/ResumeHandler.java
+++ b/executor/src/main/java/ResumeHandler.java
@@ -5,6 +5,7 @@ import executor.Executor;
 import executor.RedisClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 /**
  * Listens for "resume" commands on a Redis channel and notifies the
@@ -49,7 +50,15 @@ public class ResumeHandler {
                             @Override
                             public void onMessage(String channel, String message) {
                                 if ("resume".equalsIgnoreCase(message)) {
-                                    logger.info("Received 'resume' command from Redis");
+                                    logger.info(
+                                            com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
+                                                    .createObjectNode()
+                                                    .put("timestamp", java.time.Instant.now().toString())
+                                                    .put("event", "resume_triggered")
+                                                    .put("component", "executor")
+                                                    .put("source", "redis")
+                                                    .put("operator", "system")
+                                                    .toString());
                                     executor.resumeFromPanic();
                                 }
                             }
@@ -59,7 +68,15 @@ public class ResumeHandler {
                             @Override
                             public void onMessage(String channel, String message) {
                                 if ("resume".equalsIgnoreCase(message)) {
-                                    logger.info("Received 'resume' command from Redis");
+                                    logger.info(
+                                            com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
+                                                    .createObjectNode()
+                                                    .put("timestamp", java.time.Instant.now().toString())
+                                                    .put("event", "resume_triggered")
+                                                    .put("component", "executor")
+                                                    .put("source", "redis")
+                                                    .put("operator", "system")
+                                                    .toString());
                                     executor.resumeFromPanic();
                                 }
                             }


### PR DESCRIPTION
## Summary
- emit JSON logs when panic triggered from dashboard test endpoint
- emit structured logs for API alert panic route
- log structured resume events in API
- log panic events inside Executor's PanicBrake and CircuitBreaker
- log resume events inside Executor and when Redis resume message received

## Testing
- `npm test`
- `pytest -q`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_688097c5cad8832c9d75759519fa9ffd