### PR TITLE
fix: validate risk limits on live config update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Added feed-aggregator deployment
 - Integrated sealed secrets
 - Fix panic resume and Redis signal behavior in Executor and PanicBrake
+- Live config reloads now enforce risk validation (loss %, latency, coin exposure)
 - Remove plaintext .env.sandbox file and enforce secret hygiene in CI and gitignore
 - Cancel all legs on partial fill to prevent orphaned exposure in SpreadOpportunity
 - CVE scanning with Trivy

--- a/executor/src/main/java/ConfigManager.java
+++ b/executor/src/main/java/ConfigManager.java
@@ -1,0 +1,100 @@
+package executor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Loads and maintains runtime risk configuration from Redis.
+ * Every update is validated before being applied.
+ */
+public class ConfigManager {
+    private static final Logger logger = LoggerFactory.getLogger(ConfigManager.class);
+    private static final Path REJECT_LOG = Path.of("logs", "config_reject.log");
+
+    private final String redisHost;
+    private final int redisPort;
+
+    private double maxLossPct;
+    private double latencyMaxMs;
+    private double coinExposureLimit;
+
+    public ConfigManager(String redisHost, int redisPort, double maxLossPct,
+                         double latencyMaxMs, double coinExposureLimit) {
+        this.redisHost = redisHost;
+        this.redisPort = redisPort;
+        this.maxLossPct = maxLossPct;
+        this.latencyMaxMs = latencyMaxMs;
+        this.coinExposureLimit = coinExposureLimit;
+    }
+
+    public double getMaxLossPct() {
+        return maxLossPct;
+    }
+
+    public double getLatencyMaxMs() {
+        return latencyMaxMs;
+    }
+
+    public double getCoinExposureLimit() {
+        return coinExposureLimit;
+    }
+
+    /** Reload configuration from Redis and validate before applying. */
+    public void reload() {
+        try (Jedis jedis = new Jedis(redisHost, redisPort)) {
+            String json = jedis.get("executor:config");
+            if (json != null) {
+                applyJson(json);
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to reload config from redis: {}", e.getMessage());
+        }
+    }
+
+    /** Visible for tests: apply a config JSON string. */
+    void applyJson(String json) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(json);
+        double newLoss = node.path("maxLossPct").asDouble(maxLossPct);
+        double newLatency = node.path("latencyMaxMs").asDouble(latencyMaxMs);
+        double newExposure = node.path("coinExposureLimit").asDouble(coinExposureLimit);
+
+        ConfigValidator validator = new ConfigValidator(newLoss, newLatency,
+                0.5, 1.0, 0.0);
+        try {
+            validator.validate();
+            String bad = ConfigValidator.validateRiskLimits(newLoss, newLatency, newExposure);
+            if (bad != null) {
+                reject(bad);
+                return;
+            }
+            this.maxLossPct = newLoss;
+            this.latencyMaxMs = newLatency;
+            this.coinExposureLimit = newExposure;
+            logger.info("Config updated: loss={} latency={} exposure={}",
+                    newLoss, newLatency, newExposure);
+        } catch (RuntimeException ex) {
+            reject(ex.getMessage());
+        }
+    }
+
+    private void reject(String reason) {
+        logger.warn("Invalid config rejected: {}", reason);
+        try {
+            Files.createDirectories(REJECT_LOG.getParent());
+            Files.writeString(REJECT_LOG,
+                    reason + System.lineSeparator(),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            logger.error("Failed to write rejection log: {}", e.getMessage());
+        }
+    }
+}

--- a/executor/src/main/java/ConfigValidator.java
+++ b/executor/src/main/java/ConfigValidator.java
@@ -53,5 +53,26 @@ public class ConfigValidator {
 
         System.out.println("[VALIDATOR] Configs validated: OK");
     }
+
+    /**
+     * Validate live risk limits when reloading configuration at runtime.
+     *
+     * @param lossPct   new maximum loss percentage
+     * @param latencyMs new latency ceiling in milliseconds
+     * @param exposurePct new coin exposure percentage of NAV
+     * @return name of the parameter that violated limits, or null if all safe
+     */
+    public static String validateRiskLimits(double lossPct, double latencyMs, double exposurePct) {
+        if (lossPct > 5.0) {
+            return "maxLossPct";
+        }
+        if (latencyMs > 1000.0) {
+            return "latencyMaxMs";
+        }
+        if (exposurePct > 30.0) {
+            return "coinExposureLimit";
+        }
+        return null;
+    }
 }
 

--- a/executor/src/test/java/ConfigManagerTest.java
+++ b/executor/src/test/java/ConfigManagerTest.java
@@ -1,0 +1,20 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class ConfigManagerTest {
+
+    @Test
+    void unsafeConfigIsRejectedDuringReload() throws Exception {
+        ConfigManager mgr = new ConfigManager("localhost", 6379, 3.0, 200.0, 10.0);
+        String badJson = "{\"maxLossPct\":7.0,\"latencyMaxMs\":200,\"coinExposureLimit\":20}";
+        mgr.applyJson(badJson);
+        assertEquals(3.0, mgr.getMaxLossPct(), 1e-9);
+        assertEquals(200.0, mgr.getLatencyMaxMs(), 1e-9);
+        assertEquals(10.0, mgr.getCoinExposureLimit(), 1e-9);
+    }
+}


### PR DESCRIPTION
## Summary
- validate risk limits every time config hot reloads
- reject unsafe settings and log failures
- test config manager live validation
- document change in changelog

## Checklist
- [x] ConfigValidator hooked into hot reload path
- [x] Unsafe configs rejected and logged
- [x] Tests passing
- [x] Changelog updated

------
https://chatgpt.com/codex/tasks/task_b_6880b89eb5c4832ca1614efeba7b590f