### PR TITLE
fix: enforce slippage threshold before order placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - CVE scanning with Trivy
 - Split metrics endpoints by execution mode to support safe observability
 - Update documentation and config comments to match final audit-compliant platform behavior
+- Enforced slippage check before trade execution; configurable threshold via config
 - Rewrite documentation to reflect all audited system behavior and enforce operator clarity
 
 ## [Batch 1] - 2025-07-02

--- a/executor/src/main/java/Config.java
+++ b/executor/src/main/java/Config.java
@@ -6,6 +6,7 @@ public class Config {
     private final double lossCapPct;
     private final double latencyMaxMs;
     private final double winRateThreshold;
+    private final double maxSlippagePct;
 
     public Config(ExecutionMode mode) {
         this.executionMode = mode;
@@ -15,6 +16,8 @@ public class Config {
                 System.getenv().getOrDefault("LATENCY_MAX_MS", "250"));
         this.winRateThreshold = Double.parseDouble(
                 System.getenv().getOrDefault("WIN_RATE_THRESHOLD", "0.5"));
+        this.maxSlippagePct = Double.parseDouble(
+                System.getenv().getOrDefault("MAX_SLIPPAGE_PCT", "0.2"));
     }
 
     public ExecutionMode getExecutionMode() {
@@ -31,6 +34,10 @@ public class Config {
 
     public double getWinRateThreshold() {
         return winRateThreshold;
+    }
+
+    public double getMaxSlippagePct() {
+        return maxSlippagePct;
     }
 
     /**

--- a/executor/src/main/java/ConfigValidator.java
+++ b/executor/src/main/java/ConfigValidator.java
@@ -44,8 +44,8 @@ public class ConfigValidator {
         if (winRateThreshold < 0.4) {
             throw new RuntimeException("WIN_RATE_THRESHOLD is too low: " + winRateThreshold + " < 0.4");
         }
-        if (maxSlippagePct > 5.0) {
-            throw new RuntimeException("MAX_SLIPPAGE_PCT exceeds safe limit: " + maxSlippagePct + " > 5%");
+        if (maxSlippagePct < 0.0 || maxSlippagePct > 5.0) {
+            throw new RuntimeException("MAX_SLIPPAGE_PCT out of range: " + maxSlippagePct + " (0-5%)");
         }
         if (profitTargetUsd > 20000.0) {
             throw new RuntimeException("PROFIT_TARGET_USD exceeds safe limit: " + profitTargetUsd + " > 20000");

--- a/executor/src/main/java/RiskFilter.java
+++ b/executor/src/main/java/RiskFilter.java
@@ -15,7 +15,7 @@ public class RiskFilter {
     private double minEdge;
     private long maxLatencyMs;
     private double maxSlippagePct = Double.parseDouble(
-        System.getenv().getOrDefault("MAX_SLIPPAGE_PCT", "1.0"));
+        System.getenv().getOrDefault("MAX_SLIPPAGE_PCT", "0.2"));
     private double lossCapPct = Double.parseDouble(
         System.getenv().getOrDefault("LOSS_CAP_PCT", "5.0"));
     private int latencyMax = Integer.parseInt(

--- a/executor/src/main/java/SandboxExchangeAdapter.java
+++ b/executor/src/main/java/SandboxExchangeAdapter.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 import java.util.Random;
 
@@ -124,6 +128,17 @@ public class SandboxExchangeAdapter extends MockExchangeAdapter {
      * @return trade result
      */
     public TradeResult execute(SpreadOpportunity opp, double size, double price) {
+        String slipVal = System.getProperty("MAX_SLIPPAGE_PCT",
+                System.getenv().getOrDefault("MAX_SLIPPAGE_PCT", "0.2"));
+        double maxSlip = Double.parseDouble(slipVal);
+        try {
+            SlippageChecker.validate(opp.getGrossEdge(), opp.getNetEdge(), maxSlip);
+        } catch (IllegalArgumentException e) {
+            String msg = "Trade skipped due to slippage breach: " + e.getMessage();
+            logger.warn(msg);
+            logSlippage(msg);
+            return new TradeResult(false, 0.0, 0, "SLIPPAGE_BREACH");
+        }
         double predicted = predictor.predict(opp);
         long start = System.currentTimeMillis();
 
@@ -197,5 +212,16 @@ public class SandboxExchangeAdapter extends MockExchangeAdapter {
         }
 
         return new TradeResult(success, pnl, latency, status);
+    }
+
+    private void logSlippage(String message) {
+        try {
+            Path path = Path.of("logs", "slippage.log");
+            Files.createDirectories(path.getParent());
+            Files.writeString(path, message + System.lineSeparator(),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            logger.error("Failed to write slippage log", e);
+        }
     }
 }

--- a/executor/src/main/java/SlippageChecker.java
+++ b/executor/src/main/java/SlippageChecker.java
@@ -17,4 +17,20 @@ public class SlippageChecker {
         double allowed = Math.abs(expected) * maxSlipPercent / 100.0;
         return difference <= allowed;
     }
+
+    /**
+     * Validate the slippage between expected and actual values.
+     * Throws an {@link IllegalArgumentException} if the difference exceeds
+     * the provided percentage threshold.
+     *
+     * @param expected       expected price or edge
+     * @param actual         actual price or edge
+     * @param maxSlipPercent maximum allowed slippage in percent
+     */
+    public static void validate(double expected, double actual, double maxSlipPercent) {
+        if (!check(expected, actual, maxSlipPercent)) {
+            double diffPct = Math.abs(actual - expected) / Math.abs(expected) * 100.0;
+            throw new IllegalArgumentException("slippage " + diffPct + "% > " + maxSlipPercent + "%");
+        }
+    }
 }

--- a/executor/src/main/java/SpreadOpportunity.java
+++ b/executor/src/main/java/SpreadOpportunity.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 /** Represents an executable arbitrage opportunity between two exchanges. */
 public class SpreadOpportunity {
@@ -98,6 +102,18 @@ public class SpreadOpportunity {
 
   /** Execute the opportunity using mock exchanges. */
   public TradeResult execute(double size, double price) {
+    String slipVal = System.getProperty("MAX_SLIPPAGE_PCT",
+        System.getenv().getOrDefault("MAX_SLIPPAGE_PCT", "0.2"));
+    double maxSlip = Double.parseDouble(slipVal);
+    try {
+      SlippageChecker.validate(grossEdge, netEdge, maxSlip);
+    } catch (IllegalArgumentException e) {
+      String msg = "Trade skipped due to slippage breach: " + e.getMessage();
+      logger.warn(msg);
+      logSlippage(msg);
+      return new TradeResult(false, 0.0, 0, "SLIPPAGE_BREACH");
+    }
+
     MockExchangeAdapter buy = createAdapter(buyExchange);
     MockExchangeAdapter sell = createAdapter(sellExchange);
 
@@ -246,5 +262,16 @@ public class SpreadOpportunity {
         + ", timestamp="
         + timestamp
         + '}';
+  }
+
+  private void logSlippage(String message) {
+    try {
+      Path path = Path.of("logs", "slippage.log");
+      Files.createDirectories(path.getParent());
+      Files.writeString(path, message + System.lineSeparator(),
+          StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    } catch (IOException e) {
+      logger.error("Failed to write slippage log", e);
+    }
   }
 }

--- a/executor/src/test/java/ConfigValidatorTest.java
+++ b/executor/src/test/java/ConfigValidatorTest.java
@@ -38,7 +38,14 @@ public class ConfigValidatorTest {
     public void testSlippageTooHighFails() {
         ConfigValidator validator = new ConfigValidator(5.0, 300.0, 0.5, 10.0, 0.0);
         RuntimeException e = assertThrows(RuntimeException.class, validator::validate);
-        assertTrue(e.getMessage().contains("MAX_SLIPPAGE_PCT exceeds safe limit"));
+        assertTrue(e.getMessage().contains("MAX_SLIPPAGE_PCT"));
+    }
+
+    @Test
+    public void testSlippageNegativeFails() {
+        ConfigValidator validator = new ConfigValidator(5.0, 300.0, 0.5, -1.0, 0.0);
+        RuntimeException e = assertThrows(RuntimeException.class, validator::validate);
+        assertTrue(e.getMessage().contains("MAX_SLIPPAGE_PCT"));
     }
 
     @Test

--- a/executor/src/test/java/SlippageCheckerTest.java
+++ b/executor/src/test/java/SlippageCheckerTest.java
@@ -1,0 +1,27 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class SlippageCheckerTest {
+
+    @Test
+    void tradeRejectedWhenSlippageTooHigh() {
+        System.setProperty("MAX_SLIPPAGE_PCT", "0.2");
+        SpreadOpportunity opp = new SpreadOpportunity("BTC/USDT", "A", "B", 2.0, 1.0, 0L);
+        TradeResult result = opp.execute(1.0, 100.0);
+        assertFalse(result.success);
+        assertEquals("SLIPPAGE_BREACH", result.status);
+    }
+
+    @Test
+    void tradePassesWithinSlippageLimit() {
+        System.setProperty("MAX_SLIPPAGE_PCT", "0.2");
+        SpreadOpportunity opp = new SpreadOpportunity("BTC/USDT", "A", "B", 2.0, 1.998, 0L);
+        TradeResult result = opp.execute(1.0, 100.0);
+        assertTrue(result.success);
+        assertEquals("FILLED", result.status);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce slippage validation via `SlippageChecker.validate`
- use configurable `MAX_SLIPPAGE_PCT` with default 0.2%
- range check slippage threshold in `ConfigValidator`
- log slippage breaches to `logs/slippage.log`
- add unit tests for slippage enforcement
- update changelog

## Checklist
- [x] Slippage check added before trade execution
- [x] Config validated
- [x] Trade abort logic working
- [x] Tests passing
- [x] Changelog updated


------
https://chatgpt.com/codex/tasks/task_b_6880b8bcc458832c894ffa328723a4ef