### PR TITLE
fix: enforce resume safety with system health gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased]
 - Add real-time panic brake and execution mode banner to operator dashboard
 - Enforce system health validation before allowing panic resume actions
+- Enforced system health check and confirmation step for resume logic (API + executor)
 - Secure /resume endpoint with execution-mode-aware admin check
 
 - Downgrade numpy to 2.1.3 to resolve TensorFlow install conflict.

--- a/api/index.js
+++ b/api/index.js
@@ -18,6 +18,7 @@ import metricsRoutes from './routes/metrics.js';
 import analyticsRoutes from './routes/analytics.js';
 import cgtRoutes from './routes/cgt.js';
 import resumeRoutes from './routes/resume.js';
+import systemHealthRoutes from './routes/systemHealth.js';
 import panicRoutes from './routes/panic.js';
 import alertRoutes from './routes/alert.js';
 import configRoutes from './routes/config.js';
@@ -224,6 +225,8 @@ async function apiRoutes(api, { redis, pool, panicState }) {
     paused: await getPauseState(redis),
     panic_reason: panicState.reason,
   }));
+
+  api.register(systemHealthRoutes, { redis, pool });
 
   api.register(alertRoutes, { redis });
 

--- a/api/middleware/validate.js
+++ b/api/middleware/validate.js
@@ -20,6 +20,5 @@ export function ensurePaused(redis) {
       reply.send({ error: 'not paused' });
       return;
     }
-    await setPauseState(redis, false);
   };
 }

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -1,22 +1,63 @@
 import { requireAdmin } from '../middleware/auth.js';
 import { sendAlert } from '../../alerts/alertAgent.js';
 import { getControlChannel } from '../config/settings.js';
+import fs from 'fs';
+import path from 'path';
 import { ensurePaused } from '../middleware/validate.js';
 import logger from '../services/logger.js';
 import { setPauseState } from '../services/pauseState.js';
 
 export default async function resumeRoutes(app, opts) {
   const { redis, panicState } = opts;
+  const logDir = process.env.LOG_DIR || '/var/log/prism-arbitrage';
+  const resumeLog = path.join(logDir, 'resume.log');
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+
+  function logAttempt(event, operator, extra = {}) {
+    const entry = {
+      timestamp: new Date().toISOString(),
+      event,
+      operator,
+      ...extra,
+    };
+    fs.appendFile(resumeLog, JSON.stringify(entry) + '\n', () => {});
+  }
 
   app.post(
     '/resume',
     { preHandler: [requireAdmin, ensurePaused(redis)] },
     async (req, reply) => {
+    const user = req.user?.email || 'unknown';
+
+    const health = await app.inject({ method: 'GET', url: '/api/system/health' });
+    let healthy = false;
+    try {
+      const body = JSON.parse(health.payload);
+      healthy = body.healthy === true;
+    } catch {}
+    if (health.statusCode !== 200 || !healthy) {
+      logAttempt('resume_blocked_health', user);
+      reply.code(403);
+      return { error: 'System not healthy \u2014 resume denied' };
+    }
+
+    const confirm = req.query.confirm === 'true';
+    if (!confirm && (panicState.reason === 'loss' || panicState.reason === 'latency')) {
+      logAttempt('resume_needs_override', user, { reason: panicState.reason });
+      reply.code(403);
+      return { override_required: true };
+    }
+
+    if (confirm) {
+      await redis.set('resume_confirmed', 'true', 'EX', 60);
+    }
+
     const channel = getControlChannel();
     await redis.publish(channel, 'resume');
     await setPauseState(redis, false);
     panicState.reason = null;
-    const user = req.user?.email || 'unknown';
     const msg = `Trading resumed by ${user} at ${new Date().toISOString()}`;
     await redis.publish('alerts', msg);
     if (process.env.SANDBOX_MODE !== 'true') {
@@ -28,6 +69,7 @@ export default async function resumeRoutes(app, opts) {
     } else {
       req.log.info(`[DRY-RUN] Resume alert: ${msg}`);
     }
+    logAttempt('resume_success', user);
     logger.info(
       JSON.stringify({
         timestamp: new Date().toISOString(),

--- a/api/routes/systemHealth.js
+++ b/api/routes/systemHealth.js
@@ -1,0 +1,29 @@
+export default async function systemHealthRoutes(app, opts) {
+  const { redis, pool } = opts;
+
+  app.get('/system/health', async () => {
+    let redisHealthy = true;
+    try {
+      if (typeof redis.ping === 'function') {
+        await redis.ping();
+      }
+    } catch {
+      redisHealthy = false;
+    }
+
+    let dbHealthy = true;
+    try {
+      await pool.query('SELECT 1');
+    } catch {
+      dbHealthy = false;
+    }
+
+    return {
+      healthy: redisHealthy && dbHealthy,
+      subsystems: {
+        redis: redisHealthy,
+        db: dbHealthy,
+      },
+    };
+  });
+}

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -603,4 +603,19 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             return Math.sqrt(var);
         }
     }
+
+    /** Current daily loss percentage. */
+    public double getCurrentLossPct() {
+        return dailyLossPct;
+    }
+
+    /** Current average latency in milliseconds. */
+    public double getCurrentLatencyMs() {
+        return avgLatencyMs;
+    }
+
+    /** Execution configuration. */
+    public Config getConfig() {
+        return config;
+    }
 }

--- a/executor/src/main/java/RedisClient.java
+++ b/executor/src/main/java/RedisClient.java
@@ -194,6 +194,19 @@ public class RedisClient extends Thread {
         }
     }
 
+    /**
+     * Check if resume has been confirmed in Redis.
+     */
+    public boolean isResumeConfirmed() {
+        try (Jedis jedis = new Jedis(host, port)) {
+            String val = jedis.get("resume_confirmed");
+            return val != null && val.equalsIgnoreCase("true");
+        } catch (Exception e) {
+            logger.error("Redis read failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
     /** {@inheritDoc} */
     @Override
     public void run() {

--- a/executor/src/main/java/ResumeController.java
+++ b/executor/src/main/java/ResumeController.java
@@ -4,6 +4,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Handles resume requests with safety checks.
@@ -13,7 +15,24 @@ public class ResumeController {
 
     private final Executor executor;
     private final SystemHealthChecker checker;
+    private final RedisClient redis;
     private final ObjectMapper mapper = new ObjectMapper();
+    private final Path resumeLog;
+
+    private void logAttempt(String event, String detail) {
+        try {
+            String entry = mapper.writeValueAsString(java.util.Map.of(
+                    "timestamp", java.time.Instant.now().toString(),
+                    "event", event,
+                    "detail", detail));
+            Files.createDirectories(resumeLog.getParent());
+            Files.writeString(resumeLog, entry + System.lineSeparator(),
+                    java.nio.file.StandardOpenOption.CREATE,
+                    java.nio.file.StandardOpenOption.APPEND);
+        } catch (Exception e) {
+            logger.error("Failed to write resume log", e);
+        }
+    }
 
     /** Simple container for HTTP-like responses. */
     public static class Response {
@@ -25,9 +44,12 @@ public class ResumeController {
         }
     }
 
-    public ResumeController(Executor executor, SystemHealthChecker checker) {
+    public ResumeController(Executor executor, SystemHealthChecker checker, RedisClient redis) {
         this.executor = executor;
         this.checker = checker == null ? new SystemHealthChecker() : checker;
+        this.redis = redis;
+        String dir = System.getenv().getOrDefault("LOG_DIR", "/var/log/prism-arbitrage");
+        this.resumeLog = java.nio.file.Paths.get(dir, "resume.log");
     }
 
     /**
@@ -59,12 +81,38 @@ public class ResumeController {
             }
         }
 
-        executor.resumeFromPanic();
-        try {
-            String body = mapper.writeValueAsString(java.util.Map.of("resumed", true));
-            return new Response(200, body);
-        } catch (Exception e) {
-            return new Response(200, "{\"resumed\":true}");
+        double lossPct = executor.getCurrentLossPct();
+        double latency = executor.getCurrentLatencyMs();
+        boolean breached = lossPct > executor.getConfig().getLossCapPct()
+                || latency > executor.getConfig().getLatencyMaxMs();
+
+        if (breached) {
+            logAttempt("risk_active", "loss=" + lossPct + ",latency=" + latency);
+            long start = System.currentTimeMillis();
+            while (System.currentTimeMillis() - start < 60_000) {
+                if (redis != null && redis.isResumeConfirmed()) {
+                    executor.resumeFromPanic();
+                    logAttempt("resume_override", "confirmed");
+                    try {
+                        String body = mapper.writeValueAsString(java.util.Map.of("resumed", true));
+                        return new Response(200, body);
+                    } catch (Exception e) {
+                        return new Response(200, "{\"resumed\":true}");
+                    }
+                }
+                try { Thread.sleep(1000); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); break; }
+            }
+            logAttempt("resume_blocked", "risk breach");
+            return new Response(403, "{\"error\":\"Resume blocked due to active risk breach\"}");
+        } else {
+            executor.resumeFromPanic();
+            logAttempt("resume_success", "auto");
+            try {
+                String body = mapper.writeValueAsString(java.util.Map.of("resumed", true));
+                return new Response(200, body);
+            } catch (Exception e) {
+                return new Response(200, "{\"resumed\":true}");
+            }
         }
     }
 }

--- a/executor/src/test/java/ResumeSafetyTest.java
+++ b/executor/src/test/java/ResumeSafetyTest.java
@@ -11,11 +11,17 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("local")
 public class ResumeSafetyTest {
 
+    static class DummyRedisClient extends RedisClient {
+        boolean confirmed = false;
+        DummyRedisClient() { super("localhost", 6379, "chan", (c,m)->{}); }
+        @Override
+        public boolean isResumeConfirmed() { return confirmed; }
+    }
+
     static class DummyExecutor extends Executor {
         boolean resumed = false;
-        DummyExecutor() {
-            super(new RedisClient("localhost", 6379, "chan", (c,m)->{}),
-                  "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.LIVE));
+        DummyExecutor(DummyRedisClient client) {
+            super(client, "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.LIVE));
         }
         @Override
         public void resumeFromPanic() { resumed = true; }
@@ -30,14 +36,15 @@ public class ResumeSafetyTest {
         @Override public boolean isPanicStateCleared() { return panic; }
     }
 
-    private ResumeController.Response call(DummyExecutor exec, StubChecker chk) {
-        ResumeController controller = new ResumeController(exec, chk);
+    private ResumeController.Response call(DummyExecutor exec, StubChecker chk, DummyRedisClient redis) {
+        ResumeController controller = new ResumeController(exec, chk, redis);
         return controller.resume();
     }
 
     @Test
     void blocksWhenHeartbeatDead() {
-        DummyExecutor exec = new DummyExecutor();
+        DummyRedisClient redis = new DummyRedisClient();
+        DummyExecutor exec = new DummyExecutor(redis);
         StubChecker chk = new StubChecker();
         chk.heartbeat = false;
         ByteArrayOutputStream err = new ByteArrayOutputStream();
@@ -45,7 +52,7 @@ public class ResumeSafetyTest {
         System.setErr(new PrintStream(err));
         ResumeController.Response res;
         try {
-            res = call(exec, chk);
+            res = call(exec, chk, redis);
         } finally {
             System.setErr(orig);
         }
@@ -57,10 +64,11 @@ public class ResumeSafetyTest {
 
     @Test
     void blocksWhenSweeperBusy() {
-        DummyExecutor exec = new DummyExecutor();
+        DummyRedisClient redis = new DummyRedisClient();
+        DummyExecutor exec = new DummyExecutor(redis);
         StubChecker chk = new StubChecker();
         chk.sweeper = false;
-        ResumeController.Response res = call(exec, chk);
+        ResumeController.Response res = call(exec, chk, redis);
         assertEquals(503, res.status);
         assertTrue(res.body.contains("sweeper"));
         assertFalse(exec.resumed);
@@ -68,10 +76,11 @@ public class ResumeSafetyTest {
 
     @Test
     void blocksWhenPanicFlagSet() {
-        DummyExecutor exec = new DummyExecutor();
+        DummyRedisClient redis = new DummyRedisClient();
+        DummyExecutor exec = new DummyExecutor(redis);
         StubChecker chk = new StubChecker();
         chk.panic = false;
-        ResumeController.Response res = call(exec, chk);
+        ResumeController.Response res = call(exec, chk, redis);
         assertEquals(503, res.status);
         assertTrue(res.body.contains("panicFlag"));
         assertFalse(exec.resumed);


### PR DESCRIPTION
## Summary
- implement system health route
- validate health and override confirmation in resume API
- write resume attempts to `resume.log`
- add resume confirmation check for Redis client
- require explicit confirmation in `ResumeController`

## Testing
- `test/verify-env.sh`

------
https://chatgpt.com/codex/tasks/task_b_6880b88f0158832cac9fd3ee5643cf0b