### PR TITLE
chore: add exchange adapter stubs and clarify rollout in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add real-time panic brake and execution mode banner to operator dashboard
 - Enforce system health validation before allowing panic resume actions
 - Secure /resume endpoint with execution-mode-aware admin check
+- Added stub adapters for Binance, Kraken, and Uniswap-V3. Docs updated to reflect rollout plan.
 
 - Downgrade numpy to 2.1.3 to resolve TensorFlow install conflict.
 - Store Postgres credentials in sealed secrets

--- a/docs/Complete Guide.MD
+++ b/docs/Complete Guide.MD
@@ -1325,6 +1325,8 @@ CEX adapters (e.g., Binance, Kraken, Coinbase) connect via WebSockets and REST f
 
 DEX adapters (e.g., Uniswap V3, PancakeSwap) use on-chain price feeds or GraphQL APIs.
 
+Note: CEX/DEX adapters are stubbed for rollout sequencing. Full support will be implemented after sandbox validation. Currently stubbed adapters: Binance, Kraken, Uniswap V3.
+
 
 All feeds update bid/ask every 250 ms, parsed and pushed into a central Redis channel (spread-feed).
 

--- a/executor/src/main/java/adapters/BinanceAdapter.java
+++ b/executor/src/main/java/adapters/BinanceAdapter.java
@@ -1,0 +1,51 @@
+package adapters;
+
+import executor.ExchangeAdapter;
+import java.util.Collections;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO: Implement Binance API integration.
+ */
+public class BinanceAdapter implements ExchangeAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(BinanceAdapter.class);
+
+    /** Connect to Binance exchange. */
+    public void connect() {
+        logger.warn("Stub adapter: not yet implemented");
+    }
+
+    /** Return a dummy order book. */
+    public Map<String, Double> getOrderBook(String pair) {
+        logger.warn("Stub adapter: not yet implemented");
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean placeOrder(String pair, String side, double size, double limitPrice) {
+        logger.warn("Stub adapter: not yet implemented");
+        return false;
+    }
+
+    @Override
+    public double getFeeRate(String pair) {
+        return 0.0;
+    }
+
+    @Override
+    public double getBalance(String asset) {
+        return 0.0;
+    }
+
+    @Override
+    public void transfer(String asset, double amount, String destination) {
+        logger.warn("Stub adapter: not yet implemented");
+    }
+
+    @Override
+    public void cancel(String orderId) {
+        logger.warn("Stub adapter: not yet implemented");
+    }
+}

--- a/executor/src/main/java/adapters/KrakenAdapter.java
+++ b/executor/src/main/java/adapters/KrakenAdapter.java
@@ -1,0 +1,51 @@
+package adapters;
+
+import executor.ExchangeAdapter;
+import java.util.Collections;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO: Implement Kraken API integration.
+ */
+public class KrakenAdapter implements ExchangeAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(KrakenAdapter.class);
+
+    /** Connect to Kraken exchange. */
+    public void connect() {
+        logger.warn("Stub adapter: not yet implemented");
+    }
+
+    /** Return a dummy order book. */
+    public Map<String, Double> getOrderBook(String pair) {
+        logger.warn("Stub adapter: not yet implemented");
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean placeOrder(String pair, String side, double size, double limitPrice) {
+        logger.warn("Stub adapter: not yet implemented");
+        return false;
+    }
+
+    @Override
+    public double getFeeRate(String pair) {
+        return 0.0;
+    }
+
+    @Override
+    public double getBalance(String asset) {
+        return 0.0;
+    }
+
+    @Override
+    public void transfer(String asset, double amount, String destination) {
+        logger.warn("Stub adapter: not yet implemented");
+    }
+
+    @Override
+    public void cancel(String orderId) {
+        logger.warn("Stub adapter: not yet implemented");
+    }
+}

--- a/executor/src/main/java/adapters/UniswapV3Adapter.java
+++ b/executor/src/main/java/adapters/UniswapV3Adapter.java
@@ -1,0 +1,51 @@
+package adapters;
+
+import executor.ExchangeAdapter;
+import java.util.Collections;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO: Implement Uniswap V3 integration.
+ */
+public class UniswapV3Adapter implements ExchangeAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(UniswapV3Adapter.class);
+
+    /** Connect to Uniswap V3 smart contracts. */
+    public void connect() {
+        logger.warn("Stub adapter: not yet implemented");
+    }
+
+    /** Return a dummy order book or pool state. */
+    public Map<String, Double> getOrderBook(String pair) {
+        logger.warn("Stub adapter: not yet implemented");
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean placeOrder(String pair, String side, double size, double limitPrice) {
+        logger.warn("Stub adapter: not yet implemented");
+        return false;
+    }
+
+    @Override
+    public double getFeeRate(String pair) {
+        return 0.0;
+    }
+
+    @Override
+    public double getBalance(String asset) {
+        return 0.0;
+    }
+
+    @Override
+    public void transfer(String asset, double amount, String destination) {
+        logger.warn("Stub adapter: not yet implemented");
+    }
+
+    @Override
+    public void cancel(String orderId) {
+        logger.warn("Stub adapter: not yet implemented");
+    }
+}

--- a/executor/src/test/java/adapters/StubAdapterTest.java
+++ b/executor/src/test/java/adapters/StubAdapterTest.java
@@ -1,0 +1,26 @@
+package adapters;
+
+import executor.ExchangeAdapter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class StubAdapterTest {
+    @Test
+    void stubMethodsReturnDefaults() {
+        ExchangeAdapter binance = new BinanceAdapter();
+        ExchangeAdapter kraken = new KrakenAdapter();
+        ExchangeAdapter uni = new UniswapV3Adapter();
+
+        ((BinanceAdapter) binance).connect();
+        ((KrakenAdapter) kraken).connect();
+        ((UniswapV3Adapter) uni).connect();
+
+        assertEquals(0.0, binance.getFeeRate("BTC/USDT"), 1e-9);
+        assertEquals(0.0, kraken.getBalance("BTC"), 1e-9);
+        assertDoesNotThrow(() -> uni.transfer("ETH", 1.0, "wallet"));
+        assertFalse(binance.placeOrder("BTC/USDT", "BUY", 1.0, 1.0));
+    }
+}


### PR DESCRIPTION
## Summary
- stub Binance, Kraken and Uniswap V3 adapters
- document phased adapter rollout
- add tests for stubs
- update changelog

## Checklist
- [x] Stub classes created
- [x] Stub warnings logged
- [x] Docs reflect phased adapter rollout
- [x] Build/test passes
- [x] Changelog updated

------
https://chatgpt.com/codex/tasks/task_b_6880b9466188832c9286cd7733890086