### PR TITLE
Fix-03: auth-logging-operator-visibility

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -30,7 +30,7 @@ import { sendAlert } from '../alerts/alertAgent.js';
 import { sendEmail } from '../alerts/emailAlert.js';
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
 import { start as startWsServer } from './services/wsServer.js';
-import { getPauseState, setPauseState } from './services/pauseState.js';
+import { getPauseState, setPauseState, getResumeFailed } from './services/pauseState.js';
 import { redisReachable, fetchBalances } from './services/balances.js';
 
 const { Pool } = pg;
@@ -59,6 +59,7 @@ const panicState = { reason: null };
 
 let redis;
 let pool;
+let subscriber;
 
 async function buildApp() {
   const app = Fastify();
@@ -91,6 +92,21 @@ async function buildApp() {
         const { hostname, port } = new URL(redisUrl);
         redis = new Redis(redisUrl);
         logger.info(`[REDIS] Connected to ${hostname}:${port} via REDIS_URL`);
+        subscriber = redis.duplicate();
+        const channel = getControlChannel();
+        await subscriber.subscribe(channel);
+        subscriber.on('message', (ch, message) => {
+          if (['resume', 'halt', 'panic'].includes(message)) {
+            logger.info(
+              JSON.stringify({
+                event: 'redis_received',
+                channel: ch,
+                message,
+                ts: new Date().toISOString(),
+              })
+            );
+          }
+        });
       } catch (err) {
         logger.error(`[REDIS] Invalid REDIS_URL: ${err.message}`);
       }
@@ -105,6 +121,9 @@ async function buildApp() {
       await pool.end();
       if (redis && typeof redis.quit === 'function') {
         await redis.quit();
+      }
+      if (subscriber && typeof subscriber.quit === 'function') {
+        await subscriber.quit();
       }
     });
 
@@ -246,6 +265,7 @@ async function apiRoutes(api, { redis, pool, panicState }) {
   api.get('/system/status', async () => ({
     paused: await getPauseState(redis),
     panic_reason: panicState.reason,
+    resume_failed: await getResumeFailed(redis),
   }));
 
   api.register(systemHealthRoutes, { redis, pool });

--- a/api/routes/config.js
+++ b/api/routes/config.js
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { requireAdmin } from '../middleware/auth.js';
+import logger from '../services/logger.js';
 
 export const config = {
   maxLoss: 5,
@@ -20,6 +21,18 @@ export default async function configRoutes(app) {
   app.post('/config', { preHandler: requireAdmin }, async (req, reply) => {
     const result = schema.safeParse(req.body);
     if (!result.success || Object.keys(result.data).length === 0) {
+      const ts = new Date().toISOString();
+      for (const [field, value] of Object.entries(req.body || {})) {
+        logger.warn(
+          JSON.stringify({
+            event: 'unauthorized_config_change',
+            field,
+            value,
+            status: 'rejected',
+            ts,
+          })
+        );
+      }
       reply.code(400);
       return { error: 'invalid config' };
     }

--- a/api/routes/login.js
+++ b/api/routes/login.js
@@ -1,6 +1,7 @@
 // Login endpoint handling sandbox demo credentials
 import bcrypt from 'bcryptjs';
 import { findByEmail } from './userStore.js';
+import logger from '../services/logger.js';
 
 const SANDBOX_EMAIL = 'demo@prismarbitrage.ai';
 const SANDBOX_PASS = 'demo1234';
@@ -12,6 +13,7 @@ export default async function loginRoutes(app) {
 
   app.post('/login', async (req, reply) => {
     const { email, password } = req.body;
+    const ts = new Date().toISOString();
 
     const cookieOpts = { httpOnly: true };
     if (process.env.NODE_ENV === 'production') {
@@ -20,6 +22,9 @@ export default async function loginRoutes(app) {
 
     if (sandboxMode && email === SANDBOX_EMAIL && password === SANDBOX_PASS) {
       reply.setCookie('token', HARD_CODED_JWT, cookieOpts);
+      logger.info(
+        JSON.stringify({ event: 'login_attempt', status: 'success', user: email, ts })
+      );
       return { token: HARD_CODED_JWT };
     }
 
@@ -34,9 +39,21 @@ export default async function loginRoutes(app) {
       };
       const token = app.jwt.sign(payload, { algorithm: 'HS256' });
       reply.setCookie('token', token, cookieOpts);
+      logger.info(
+        JSON.stringify({ event: 'login_attempt', status: 'success', user: email, ts })
+      );
       return { token };
     }
 
+    logger.warn(
+      JSON.stringify({
+        event: 'login_attempt',
+        status: 'failure',
+        user: email,
+        reason: 'bad credentials',
+        ts,
+      })
+    );
     reply.code(401).send({ error: 'invalid credentials' });
   });
 }

--- a/api/services/pauseState.js
+++ b/api/services/pauseState.js
@@ -1,6 +1,7 @@
 import logger from './logger.js';
 
 export const PAUSE_KEY = 'arb:paused_state';
+export const RESUME_FAILED_KEY = 'arb:resume_failed';
 
 export async function setPauseState(redis, value) {
   try {
@@ -17,5 +18,23 @@ export async function getPauseState(redis) {
   } catch (err) {
     logger.warn('[REDIS ERROR] Cannot access paused state — defaulting to safe paused mode');
     return true;
+  }
+}
+
+export async function getResumeFailed(redis) {
+  try {
+    const val = await redis.get(RESUME_FAILED_KEY);
+    return val === 'true';
+  } catch (err) {
+    logger.warn('[REDIS ERROR] Cannot access resume_failed flag');
+    return false;
+  }
+}
+
+export async function setResumeFailed(redis, value) {
+  try {
+    await redis.set(RESUME_FAILED_KEY, value ? 'true' : 'false');
+  } catch (err) {
+    logger.warn('[REDIS ERROR] Cannot update resume_failed flag');
   }
 }

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -12,6 +12,7 @@ import Alerts from './pages/Alerts';
 import Login from './pages/Login';
 import Infrastructure from './pages/Infrastructure';
 import AdminPanel from './pages/AdminPanel';
+import Config from './pages/Config';
 // Guard routes so only logged-in users see them
 
 function RequireAuth({ children }) {
@@ -32,6 +33,7 @@ function App() {
             <Route path="/analytics" element={<RequireAuth><Analytics /></RequireAuth>} />
             <Route path="/infrastructure" element={<Infrastructure />} />
             <Route path="/admin" element={<AdminPanel />} />
+            <Route path="/config" element={<RequireAuth><Config /></RequireAuth>} />
             <Route path="/alerts" element={<Alerts />} />
             <Route path="/login" element={<Login />} />
           </Routes>

--- a/dashboard/src/__tests__/SystemStatusBanner.test.jsx
+++ b/dashboard/src/__tests__/SystemStatusBanner.test.jsx
@@ -3,12 +3,12 @@ import { render, screen, act, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SystemStatusBanner from '../components/SystemStatusBanner.jsx';
 
-async function setup({ paused, mode }) {
+async function setup({ paused, mode, resumeFailed = false }) {
   global.fetch = jest
     .fn()
     .mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ paused, panic_reason: null }),
+      json: () => Promise.resolve({ paused, panic_reason: null, resume_failed: resumeFailed }),
     })
     .mockResolvedValueOnce({
       ok: true,
@@ -50,4 +50,10 @@ test('shows sandbox panic state', async () => {
   const banner = await screen.findByTestId('system-status-banner');
   expect(banner).toHaveTextContent('Sandbox Panic - Simulating Failure State');
   expect(banner).toHaveClass('bg-red-900');
+});
+
+test('shows resume failed banner', async () => {
+  await setup({ mode: 'live', paused: false, resumeFailed: true });
+  const banner = await screen.findByTestId('resume-failed-banner');
+  expect(banner).toHaveTextContent('Resume failed: Executor not responding');
 });

--- a/dashboard/src/components/SystemStatusBanner.jsx
+++ b/dashboard/src/components/SystemStatusBanner.jsx
@@ -4,11 +4,13 @@ import { fetchSystemStatus } from '../utils/api.js';
 export default function SystemStatusBanner() {
   const [mode, setMode] = useState('live');
   const [panic, setPanic] = useState(false);
+  const [resumeFailed, setResumeFailed] = useState(false);
 
   async function loadStatus() {
     try {
       const data = await fetchSystemStatus();
       setPanic(Boolean(data.paused));
+      setResumeFailed(Boolean(data.resume_failed));
     } catch (err) {
       console.error('Failed to fetch system status', err);
     }
@@ -29,6 +31,26 @@ export default function SystemStatusBanner() {
     const id = setInterval(loadStatus, 30000);
     return () => clearInterval(id);
   }, []);
+
+  useEffect(() => {
+    if (!resumeFailed) return;
+    const t = setTimeout(() => setResumeFailed(false), 10000);
+    return () => clearTimeout(t);
+  }, [resumeFailed]);
+
+  if (resumeFailed) {
+    return (
+      <div
+        data-testid="resume-failed-banner"
+        className="bg-red-700 text-white text-center py-2 font-semibold"
+      >
+        Resume failed: Executor not responding
+        <button className="ml-2 underline" onClick={() => setResumeFailed(false)}>
+          Dismiss
+        </button>
+      </div>
+    );
+  }
 
   let bg = 'bg-green-600';
   let text = '✅ Live - Trading Active';

--- a/dashboard/src/pages/Config.jsx
+++ b/dashboard/src/pages/Config.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+
+export default function Config() {
+  const [maxLoss, setMaxLoss] = useState(5);
+  const [maxLatency, setMaxLatency] = useState(250);
+  const [loading, setLoading] = useState(true);
+  const [toast, setToast] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/config');
+        if (res.ok) {
+          const data = await res.json();
+          if (typeof data.maxLoss === 'number') setMaxLoss(data.maxLoss);
+          if (typeof data.maxLatency === 'number') setMaxLatency(data.maxLatency);
+        } else {
+          setToast({ type: 'error', msg: 'Failed to load config' });
+        }
+      } catch {
+        setToast({ type: 'error', msg: 'Failed to load config' });
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  async function save() {
+    try {
+      const res = await fetch('/api/config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ maxLoss, maxLatency }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        setToast({ type: 'success', msg: 'Saved config' });
+      } else {
+        setToast({ type: 'error', msg: data.error || 'Invalid config' });
+      }
+    } catch {
+      setToast({ type: 'error', msg: 'Save failed' });
+    }
+  }
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="relative p-4 space-y-4">
+      {toast && (
+        <div
+          className={`absolute right-4 top-4 px-3 py-2 text-white rounded ${
+            toast.type === 'success' ? 'bg-green-600' : 'bg-red-600'
+          }`}
+        >
+          {toast.msg}
+        </div>
+      )}
+      <label className="block">
+        Max Loss
+        <input
+          type="number"
+          className="ml-2 border"
+          value={maxLoss}
+          onChange={(e) => setMaxLoss(Number(e.target.value))}
+        />
+      </label>
+      <label className="block">
+        Max Latency
+        <input
+          type="number"
+          className="ml-2 border"
+          value={maxLatency}
+          onChange={(e) => setMaxLatency(Number(e.target.value))}
+        />
+      </label>
+      <button className="bg-blue-600 text-white px-3 py-1 rounded" onClick={save}>
+        Save
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- log login attempt success or failure in JSON
- reject unsafe config updates and log as unauthorized
- subscribe to control-feed and log Redis messages
- expose resume_failed status via the API
- show resume failure banner in dashboard
- add config page with toast errors

## Testing
- `npm --prefix dashboard test -- --runInBand`
- `npm --prefix api test -- --runInBand` *(fails: resume endpoint, model routes)*
- `pytest` *(fails: ModuleNotFoundError for numpy)*
- `executor/gradlew test -p executor -PtestEnv=local` *(fails: OutOfMemoryError)*

------
https://chatgpt.com/codex/tasks/task_b_6880e750f164832cbf405ab11ec20aea