### PR TITLE
fix panic/resume controls

### DIFF
--- a/api/__tests__/panicResume.test.js
+++ b/api/__tests__/panicResume.test.js
@@ -46,5 +46,11 @@ describeLocal('panic resume cycle', () => {
     const metrics2 = await request(app.server).get('/api/metrics/sandbox');
     expect(metrics2.body.panicActive).toBe(false);
   });
+
+  test('panic trigger debounced', async () => {
+    await request(app.server).post('/api/test/panic').send({ type: 'loss' });
+    const res = await request(app.server).post('/api/test/panic').send({ type: 'loss' });
+    expect(res.body.ignored).toBe(true);
+  });
 });
 

--- a/api/__tests__/system.status.test.js
+++ b/api/__tests__/system.status.test.js
@@ -30,12 +30,12 @@ describeLocal('system status endpoint', () => {
     const res = await request(app.server)
       .get('/api/system/status')
       .set('Cookie', cookie);
-    expect(res.body).toEqual({ paused: true, panic_reason: 'loss' });
+    expect(res.body).toEqual({ paused: true, panic_reason: 'loss', resume_failed: false });
 
     await request(app.server).post('/api/test/resume');
     const res2 = await request(app.server)
       .get('/api/system/status')
       .set('Cookie', cookie);
-    expect(res2.body).toEqual({ paused: false, panic_reason: null });
+    expect(res2.body).toEqual({ paused: false, panic_reason: null, resume_failed: false });
   });
 });

--- a/api/index.js
+++ b/api/index.js
@@ -30,7 +30,12 @@ import { sendAlert } from '../alerts/alertAgent.js';
 import { sendEmail } from '../alerts/emailAlert.js';
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
 import { start as startWsServer } from './services/wsServer.js';
-import { getPauseState, setPauseState } from './services/pauseState.js';
+import {
+  getPauseState,
+  setPauseState,
+  RESUME_FAILED_KEY,
+  RESUME_ACK_KEY,
+} from './services/pauseState.js';
 import { redisReachable, fetchBalances } from './services/balances.js';
 
 const { Pool } = pg;
@@ -55,7 +60,7 @@ if (process.env.NODE_ENV === 'production') {
 // Test mode disables external side effects
 
 const isTest = process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID;
-const panicState = { reason: null };
+const panicState = { reason: null, last: 0 };
 
 let redis;
 let pool;
@@ -246,6 +251,7 @@ async function apiRoutes(api, { redis, pool, panicState }) {
   api.get('/system/status', async () => ({
     paused: await getPauseState(redis),
     panic_reason: panicState.reason,
+    resume_failed: (await redis.get(RESUME_FAILED_KEY)) === 'true',
   }));
 
   api.register(systemHealthRoutes, { redis, pool });
@@ -263,9 +269,24 @@ async function apiRoutes(api, { redis, pool, panicState }) {
           reply.code(400);
           return { error: 'not paused' };
         }
+        await redis.set(RESUME_FAILED_KEY, 'false');
         await setPauseState(redis, false);
         panicState.reason = null;
         await redis.publish(getControlChannel(), 'resume');
+
+        let ack = false;
+        const start = Date.now();
+        while (Date.now() - start < 5000) {
+          const val = await redis.get(RESUME_ACK_KEY);
+          if (val === 'true') { ack = true; break; }
+          await new Promise(r => setTimeout(r, 500));
+        }
+        if (!ack) {
+          await redis.publish(getControlChannel(), 'resume');
+          await redis.set(RESUME_FAILED_KEY, 'true');
+        } else {
+          await redis.del(RESUME_FAILED_KEY);
+        }
         logger.info('[RESUME] Trading re-enabled by operator');
         return { paused: false, source: 'manual' };
       });

--- a/api/routes/alert.js
+++ b/api/routes/alert.js
@@ -8,20 +8,26 @@ export default async function alertRoutes(app, { redis }) {
     const timestamp = new Date().toISOString();
 
     try {
+      const last = await redis.get('panic_last_ts');
+      const now = Date.now();
+      if (last && now - parseInt(last, 10) < 30000) {
+        logger.info(JSON.stringify({ event: 'panic_ignored', ts: timestamp }));
+        return { paused: true, ignored: true, triggeredBy: source, timestamp };
+      }
       const val = await redis.get(PAUSE_KEY);
       const alreadyPaused = val === 'true';
       if (!alreadyPaused) {
         await redis.set(PAUSE_KEY, 'true');
         await redis.publish(getControlChannel(), 'halt');
       }
+      await redis.set('panic_last_ts', String(now));
       logger.warn(
         JSON.stringify({
-          timestamp,
-          event: 'panic_triggered',
-          component: 'api',
-          source: 'alert_api',
-          operator: source,
-        }),
+          event: 'panic',
+          reason: req.body?.type || 'alert',
+          value: req.body?.value || 0,
+          ts: timestamp,
+        })
       );
       return { paused: true, triggeredBy: source, timestamp };
     } catch (err) {

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -8,17 +8,25 @@ export default async function panicRoutes(app, { redis, panicState }) {
     if (process.env.SANDBOX_MODE !== 'true') {
       return reply.code(403).send();
     }
+    const now = Date.now();
+    if (now - (panicState.last || 0) < 30000) {
+      logger.info(
+        JSON.stringify({ event: 'panic_ignored', ts: new Date().toISOString() })
+      );
+      return { paused: true, ignored: true };
+    }
+    panicState.last = now;
+    await redis.set('panic_last_ts', String(now));
     await setPauseState(redis, true);
     panicState.reason = req.body?.type || null;
     await redis.publish(getControlChannel(), 'halt');
     logger.warn(
       JSON.stringify({
-        timestamp: new Date().toISOString(),
-        event: 'panic_triggered',
-        component: 'api',
-        source: 'dashboard',
-        operator: req.user?.email || 'unknown',
-      }),
+        event: 'panic',
+        reason: panicState.reason || 'manual',
+        value: req.body?.value || 0,
+        ts: new Date().toISOString(),
+      })
     );
     try {
       await sendAlert('email', 'Panic brake triggered (test mode)');

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { ensurePaused } from '../middleware/validate.js';
 import logger from '../services/logger.js';
-import { setPauseState } from '../services/pauseState.js';
+import { setPauseState, RESUME_ACK_KEY, RESUME_FAILED_KEY } from '../services/pauseState.js';
 
 export default async function resumeRoutes(app, opts) {
   const { redis, panicState } = opts;
@@ -55,9 +55,27 @@ export default async function resumeRoutes(app, opts) {
     }
 
     const channel = getControlChannel();
+    await redis.set(RESUME_FAILED_KEY, 'false');
     await redis.publish(channel, 'resume');
     await setPauseState(redis, false);
     panicState.reason = null;
+
+    let ack = false;
+    const start = Date.now();
+    while (Date.now() - start < 5000) {
+      const val = await redis.get(RESUME_ACK_KEY);
+      if (val === 'true') {
+        ack = true;
+        break;
+      }
+      await new Promise(r => setTimeout(r, 500));
+    }
+    if (!ack) {
+      await redis.publish(channel, 'resume');
+      await redis.set(RESUME_FAILED_KEY, 'true');
+    } else {
+      await redis.del(RESUME_FAILED_KEY);
+    }
     const msg = `Trading resumed by ${user} at ${new Date().toISOString()}`;
     await redis.publish('alerts', msg);
     if (process.env.SANDBOX_MODE !== 'true') {
@@ -71,13 +89,7 @@ export default async function resumeRoutes(app, opts) {
     }
     logAttempt('resume_success', user);
     logger.info(
-      JSON.stringify({
-        timestamp: new Date().toISOString(),
-        event: 'resume_triggered',
-        component: 'api',
-        source: 'dashboard',
-        operator: user,
-      }),
+      JSON.stringify({ event: 'resume', ts: new Date().toISOString() })
     );
     return { resumed: true };
   }

--- a/api/services/pauseState.js
+++ b/api/services/pauseState.js
@@ -1,6 +1,8 @@
 import logger from './logger.js';
 
 export const PAUSE_KEY = 'arb:paused_state';
+export const RESUME_FAILED_KEY = 'resume_failed';
+export const RESUME_ACK_KEY = 'resume_ack';
 
 export async function setPauseState(redis, value) {
   try {
@@ -17,5 +19,13 @@ export async function getPauseState(redis) {
   } catch (err) {
     logger.warn('[REDIS ERROR] Cannot access paused state — defaulting to safe paused mode');
     return true;
+  }
+}
+
+export async function setResumeAck(redis) {
+  try {
+    await redis.set(RESUME_ACK_KEY, 'true', 'EX', 60);
+  } catch (err) {
+    logger.warn('[REDIS ERROR] Cannot set resume ack');
   }
 }

--- a/dashboard/src/__tests__/ResumeButton.test.jsx
+++ b/dashboard/src/__tests__/ResumeButton.test.jsx
@@ -27,6 +27,21 @@ test('button disabled with tooltip when resume blocked', async () => {
   expect(btn).toHaveAttribute('title', 'System not ready to resume \u2014 check logs');
 });
 
+test('shows resume failed message', async () => {
+  const refresh = jest.fn();
+  global.fetch = jest.fn(() => Promise.resolve({ status: 200, ok: true, json: () => Promise.resolve({ resumed: true }) }));
+
+  await act(async () => {
+    render(
+      <SystemStatusContext.Provider value={{ panic: true, reason: 'loss', resumeFailed: true, refreshStatus: refresh }}>
+        <ResumeButton />
+      </SystemStatusContext.Provider>
+    );
+  });
+
+  expect(screen.getByTestId('resume-failed')).toBeInTheDocument();
+});
+
 test('shows confirmation modal and confirms resume', async () => {
   const refresh = jest.fn();
   global.fetch = jest

--- a/dashboard/src/components/ResumeButton.jsx
+++ b/dashboard/src/components/ResumeButton.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useSystemStatus } from '../context/SystemStatusContext.jsx';
 
 export default function ResumeButton() {
-  const { panic, reason, refreshStatus } = useSystemStatus();
+  const { panic, reason, resumeFailed, refreshStatus } = useSystemStatus();
   const [blocked, setBlocked] = useState(false);
   const [confirmOverride, setConfirmOverride] = useState(false);
   const [toast, setToast] = useState(null);
@@ -49,6 +49,9 @@ export default function ResumeButton() {
 
   return (
     <div className="relative inline-block">
+      {resumeFailed && (
+        <div data-testid="resume-failed" className="text-red-600 mb-2">Resume failed</div>
+      )}
       {toast && (
         <div className="absolute right-0 -top-10 px-3 py-1 text-white bg-green-600 rounded">
           {toast}

--- a/dashboard/src/context/SystemStatusContext.jsx
+++ b/dashboard/src/context/SystemStatusContext.jsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { fetchSystemStatus } from '../utils/api.js';
 
-const SystemStatusContext = createContext({ panic: false, reason: '' });
+const SystemStatusContext = createContext({ panic: false, reason: '', resumeFailed: false });
 
 export { SystemStatusContext };
 
@@ -11,6 +11,7 @@ export const useSystemStatus = () => useContext(SystemStatusContext);
 export function SystemStatusProvider({ children }) {
   const [panic, setPanic] = useState(false);
   const [reason, setReason] = useState('');
+  const [resumeFailed, setResumeFailed] = useState(false);
 
   // Poll API for current panic state
   async function fetchStatus() {
@@ -18,6 +19,7 @@ export function SystemStatusProvider({ children }) {
       const data = await fetchSystemStatus();
       setPanic(Boolean(data.paused));
       setReason(data.panic_reason || '');
+      setResumeFailed(Boolean(data.resume_failed));
     } catch (err) {
       console.error('Failed to fetch system status', err);
     }
@@ -28,7 +30,7 @@ export function SystemStatusProvider({ children }) {
   }, []);
 
   return (
-    <SystemStatusContext.Provider value={{ panic, reason, refreshStatus: fetchStatus }}>
+    <SystemStatusContext.Provider value={{ panic, reason, resumeFailed, refreshStatus: fetchStatus }}>
       {children}
     </SystemStatusContext.Provider>
   );

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -223,6 +223,17 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
      * @param message JSON encoded opportunity
      */
     public void handleMessage(String message) {
+        if (redisClient.isPaused()) {
+            logger.info(
+                    com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
+                            .createObjectNode()
+                            .put("event", "panic_active")
+                            .put("action", "evaluation_skipped")
+                            .put("ts", java.time.Instant.now().toString())
+                            .toString());
+            return;
+        }
+
         SpreadOpportunity opp = validateMessage(message);
         if (opp == null) {
             return;
@@ -487,12 +498,10 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             logger.info(
                     com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
                             .createObjectNode()
-                            .put("timestamp", java.time.Instant.now().toString())
-                            .put("event", "resume_triggered")
-                            .put("component", "executor")
-                            .put("source", "redis")
-                            .put("operator", "system")
+                            .put("event", "resume")
+                            .put("ts", java.time.Instant.now().toString())
                             .toString());
+            redisClient.setResumeAck();
             AlertManager.send("RESUME", "Trading resumed at " + ts);
             redisClient.publish("alerts", "Trading resumed at " + ts);
             redisClient.publish(controlChannel, "resume:" + ts);

--- a/executor/src/main/java/PanicBrake.java
+++ b/executor/src/main/java/PanicBrake.java
@@ -86,27 +86,30 @@ public class PanicBrake {
 
         boolean triggered = false;
         String reason = null;
+        double value = 0.0;
 
         if (dailyLossPct > lossCap) {
-            reason = "LOSS_CAP";
+            reason = "loss";
+            value = -dailyLossPct;
         } else if (avgLatencyMs > latencyCap) {
-            reason = "LATENCY_CAP";
+            reason = "latency";
+            value = avgLatencyMs;
         } else if (winRate < winRateThresh) {
-            reason = "WIN_RATE";
+            reason = "win_rate";
+            value = winRate;
         } else if (profitTarget > 0 && profitSoFar >= profitTarget) {
-            reason = "PROFIT_TARGET";
+            reason = "profit_target";
+            value = profitSoFar;
         }
 
         if (reason != null) {
             logger.error(
                     com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
                             .createObjectNode()
-                            .put("timestamp", java.time.Instant.now().toString())
-                            .put("event", "panic_triggered")
-                            .put("component", "executor")
-                            .put("source", "internal")
-                            .put("operator", "system")
+                            .put("event", "panic")
                             .put("reason", reason)
+                            .put("value", value)
+                            .put("ts", java.time.Instant.now().toString())
                             .toString());
             triggered = true;
         }

--- a/executor/src/main/java/RedisClient.java
+++ b/executor/src/main/java/RedisClient.java
@@ -15,6 +15,8 @@ import java.util.function.Consumer;
  */
 public class RedisClient extends Thread {
     private static final Logger logger = LoggerFactory.getLogger(RedisClient.class);
+    public static final String PAUSE_KEY = "arb:paused_state";
+    public static final String RESUME_ACK_KEY = "resume_ack";
 
     public interface MessageHandler {
         void onMessage(String channel, String message);
@@ -232,6 +234,26 @@ public class RedisClient extends Thread {
         } catch (Exception e) {
             logger.error("Redis read failed: {}", e.getMessage());
             return false;
+        }
+    }
+
+    /** Check if trading is paused */
+    public boolean isPaused() {
+        try (Jedis jedis = new Jedis(host, port)) {
+            String val = jedis.get(PAUSE_KEY);
+            return val != null && val.equalsIgnoreCase("true");
+        } catch (Exception e) {
+            logger.error("Redis read failed: {}", e.getMessage());
+            return true;
+        }
+    }
+
+    /** Record resume acknowledgement */
+    public void setResumeAck() {
+        try (Jedis jedis = new Jedis(host, port)) {
+            jedis.setex(RESUME_ACK_KEY, 60, "true");
+        } catch (Exception e) {
+            logger.error("Redis write failed: {}", e.getMessage());
         }
     }
 

--- a/executor/src/test/java/PanicResumeLifecycleTest.java
+++ b/executor/src/test/java/PanicResumeLifecycleTest.java
@@ -1,0 +1,46 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class PanicResumeLifecycleTest {
+    static class DummyRedis extends RedisClient {
+        boolean paused = true;
+        boolean ack = false;
+        int publishes = 0;
+        DummyRedis() { super("localhost", 6379, "chan", (c,m)->{}); }
+        @Override public void start() {}
+        @Override public boolean ping() { return true; }
+        @Override public boolean publish(String ch, String msg) { publishes++; return true; }
+        @Override public boolean isPaused() { return paused; }
+        @Override public void setResumeAck() { ack = true; }
+    }
+
+    static class DummyExecutor extends Executor {
+        DummyRedis client;
+        DummyExecutor(DummyRedis c) {
+            super(c, "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.SANDBOX));
+            this.client = c;
+            setSandboxMode(true);
+        }
+        @Override public void start() {}
+    }
+
+    @Test
+    void skipsWhenPausedThenResumes() {
+        ProfitTracker.init(10000, "http://localhost");
+        DummyRedis redis = new DummyRedis();
+        DummyExecutor exec = new DummyExecutor(redis);
+        String msg = "{\"pair\":\"BTC/USDT\",\"buyExchange\":\"A\",\"sellExchange\":\"B\",\"grossEdge\":1.0,\"netEdge\":1.0}";
+        exec.handleMessage(msg);
+        assertEquals(0, redis.publishes);
+        redis.paused = false;
+        exec.resumeFromPanic();
+        exec.handleMessage(msg);
+        assertTrue(redis.ack);
+        assertEquals(1, redis.publishes);
+    }
+}


### PR DESCRIPTION
## Summary
- debounce panic triggers on API side
- ensure resume handshake with Redis ack
- store panic/resume status for dashboard
- enforce paused check in executor loop
- log structured JSON for panic and resume events
- show resume failure message in UI
- add panic-resume lifecycle unit test

## Testing
- `npm test` *(fails: Cannot find module 'winston')*
- `npm test` in dashboard
- `./gradlew test` *(fails: there were failing tests)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880e72776b0832c9fd6d5c2c1022b19