### PR TITLE
fix: synchronize trade metrics update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix panic resume and Redis signal behavior in Executor and PanicBrake
 - Added async fill confirmation system with cancel-on-partial fallback for safer trade execution
 - Live config reloads now enforce risk validation (loss %, latency, coin exposure)
+- Executor metrics now updated using atomic structures for thread safety
 - Remove plaintext .env.sandbox file and enforce secret hygiene in CI and gitignore
 - Cancel all legs on partial fill to prevent orphaned exposure in SpreadOpportunity
 - CVE scanning with Trivy

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -54,11 +54,11 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     private final java.util.Deque<Double> midPrices = new java.util.ArrayDeque<>();
 
     private double dailyLossPct;
-    private double avgLatencyMs;
-    private double winRate;
-    private int totalTrades;
-    private int winTrades;
-    private long cumulativeLatencyMs;
+    private volatile double averageLatencyMs;
+    private volatile double winRate;
+    private final java.util.concurrent.atomic.AtomicInteger tradeCount = new java.util.concurrent.atomic.AtomicInteger();
+    private final java.util.concurrent.atomic.AtomicInteger winCount = new java.util.concurrent.atomic.AtomicInteger();
+    private final java.util.concurrent.atomic.AtomicLong totalLatencyMs = new java.util.concurrent.atomic.AtomicLong();
     private final java.util.concurrent.atomic.AtomicBoolean isPanic = new java.util.concurrent.atomic.AtomicBoolean(false);
     private boolean canaryMode;
     private boolean ghostMode;
@@ -251,7 +251,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
 
         recordMetrics(opp, result);
 
-        if (!sandboxMode && PanicBrake.shouldHalt(redisClient, config, dailyLossPct, avgLatencyMs, winRate)) {
+        if (!sandboxMode && PanicBrake.shouldHalt(redisClient, config, dailyLossPct, averageLatencyMs, winRate)) {
             if (isPanic.compareAndSet(false, true)) {
                 logger.error("PANIC BRAKE TRIGGERED - trading paused");
                 AlertManager.sendAlert("PANIC", "BRAKE TRIGGERED");
@@ -433,16 +433,16 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     }
 
     private void updatePerformanceMetrics(TradeResult result) {
-        totalTrades++;
-        cumulativeLatencyMs += result.latencyMs;
-        avgLatencyMs = cumulativeLatencyMs / (double) totalTrades;
+        tradeCount.incrementAndGet();
+        totalLatencyMs.addAndGet(result.latencyMs);
+        averageLatencyMs = totalLatencyMs.get() / (double) tradeCount.get();
 
         if (result.success) {
-            winTrades++;
+            winCount.incrementAndGet();
         }
-        winRate = winTrades / (double) totalTrades;
+        winRate = winCount.get() / (double) tradeCount.get();
 
-        logger.debug("Metrics: latency={}ms, winRate={}, totalTrades={}", result.latencyMs, winRate, totalTrades);
+        logger.debug("Metrics: latency={}ms, winRate={}, totalTrades={}", result.latencyMs, winRate, tradeCount.get());
     }
 
     /**
@@ -611,7 +611,17 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
 
     /** Current average latency in milliseconds. */
     public double getCurrentLatencyMs() {
-        return avgLatencyMs;
+        return averageLatencyMs;
+    }
+
+    /** Immutable snapshot of current performance metrics. */
+    public MetricsSnapshot getMetrics() {
+        return new MetricsSnapshot(
+                tradeCount.get(),
+                winCount.get(),
+                totalLatencyMs.get(),
+                averageLatencyMs,
+                winRate);
     }
 
     /** Execution configuration. */

--- a/executor/src/main/java/MetricsSnapshot.java
+++ b/executor/src/main/java/MetricsSnapshot.java
@@ -1,0 +1,18 @@
+package executor;
+
+/** Immutable snapshot of Executor performance metrics. */
+public class MetricsSnapshot {
+    public final int tradeCount;
+    public final int winCount;
+    public final long totalLatencyMs;
+    public final double averageLatencyMs;
+    public final double winRate;
+
+    public MetricsSnapshot(int tradeCount, int winCount, long totalLatencyMs, double averageLatencyMs, double winRate) {
+        this.tradeCount = tradeCount;
+        this.winCount = winCount;
+        this.totalLatencyMs = totalLatencyMs;
+        this.averageLatencyMs = averageLatencyMs;
+        this.winRate = winRate;
+    }
+}

--- a/executor/src/test/java/ExecutorMetricsTest.java
+++ b/executor/src/test/java/ExecutorMetricsTest.java
@@ -1,0 +1,61 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Ensure metrics updates are thread-safe when accessed concurrently. */
+@Tag("local")
+public class ExecutorMetricsTest {
+    static class DummyRedisClient extends RedisClient {
+        DummyRedisClient() { super("localhost", 6379, "chan", (c,m) -> {}); }
+        @Override public void start() {}
+        @Override public boolean ping() { return true; }
+        @Override public boolean publish(String c, String m) { return true; }
+    }
+
+    static class ExposedExecutor extends Executor {
+        ExposedExecutor() {
+            super(new DummyRedisClient(), "localhost", 6379, new RiskFilter(), new NearMissLogger(null));
+        }
+        @Override public void start() {}
+        void applyMetric(TradeResult r) throws Exception {
+            java.lang.reflect.Method m = Executor.class.getDeclaredMethod("updatePerformanceMetrics", TradeResult.class);
+            m.setAccessible(true);
+            m.invoke(this, r);
+        }
+    }
+
+    @Test
+    void metricsConsistentWithParallelUpdates() throws Exception {
+        ExposedExecutor exec = new ExposedExecutor();
+        int threads = 4;
+        int tradesPerThread = 30;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        for (int i = 0; i < threads; i++) {
+            pool.submit(() -> {
+                for (int j = 0; j < tradesPerThread; j++) {
+                    try {
+                        exec.applyMetric(new TradeResult(true, 1.0, 5));
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+
+        MetricsSnapshot snap = exec.getMetrics();
+        int expected = threads * tradesPerThread;
+        assertEquals(expected, snap.tradeCount);
+        assertEquals(expected, snap.winCount);
+        assertEquals(expected * 5L, snap.totalLatencyMs);
+        assertEquals((double) (expected * 5L) / expected, snap.averageLatencyMs, 1e-9);
+    }
+}


### PR DESCRIPTION
## Summary
- update executor trade metrics to atomic counters
- add `MetricsSnapshot` immutable record
- expose `getMetrics()` method for Prometheus endpoint use
- add parallel metrics test
- document update in changelog

## Testing
- `test/verify-env.sh`
- `./gradlew test --tests executor.ExecutorMetricsTest`

------
https://chatgpt.com/codex/tasks/task_b_6880cb18bbd8832ca4646d0afc8bffc0