### PR TITLE
fix: log all trade outcomes including failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Update documentation and config comments to match final audit-compliant platform behavior
 - Enforced slippage check before trade execution; configurable threshold via config
 - Rewrite documentation to reflect all audited system behavior and enforce operator clarity
+- Added audit logging for all trade attempts: success, fail, rejected, skipped
 
 ## [Batch 1] - 2025-07-02
 ### Added

--- a/executor/src/main/java/SpreadOpportunity.java
+++ b/executor/src/main/java/SpreadOpportunity.java
@@ -111,6 +111,12 @@ public class SpreadOpportunity {
       String msg = "Trade skipped due to slippage breach: " + e.getMessage();
       logger.warn(msg);
       logSlippage(msg);
+      TradeLogger.logAudit(
+          pair,
+          TradeLogger.STATUS_REJECTED,
+          "slippage > threshold",
+          grossEdge - netEdge,
+          0);
       return new TradeResult(false, 0.0, 0, "SLIPPAGE_BREACH");
     }
 
@@ -151,6 +157,9 @@ public class SpreadOpportunity {
     double pnl = netEdge - buyFee - sellFee - buyCancel - sellCancel;
     boolean success = !partial && buyOk && sellOk;
     String status = partial ? "PARTIAL_ABORTED" : (success ? "FILLED" : "FAILED");
+    String outcome = success ? TradeLogger.STATUS_SUCCESS : TradeLogger.STATUS_FAILED;
+    String reason = success ? "" : (partial ? "partial fill" : "order failure");
+    TradeLogger.logAudit(pair, outcome, reason, grossEdge - netEdge, latencyMs);
 
     return new TradeResult(success, success ? pnl : 0.0, latencyMs, status);
   }

--- a/executor/src/main/java/TradeLogger.java
+++ b/executor/src/main/java/TradeLogger.java
@@ -15,6 +15,11 @@ public class TradeLogger {
     private static final Logger logger = LoggerFactory.getLogger(TradeLogger.class);
     private final Connection connection;
 
+    public static final String STATUS_SUCCESS = "success";
+    public static final String STATUS_FAILED = "failed";
+    public static final String STATUS_REJECTED = "rejected";
+    public static final String STATUS_SKIPPED = "skipped";
+
     /**
      * @param connection database connection used for inserts
      */
@@ -48,6 +53,39 @@ public class TradeLogger {
             }
         } catch (SQLException e) {
             logger.error("Failed to log trade", e);
+        }
+    }
+
+    /**
+     * Append a trade outcome to the audit log in JSON format.
+     *
+     * @param pair        trading pair
+     * @param status      outcome status (success, failed, rejected, skipped)
+     * @param reason      optional reason for non-success
+     * @param slippagePct observed slippage percentage
+     * @param latencyMs   round-trip latency in milliseconds
+     */
+    public static void logAudit(String pair, String status, String reason, double slippagePct, long latencyMs) {
+        try {
+            java.nio.file.Path path = java.nio.file.Path.of("logs", "trade_audit.log");
+            java.nio.file.Files.createDirectories(path.getParent());
+            com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            com.fasterxml.jackson.databind.node.ObjectNode node = mapper.createObjectNode();
+            node.put("timestamp", java.time.Instant.now().toString());
+            node.put("pair", pair);
+            node.put("status", status);
+            if (reason != null && !reason.isEmpty()) {
+                node.put("reason", reason);
+            }
+            node.put("slippagePct", slippagePct);
+            node.put("latencyMs", latencyMs);
+            java.nio.file.Files.writeString(
+                    path,
+                    node.toString() + System.lineSeparator(),
+                    java.nio.file.StandardOpenOption.CREATE,
+                    java.nio.file.StandardOpenOption.APPEND);
+        } catch (Exception e) {
+            logger.error("Failed to write audit log", e);
         }
     }
 }

--- a/executor/src/test/java/TradeLoggerTest.java
+++ b/executor/src/test/java/TradeLoggerTest.java
@@ -1,0 +1,52 @@
+package executor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("local")
+public class TradeLoggerTest {
+  @BeforeEach
+  void setup() throws Exception {
+    Files.createDirectories(Path.of("logs"));
+    Files.deleteIfExists(Path.of("logs", "trade_audit.log"));
+  }
+
+  @Test
+  void logsSuccessOutcome() throws Exception {
+    TradeLogger.logAudit("BTC/USDT", TradeLogger.STATUS_SUCCESS, "", 0.1, 50);
+    List<String> lines = Files.readAllLines(Path.of("logs", "trade_audit.log"));
+    assertEquals(1, lines.size());
+    assertTrue(lines.get(0).contains("\"status\":\"success\""));
+  }
+
+  @Test
+  void logsFailedOutcome() throws Exception {
+    TradeLogger.logAudit("ETH/USDT", TradeLogger.STATUS_FAILED, "order failure", 0.2, 60);
+    List<String> lines = Files.readAllLines(Path.of("logs", "trade_audit.log"));
+    assertEquals(1, lines.size());
+    assertTrue(lines.get(0).contains("\"status\":\"failed\""));
+    assertTrue(lines.get(0).contains("order failure"));
+  }
+
+  @Test
+  void logsRejectedOutcome() throws Exception {
+    TradeLogger.logAudit("BTC/USDT", TradeLogger.STATUS_REJECTED, "slippage", 0.9, 0);
+    List<String> lines = Files.readAllLines(Path.of("logs", "trade_audit.log"));
+    assertEquals(1, lines.size());
+    assertTrue(lines.get(0).contains("\"status\":\"rejected\""));
+  }
+
+  @Test
+  void logsSkippedOutcome() throws Exception {
+    TradeLogger.logAudit("ETH/BTC", TradeLogger.STATUS_SKIPPED, "net edge too low", 0.0, 0);
+    List<String> lines = Files.readAllLines(Path.of("logs", "trade_audit.log"));
+    assertEquals(1, lines.size());
+    assertTrue(lines.get(0).contains("\"status\":\"skipped\""));
+  }
+}


### PR DESCRIPTION
## Summary
- track success/failed/rejected/skipped outcomes in TradeLogger
- write trade outcome audit JSON lines inside SpreadOpportunity
- test TradeLogger logging for all statuses
- update changelog

## Testing
- `bash test/verify-env.sh`
- `./gradlew test --tests TradeLoggerTest`
- `./gradlew test` *(fails: OutOfMemoryError)*

------
https://chatgpt.com/codex/tasks/task_b_6880cb5d3cd8832cbb7cb581dd21c611