### PR TITLE
fix: persist risk settings across API restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Added two-step confirmation for Resume trading action with Redis override signal
 - Added stub adapters for Binance, Kraken, and Uniswap-V3. Docs updated to reflect rollout plan.
 
+- API now persists risk cap settings (maxLossPct, latency, exposure) in Redis and reloads on startup
+
 - Downgrade numpy to 2.1.3 to resolve TensorFlow install conflict.
 - Store Postgres credentials in sealed secrets
 - Added feed-aggregator deployment manifest

--- a/api/__tests__/alert.panic.test.js
+++ b/api/__tests__/alert.panic.test.js
@@ -9,7 +9,7 @@ let cookie;
 
 beforeAll(async () => {
   ({ buildApp } = await import('../index.js'));
-  app = buildApp();
+  app = await buildApp();
   await app.listen({ port: 0 });
   const login = await request(app.server)
     .post('/api/login')

--- a/api/__tests__/api.test.js
+++ b/api/__tests__/api.test.js
@@ -10,7 +10,7 @@ let app;
 
 beforeAll(async () => {
   ({ buildApp } = await import('../index.js'));
-  app = buildApp();
+  app = await buildApp();
   await app.listen({ port: 8080 });
 });
 

--- a/api/__tests__/config.validation.test.js
+++ b/api/__tests__/config.validation.test.js
@@ -13,7 +13,7 @@ let cookie;
 
 beforeAll(async () => {
   ({ buildApp } = await import('../index.js'));
-  app = buildApp();
+  app = await buildApp();
   await app.listen({ port: 0 });
   const login = await request(app.server)
     .post('/api/login')

--- a/api/__tests__/metrics.mode.test.js
+++ b/api/__tests__/metrics.mode.test.js
@@ -9,7 +9,7 @@ let app;
 
 beforeAll(async () => {
   ({ buildApp } = await import('../index.js'));
-  app = buildApp();
+  app = await buildApp();
   await app.listen({ port: 0 });
 });
 

--- a/api/__tests__/panicResume.test.js
+++ b/api/__tests__/panicResume.test.js
@@ -10,7 +10,7 @@ let cookie;
 
 beforeAll(async () => {
   ({ buildApp } = await import('../index.js'));
-  app = buildApp();
+  app = await buildApp();
   await app.listen({ port: 0 });
   const login = await request(app.server)
     .post('/api/login')

--- a/api/__tests__/resume.auth.test.js
+++ b/api/__tests__/resume.auth.test.js
@@ -12,7 +12,7 @@ let warnSpy;
 
 beforeAll(async () => {
   ({ buildApp } = await import('../index.js'));
-  app = buildApp();
+  app = await buildApp();
   await app.listen({ port: 0 });
 });
 

--- a/api/__tests__/routes/models.test.js
+++ b/api/__tests__/routes/models.test.js
@@ -21,7 +21,7 @@ let cookie;
 
 beforeAll(async () => {
   ({ buildApp } = await import('../../index.js'));
-  app = buildApp();
+  app = await buildApp();
   await app.listen({ port: 0 });
 
   const login = await request(app.server)

--- a/api/__tests__/settings.validation.test.js
+++ b/api/__tests__/settings.validation.test.js
@@ -16,7 +16,7 @@ let warnSpy;
 
 beforeAll(async () => {
   ({ buildApp } = await import("../index.js"));
-  app = buildApp();
+  app = await buildApp();
   await app.listen({ port: 0 });
   const login = await request(app.server)
     .post("/api/login")
@@ -96,6 +96,17 @@ describeLocal("settings validation", () => {
     );
   });
 
+  test("rejects unsafe coinExposureLimit", async () => {
+    const res = await request(app.server)
+      .patch("/api/settings")
+      .set("Cookie", cookie)
+      .send({ coinExposureLimit: 50 });
+    expect(res.statusCode).toBe(400);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[SETTINGS-REJECTED] coinExposureLimit=50 exceeds limit",
+    );
+  });
+
   test("rejects malformed sweep_cadence", async () => {
     const res = await request(app.server)
       .patch("/api/settings")
@@ -111,6 +122,7 @@ describeLocal("settings validation", () => {
       .send({
         maxLossPct: 10,
         latencyMaxMs: 500,
+        coinExposureLimit: 20,
         personality_mode: "Aggressive",
         sweep_cadence: "Daily",
       });

--- a/api/__tests__/system.status.test.js
+++ b/api/__tests__/system.status.test.js
@@ -12,7 +12,7 @@ let cookie;
 
 beforeAll(async () => {
   ({ buildApp } = await import('../index.js'));
-  app = buildApp();
+  app = await buildApp();
   await app.listen({ port: 0 });
   const login = await request(app.server)
     .post('/api/login')

--- a/api/config/settings.js
+++ b/api/config/settings.js
@@ -16,8 +16,9 @@ export const settings = {
   ghost_mode: false,
   personality_mode: "Realistic",
   sweep_cadence: "None",
-  maxLossPct: 0,
-  latencyMaxMs: 250,
+  maxLossPct: parseFloat(process.env.LOSS_CAP_PCT || "0"),
+  latencyMaxMs: parseFloat(process.env.LATENCY_MAX_MS || "250"),
+  coinExposureLimit: parseFloat(process.env.COIN_CAP_PCT || "10"),
 };
 
 // Returns ExecutionMode for the current request.

--- a/api/index.js
+++ b/api/index.js
@@ -24,6 +24,7 @@ import alertRoutes from './routes/alert.js';
 import configRoutes from './routes/config.js';
 import opportunitiesRoutes from './routes/opportunities.js';
 import { getControlChannel } from './config/settings.js';
+import { loadSettingsFromRedis } from './services/configManager.js';
 import { baseOpenPaths } from './lib/constants.js';
 import { sendAlert } from '../alerts/alertAgent.js';
 import { sendEmail } from '../alerts/emailAlert.js';
@@ -59,7 +60,7 @@ const panicState = { reason: null };
 let redis;
 let pool;
 
-function buildApp() {
+async function buildApp() {
   const app = Fastify();
   app.register(fastifyCookie);
   app.register(fastifyJwt, {
@@ -68,22 +69,23 @@ function buildApp() {
   });
     // Postgres connection via env vars for local or prod
 
-    pool = new Pool({
-      host: process.env.PGHOST || 'localhost',
-      port: process.env.PGPORT || 5432,
-      database: process.env.PGDATABASE || 'arbdb',
-      user: process.env.PGUSER || 'postgres',
-      password: process.env.PGPASSWORD || '',
-    });
-
     if (isTest) {
+      pool = { query: async () => ({ rows: [] }), end: async () => {} };
       const store = { 'arb:paused_state': 'false' };
       redis = {
         publish: async () => 1,
         get: async key => store[key],
-        set: async (key, val) => { store[key] = val; return 'OK'; }
+        set: async (key, val) => { store[key] = val; return 'OK'; },
+        ping: async () => 'PONG',
       };
     } else {
+      pool = new Pool({
+        host: process.env.PGHOST || 'localhost',
+        port: process.env.PGPORT || 5432,
+        database: process.env.PGDATABASE || 'arbdb',
+        user: process.env.PGUSER || 'postgres',
+        password: process.env.PGPASSWORD || '',
+      });
       const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
       try {
         const { hostname, port } = new URL(redisUrl);
@@ -93,6 +95,8 @@ function buildApp() {
         logger.error(`[REDIS] Invalid REDIS_URL: ${err.message}`);
       }
     }
+
+    await loadSettingsFromRedis(redis);
 
     app.register(apiRoutes, { prefix: '/api', redis, pool, panicState });
 
@@ -107,12 +111,30 @@ function buildApp() {
   return app;
 }
 
-const app = buildApp();
+let app;
 
-logger.info('API initialized');
-['BINANCE_KEY', 'SMTP_USER', 'SMTP_PASS'].forEach(key => {
-  logger.info(`${key} present: ${process.env[key] ? 'true' : 'false'}`);
-});
+async function start() {
+  app = await buildApp();
+  logger.info('API initialized');
+  ['BINANCE_KEY', 'SMTP_USER', 'SMTP_PASS'].forEach(key => {
+    logger.info(`${key} present: ${process.env[key] ? 'true' : 'false'}`);
+  });
+
+  if (!isTest) {
+    startWsServer();
+    app.listen({ port: 8080, host: '0.0.0.0' }, err => {
+      if (err) {
+        logger.error(err);
+        process.exit(1);
+      }
+      logger.info('API service started');
+    });
+  }
+}
+
+if (!isTest) {
+  start();
+}
 
 const alertSettings = {
   smtp_user: '',
@@ -284,17 +306,6 @@ async function apiRoutes(api, { redis, pool, panicState }) {
   api.register(metricsRoutes, { redis });
   api.register(analyticsRoutes, { pool });
   api.register(cgtRoutes, { pool });
-}
-
-if (!isTest) {
-  startWsServer();
-  app.listen({ port: 8080, host: '0.0.0.0' }, err => {
-    if (err) {
-      logger.error(err);
-      process.exit(1);
-    }
-    logger.info('API service started');
-  });
 }
 
 export default app;

--- a/api/routes/settings.js
+++ b/api/routes/settings.js
@@ -2,6 +2,7 @@ import { z } from "zod";
 import logger from "../services/logger.js";
 import { setMode as setRiskFilterMode } from "../services/riskFilter.js";
 import { getControlChannel } from "../config/settings.js";
+import { getConfigSource, loadSettingsFromRedis } from "../services/configManager.js";
 
 export let settings = {
   schema_version: 1,
@@ -15,11 +16,12 @@ export let settings = {
   maxLoss: 0,
   maxLossPct: 0,
   latencyMaxMs: 250,
+  coinExposureLimit: 10,
 };
 
 export default async function settingsRoutes(app, opts) {
   const { redis } = opts;
-  app.get("/settings", async () => settings);
+  app.get("/settings", async () => ({ ...settings, source: getConfigSource() }));
 
   const schema = z
     .object({
@@ -34,6 +36,7 @@ export default async function settingsRoutes(app, opts) {
       maxLoss: z.number().optional(),
       maxLossPct: z.number().optional(),
       latencyMaxMs: z.number().optional(),
+      coinExposureLimit: z.number().optional(),
     })
     .strict();
 
@@ -59,6 +62,14 @@ export default async function settingsRoutes(app, opts) {
       );
       reply.code(400);
       return { error: "latencyMaxMs exceeds limit" };
+    }
+
+    if (typeof data.coinExposureLimit === "number" && data.coinExposureLimit > 30) {
+      logger.warn(
+        `[SETTINGS-REJECTED] coinExposureLimit=${data.coinExposureLimit} exceeds limit`,
+      );
+      reply.code(400);
+      return { error: "coinExposureLimit exceeds limit" };
     }
 
     if (typeof data.personality_mode === "string") {
@@ -148,6 +159,22 @@ export default async function settingsRoutes(app, opts) {
         logger.error('Failed to publish latency update', err);
       }
     }
+    if (typeof req.body.coinExposureLimit === "number") {
+      settings.coinExposureLimit = req.body.coinExposureLimit;
+    }
+
+    const now = new Date().toISOString();
+    try {
+      await Promise.all([
+        redis.set('config:maxLossPct', JSON.stringify({ value: settings.maxLossPct, updatedAt: now })),
+        redis.set('config:latencyMaxMs', JSON.stringify({ value: settings.latencyMaxMs, updatedAt: now })),
+        redis.set('config:coinExposureLimit', JSON.stringify({ value: settings.coinExposureLimit, updatedAt: now })),
+      ]);
+    } catch (err) {
+      logger.error('Failed to persist settings to Redis', err);
+    }
+
+    await loadSettingsFromRedis(redis);
     return { saved: true };
   };
 

--- a/api/services/configManager.js
+++ b/api/services/configManager.js
@@ -1,0 +1,64 @@
+import settings from '../config/settings.js';
+import logger from './logger.js';
+
+const KEYS = {
+  maxLossPct: 'config:maxLossPct',
+  latencyMaxMs: 'config:latencyMaxMs',
+  coinExposureLimit: 'config:coinExposureLimit',
+};
+
+let source = 'fallback';
+
+export async function loadSettingsFromRedis(redis) {
+  source = 'fallback';
+  const envDefaults = {
+    maxLossPct: parseFloat(process.env.LOSS_CAP_PCT || settings.maxLossPct),
+    latencyMaxMs: parseFloat(process.env.LATENCY_MAX_MS || settings.latencyMaxMs),
+    coinExposureLimit: parseFloat(process.env.COIN_CAP_PCT || settings.coinExposureLimit),
+  };
+  if (!redis || typeof redis.mget !== 'function') {
+    Object.assign(settings, envDefaults);
+    return source;
+  }
+  try {
+    const [loss, latency, coin] = await redis.mget(
+      KEYS.maxLossPct,
+      KEYS.latencyMaxMs,
+      KEYS.coinExposureLimit,
+    );
+    if (loss) {
+      settings.maxLossPct = JSON.parse(loss).value;
+      source = 'redis';
+    } else {
+      settings.maxLossPct = envDefaults.maxLossPct;
+    }
+    if (latency) {
+      settings.latencyMaxMs = JSON.parse(latency).value;
+      source = 'redis';
+    } else {
+      settings.latencyMaxMs = envDefaults.latencyMaxMs;
+    }
+    if (coin) {
+      settings.coinExposureLimit = JSON.parse(coin).value;
+      source = 'redis';
+    } else {
+      settings.coinExposureLimit = envDefaults.coinExposureLimit;
+    }
+    logger.info(
+      `Config loaded from Redis: { maxLossPct: ${settings.maxLossPct}, latencyMaxMs: ${settings.latencyMaxMs}, coinCap: ${settings.coinExposureLimit} }`,
+    );
+  } catch (err) {
+    Object.assign(settings, envDefaults);
+    logger.error(`[REDIS] Failed to load config: ${err.message}`);
+  }
+  return source;
+}
+
+export function getConfigSource() {
+  return source;
+}
+
+export default {
+  loadSettingsFromRedis,
+  getConfigSource,
+};


### PR DESCRIPTION
## Summary
- add Redis-backed configManager and risk cap persistence
- extend settings schema with coinExposureLimit
- load settings from Redis on startup
- update tests for async buildApp
- update CHANGELOG

## Testing
- `bash test/verify-env.sh`
- `npm --prefix api test` *(fails: pool.end not a function)*

------
https://chatgpt.com/codex/tasks/task_b_6880caf8d73c832cbf1ab72c152fb6aa