### PR TITLE
Implement sealed secrets

### DIFF
--- a/infra/helm/templates/analytics-deployment.yaml
+++ b/infra/helm/templates/analytics-deployment.yaml
@@ -22,9 +22,9 @@ spec:
           ports:
             - containerPort: {{ .Values.analytics.port }}
           resources: {{- toYaml .Values.analytics.resources | nindent 12 }}
+          # Validation: This pod mounts analytics-secrets via envFrom.secretRef
           envFrom:
-            - secretRef:
-                name: prod-secrets
+{{- toYaml .Values.analytics.envFrom | nindent 12 }}
           volumeMounts:
             - name: prism-logs
               mountPath: /var/log/prism-arbitrage

--- a/infra/helm/templates/api-deployment.yaml
+++ b/infra/helm/templates/api-deployment.yaml
@@ -22,9 +22,9 @@ spec:
           ports:
             - containerPort: {{ .Values.api.port }}
           resources: {{- toYaml .Values.api.resources | nindent 12 }}
+          # Validation: This pod mounts api-secrets via envFrom.secretRef
           envFrom:
-            - secretRef:
-                name: api-secrets
+{{- toYaml .Values.api.envFrom | nindent 12 }}
           volumeMounts:
             - name: prism-logs
               mountPath: /var/log/prism-arbitrage

--- a/infra/helm/templates/dashboard-deployment.yaml
+++ b/infra/helm/templates/dashboard-deployment.yaml
@@ -22,9 +22,9 @@ spec:
           ports:
             - containerPort: {{ .Values.dashboard.port }}
           resources: {{- toYaml .Values.dashboard.resources | nindent 12 }}
+          # Validation: This pod mounts dashboard-secrets via envFrom.secretRef
           envFrom:
-            - secretRef:
-                name: prod-secrets
+{{- toYaml .Values.dashboard.envFrom | nindent 12 }}
           volumeMounts:
             - name: prism-logs
               mountPath: /var/log/prism-arbitrage

--- a/infra/helm/templates/executor-deployment.yaml
+++ b/infra/helm/templates/executor-deployment.yaml
@@ -20,9 +20,9 @@ spec:
         - name: executor
           image: {{ .Values.executor.image }}
           resources: {{- toYaml .Values.executor.resources | nindent 12 }}
+          # Validation: This pod mounts executor-secrets via envFrom.secretRef
           envFrom:
-            - secretRef:
-                name: prod-secrets
+{{- toYaml .Values.executor.envFrom | nindent 12 }}
           volumeMounts:
             - name: prism-logs
               mountPath: /var/log/prism-arbitrage

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -20,6 +20,9 @@ api:
     limits:
       cpu: "500m"
       memory: "512Mi"
+  envFrom:
+    - secretRef:
+        name: api-secrets
   env:
     # JWT_SECRET: "<your-secret>"
     # PGHOST: "postgres"
@@ -40,6 +43,9 @@ analytics:
       cpu: "1000m"
       memory: "1Gi"
       nvidia.com/gpu: "1"
+  envFrom:
+    - secretRef:
+        name: analytics-secrets
   env:
     # MODEL_PATH: "/models/model.h5"
     # GPU_ENABLED: "true"
@@ -55,6 +61,9 @@ dashboard:
     limits:
       cpu: "200m"
       memory: "256Mi"
+  envFrom:
+    - secretRef:
+        name: dashboard-secrets
   env:
     # PUBLIC_URL: "https://arb.example.com"
     # NODE_ENV: "production"
@@ -66,6 +75,9 @@ executor:
       cpu: "250m"
     limits:
       cpu: "500m"
+  envFrom:
+    - secretRef:
+        name: executor-secrets
   env:
     # REDIS_URL: "redis://redis:6379"
     # ANALYTICS_URL: "http://analytics:5000/trade"

--- a/infra/secrets/sealed-secret-analytics.yaml
+++ b/infra/secrets/sealed-secret-analytics.yaml
@@ -1,0 +1,8 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: analytics-secrets
+  namespace: default
+spec:
+  encryptedData:
+    PLACEHOLDER: AgREPLACE_ME

--- a/infra/secrets/sealed-secret-api.yaml
+++ b/infra/secrets/sealed-secret-api.yaml
@@ -1,0 +1,11 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: api-secrets
+  namespace: default
+spec:
+  encryptedData:
+    JWT_SECRET: AgREPLACE_ME
+    BINANCE_KEY: AgREPLACE_ME
+    SMTP_USER: AgREPLACE_ME
+    SMTP_PASS: AgREPLACE_ME

--- a/infra/secrets/sealed-secret-dashboard.yaml
+++ b/infra/secrets/sealed-secret-dashboard.yaml
@@ -1,0 +1,8 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: dashboard-secrets
+  namespace: default
+spec:
+  encryptedData:
+    JWT_SECRET: AgREPLACE_ME

--- a/infra/secrets/sealed-secret-executor.yaml
+++ b/infra/secrets/sealed-secret-executor.yaml
@@ -1,0 +1,8 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: executor-secrets
+  namespace: default
+spec:
+  encryptedData:
+    BINANCE_KEY: AgREPLACE_ME


### PR DESCRIPTION
## Summary
- generate placeholder sealed secrets for each service
- inject sealed secrets via envFrom blocks in Helm values and templates
- document mounted secrets with validation comments

## Testing
- `npm test` in `dashboard`
- `npm test` in `api` *(fails: Cannot find module 'winston')*
- `pytest` in `analytics`
- `./gradlew test` in `executor` *(fails: failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_6880e5fd04f0832cb321df5654211583