### PR TITLE
fix: prevent thread leaks in ProfitTracker background task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Update documentation and config comments to match final audit-compliant platform behavior
 - Enforced slippage check before trade execution; configurable threshold via config
 - Rewrite documentation to reflect all audited system behavior and enforce operator clarity
+- ProfitTracker background thread now properly shut down to prevent leaks
 
 ## [Batch 1] - 2025-07-02
 ### Added

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -561,6 +561,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
      */
     public void shutdown() {
         redisClient.shutdown();
+        ProfitTracker.shutdown();
         try {
             if (dbConnection != null && !dbConnection.isClosed()) {
                 dbConnection.close();

--- a/executor/src/main/java/Main.java
+++ b/executor/src/main/java/Main.java
@@ -100,6 +100,7 @@ public class Main {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             arbDetector.stop();
             bookClient.shutdown();
+            ProfitTracker.shutdown();
         }));
 
         // Initialize background schedulers

--- a/executor/src/main/java/ProfitTracker.java
+++ b/executor/src/main/java/ProfitTracker.java
@@ -19,7 +19,12 @@ import org.slf4j.LoggerFactory;
 public class ProfitTracker {
     private static final Logger logger = LoggerFactory.getLogger(ProfitTracker.class);
     private static final HttpClient httpClient = HttpClient.newHttpClient();
-    private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private static final ScheduledExecutorService scheduler =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r);
+                t.setName("ProfitTrackerThread");
+                return t;
+            });
     private static final int MAX_RETRIES = 3;
     private static double globalTotal = 0.0;
     private static double dailyTotal = 0.0;
@@ -28,6 +33,10 @@ public class ProfitTracker {
 
     private static double startingBalance = 10_000.0;
     private static String analyticsUrl = "http://localhost:5000/trade";
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(ProfitTracker::shutdown));
+    }
 
     /**
      * Initialize the tracker with starting capital and analytics endpoint.
@@ -143,6 +152,14 @@ public class ProfitTracker {
      */
     public static double getStartingBalance() {
         return startingBalance;
+    }
+
+    /** Shutdown the scheduler to clean up background thread. */
+    public static void shutdown() {
+        if (scheduler != null && !scheduler.isShutdown()) {
+            scheduler.shutdownNow();
+            logger.info("ProfitTracker scheduler shutdown.");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add shutdown hook for ProfitTracker
- name the ProfitTracker background thread
- call `ProfitTracker.shutdown()` from exit paths
- document shutdown in changelog

## Testing
- `bash test/verify-env.sh`

------
https://chatgpt.com/codex/tasks/task_b_6880cb8fcf28832c8a883bae92ce723e