### PR TITLE
fix: add two-stage resume confirmation in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add real-time panic brake and execution mode banner to operator dashboard
 - Enforce system health validation before allowing panic resume actions
 - Secure /resume endpoint with execution-mode-aware admin check
+- Added two-step confirmation for Resume trading action with Redis override signal
 
 - Downgrade numpy to 2.1.3 to resolve TensorFlow install conflict.
 - Store Postgres credentials in sealed secrets

--- a/RedisPublisher.js
+++ b/RedisPublisher.js
@@ -1,0 +1,11 @@
+import createLogger from './lib/logger.js';
+
+const logger = createLogger('redis-publisher');
+
+export async function setResumeConfirmation(redis) {
+  try {
+    await redis.set('resume_confirmed', 'true', 'EX', 60);
+  } catch (err) {
+    logger.error('Failed to set resume confirmation key', err);
+  }
+}

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -1,17 +1,33 @@
 import { requireAdmin } from '../middleware/auth.js';
 import { sendAlert } from '../../alerts/alertAgent.js';
 import { getControlChannel } from '../config/settings.js';
-import { ensurePaused } from '../middleware/validate.js';
 import logger from '../services/logger.js';
-import { setPauseState } from '../services/pauseState.js';
+import { setPauseState, getPauseState } from '../services/pauseState.js';
+import { setResumeConfirmation } from '../../RedisPublisher.js';
 
 export default async function resumeRoutes(app, opts) {
   const { redis, panicState } = opts;
 
-  app.post(
-    '/resume',
-    { preHandler: [requireAdmin, ensurePaused(redis)] },
-    async (req, reply) => {
+  app.post('/resume', { preHandler: [requireAdmin] }, async (req, reply) => {
+    const paused = await getPauseState(redis);
+    if (!paused) {
+      reply.code(400);
+      return { error: 'not paused' };
+    }
+
+    const confirm = req.query.confirm === 'true';
+    const lossBreach = await redis.get('loss_breached');
+    const latencyBreach = await redis.get('latency_breached');
+
+    if (!confirm && (lossBreach === 'true' || latencyBreach === 'true')) {
+      reply.code(403);
+      return { override_required: true };
+    }
+
+    if (confirm) {
+      await setResumeConfirmation(redis);
+    }
+
     const channel = getControlChannel();
     await redis.publish(channel, 'resume');
     await setPauseState(redis, false);
@@ -38,6 +54,5 @@ export default async function resumeRoutes(app, opts) {
       }),
     );
     return { resumed: true };
-  }
-  );
+  });
 }

--- a/dashboard/src/__tests__/ResumeButton.test.jsx
+++ b/dashboard/src/__tests__/ResumeButton.test.jsx
@@ -26,3 +26,37 @@ test('button disabled with tooltip when resume blocked', async () => {
   expect(btn).toBeDisabled();
   expect(btn).toHaveAttribute('title', 'System not ready to resume \u2014 check logs');
 });
+
+test('confirmation modal flow', async () => {
+  const refresh = jest.fn();
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({
+      status: 403,
+      ok: false,
+      json: () => Promise.resolve({ override_required: true }),
+    })
+    .mockResolvedValueOnce({ status: 200, ok: true, json: () => Promise.resolve({ resumed: true }) });
+
+  await act(async () => {
+    render(
+      <SystemStatusContext.Provider value={{ panic: true, reason: 'loss', refreshStatus: refresh }}>
+        <ResumeButton />
+      </SystemStatusContext.Provider>
+    );
+  });
+
+  const btn = screen.getByRole('button', { name: /resume trading/i });
+  await act(async () => {
+    fireEvent.click(btn);
+  });
+
+  expect(await screen.findByText(/risk thresholds/i)).toBeInTheDocument();
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+  });
+
+  expect(refresh).toHaveBeenCalled();
+  expect(screen.queryByText(/risk thresholds/i)).not.toBeInTheDocument();
+});

--- a/dashboard/src/components/ResumeButton.jsx
+++ b/dashboard/src/components/ResumeButton.jsx
@@ -1,9 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSystemStatus } from '../context/SystemStatusContext.jsx';
 
 export default function ResumeButton() {
   const { panic, reason, refreshStatus } = useSystemStatus();
   const [blocked, setBlocked] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+  const [toast, setToast] = useState(null);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   async function handleResume() {
     setBlocked(false);
@@ -11,12 +19,41 @@ export default function ResumeButton() {
       const res = await fetch('/api/resume', { method: 'POST' });
       if (res.status === 503) {
         setBlocked(true);
+        setToast({ type: 'error', msg: 'System not ready for resume.' });
+        return;
+      }
+      if (res.status === 403) {
+        const data = await res.json().catch(() => ({}));
+        if (data.override_required) {
+          setConfirm(true);
+          return;
+        }
       }
       if (res.ok) {
         await refreshStatus();
+        setToast({ type: 'success', msg: 'Resume in progress...' });
       }
     } catch (err) {
       console.error('Failed to resume trading', err);
+    }
+  }
+
+  async function confirmResume() {
+    try {
+      const res = await fetch('/api/resume?confirm=true', { method: 'POST' });
+      if (res.status === 503) {
+        setConfirm(false);
+        setBlocked(true);
+        setToast({ type: 'error', msg: 'System not ready for resume.' });
+        return;
+      }
+      if (res.ok) {
+        setConfirm(false);
+        await refreshStatus();
+        setToast({ type: 'success', msg: 'Resume in progress...' });
+      }
+    } catch (err) {
+      console.error('Resume confirm failed', err);
     }
   }
 
@@ -25,13 +62,39 @@ export default function ResumeButton() {
     : `Panic triggered: ${reason} \u2014 click to resume`;
 
   return (
-    <button
-      className="bg-green-600 text-white px-3 py-1 rounded disabled:bg-gray-300 disabled:text-gray-500"
-      disabled={!panic || blocked}
-      title={title}
-      onClick={handleResume}
-    >
-      Resume Trading
-    </button>
+    <div className="relative inline-block">
+      {toast && (
+        <div
+          className={`absolute right-0 -top-8 px-2 py-1 text-white rounded ${
+            toast.type === 'success' ? 'bg-green-600' : 'bg-red-600'
+          }`}
+        >
+          {toast.msg}
+        </div>
+      )}
+      <button
+        className="bg-green-600 text-white px-3 py-1 rounded disabled:bg-gray-300 disabled:text-gray-500"
+        disabled={!panic || blocked}
+        title={title}
+        onClick={handleResume}
+      >
+        Resume Trading
+      </button>
+      {confirm && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-white p-4 rounded space-y-4">
+            <p>Risk thresholds still breached. Resume anyway?</p>
+            <div className="flex justify-end space-x-2">
+              <button className="px-3 py-1 bg-gray-200 rounded" onClick={() => setConfirm(false)}>
+                Cancel
+              </button>
+              <button className="px-3 py-1 bg-green-600 text-white rounded" onClick={confirmResume}>
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement confirmation modal in `ResumeButton`
- require override on API resume endpoint
- publish Redis key `resume_confirmed` with 60s TTL
- test confirmation flow for Resume button
- document new resume logic

## Testing
- `bash test/verify-env.sh`
- `npm test --prefix api`
- `npm test --prefix dashboard`


------
https://chatgpt.com/codex/tasks/task_b_6880b925581c832cb3a515656c922010