### PR TITLE
chore: update helm deployment process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ __pycache__/
 # Gradle wrapper binary
 executor/gradle/wrapper/gradle-wrapper.jar
 .venv/
+ops/snapshots/

--- a/README.md
+++ b/README.md
@@ -97,10 +97,16 @@ Branch protection rules require the CI checks to succeed before merging.
 
 1. Provision an Ubuntu 22.04 VM in Proxmox (10 cores, 32 GB RAM).
 2. Install Kubernetes, Helm and the SealedSecrets controller on the VM.
-3. Clone the repo on the VM and create sealed secrets for all `.env` files.
+3. Clone the repo on the VM and check out the production branch:
+   ```bash
+   git clone https://github.com/prism-arbitrage/crypto-arbitrage.git
+   cd crypto-arbitrage
+   git checkout main
+   ```
+   Create sealed secrets for all `.env` files.
 4. Deploy with Helm:
    ```bash
-   helm install prism ./infra/helm
+   helm install prism-prod ./infra/helm --namespace default
    ```
 5. Expose the dashboard via ingress or port‑forward and confirm login works.
 
@@ -138,6 +144,24 @@ kubectl apply -f sealed-api.yaml
 Run all mocked tests locally:
 ```bash
 ./test/run-local.sh
+```
+
+## Helm Release Rollback
+
+Check previous releases and revert if needed:
+
+```bash
+helm history prism-prod
+helm rollback prism-prod <revision>
+```
+
+On every successful deploy from the `main` branch, store a release snapshot:
+
+```
+mkdir -p /ops/snapshots/prism-prod-1.0.0
+helm get values prism-prod > /ops/snapshots/prism-prod-1.0.0/values.yaml
+git rev-parse HEAD > /ops/snapshots/prism-prod-1.0.0/commit.txt
+# add brief notes to /ops/snapshots/prism-prod-1.0.0/notes.md
 ```
 
 ---

--- a/docs/Complete Guide.MD
+++ b/docs/Complete Guide.MD
@@ -656,7 +656,7 @@ Helm Local Deployment (Optional)
 
  bash
 CopyEdit
-helm install arb infra/helm/
+helm install prism-prod infra/helm/ --namespace default
 
 
 
@@ -886,17 +886,17 @@ Deploy the Entire App:
 bash
 CopyEdit
 cd infra/helm
-helm install prism-arbitrage . --namespace default
+helm install prism-prod . --namespace default
 
 Upgrade in Place:
 bash
 CopyEdit
-helm upgrade prism-arbitrage . --namespace default
+helm upgrade prism-prod . --namespace default
 
 Rollback If Needed:
 bash
 CopyEdit
-helm rollback prism-arbitrage <revision>
+helm rollback prism-prod <revision>
 
 Verify Pods and Services:
 bash
@@ -4746,7 +4746,7 @@ List All Release Revisions
 
  bash
 CopyEdit
-helm history prism-arbitrage
+helm history prism-prod
  Output Example:
 
  yaml
@@ -4760,7 +4760,7 @@ Rollback to Known Good Revision
 
  bash
 CopyEdit
-helm rollback prism-arbitrage 1
+helm rollback prism-prod 1
 
 
 Verify Rollback

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -8,4 +8,4 @@ Use this list before promoting a new version to production.
 - [ ] Secrets sealed and committed.
 - [ ] `helm upgrade` executed with the correct release name.
 - [ ] Post-deploy checks: `kubectl get pods`, dashboard loads, no errors in logs.
-- [ ] Snapshot captured under `ops/snapshots/` for audit.
+- [ ] Snapshot captured under `/ops/snapshots/prism-prod-<version>/` for audit.

--- a/docs/ops/Phase-2-server-deployment.md
+++ b/docs/ops/Phase-2-server-deployment.md
@@ -196,19 +196,19 @@ kubectl apply -f sealed-secret.yaml
 
 ```bash
 cd infra/helm
-helm install prism-arbitrage . --namespace default
+helm install prism-prod . --namespace default
 ```
 
 To upgrade:
 
 ```bash
-helm upgrade prism-arbitrage . --namespace default
+helm upgrade prism-prod . --namespace default
 ```
 
 Rollback:
 
 ```bash
-helm rollback prism-arbitrage <revision>
+helm rollback prism-prod <revision>
 ```
 
 ---

--- a/docs/ops/log-forwarder-guide.MD
+++ b/docs/ops/log-forwarder-guide.MD
@@ -13,7 +13,7 @@ logForwarder:
 
 1. Deploy the log forwarder:
    ```bash
-   helm upgrade --install arb infra/helm -f infra/helm/values.yaml
+   helm upgrade --install prism-prod infra/helm -f infra/helm/values.yaml --namespace default
    ```
 2. Access Loki through Grafana to search logs across all services.
 

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -9,7 +9,7 @@ This guide explains how to revert a deployment using **Helm**. Ensure any databa
 List existing revisions so you know which one to roll back to:
 
 ```bash
-helm history arb
+helm history prism-prod
 ```
 
 ---
@@ -19,7 +19,7 @@ helm history arb
 Specify the target revision from the previous command:
 
 ```bash
-helm rollback arb <revision>
+helm rollback prism-prod <revision>
 ```
 
 > **Warning**: Rolling back may fail if the target revision uses a different database schema. Confirm migrations are compatible before proceeding.
@@ -43,8 +43,8 @@ A `Running` status indicates the rollback succeeded.
 Before performing any rollback, capture the current deployment state for auditing:
 
 ```bash
-helm get values arb > snapshots/$(date +%Y%m%d)-values.yaml
-git rev-parse HEAD > snapshots/$(date +%Y%m%d)-commit.txt
+helm get values prism-prod > /ops/snapshots/prism-prod-$(date +%Y%m%d)/values.yaml
+git rev-parse HEAD > /ops/snapshots/prism-prod-$(date +%Y%m%d)/commit.txt
 ```
 
-Add any additional notes about the release to `snapshots/<date>-notes.txt`.
+Add any additional notes about the release to `/ops/snapshots/prism-prod-<date>/notes.md`.

--- a/infra/helm/Chart.yaml
+++ b/infra/helm/Chart.yaml
@@ -1,2 +1,3 @@
 name: crypto-arbitrage
-version: 0.1.0
+version: 1.0.0
+appVersion: 1.0.0

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -67,5 +67,5 @@ log "Applying NVIDIA GPU plugin"
 kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.12.3/nvidia-device-plugin.yml
 
 log "Deploying Helm chart"
-helm upgrade --install --atomic prism "$ROOT_DIR/infra/helm" \
-  --namespace arbitrage --create-namespace
+helm upgrade --install --atomic prism-prod "$ROOT_DIR/infra/helm" \
+  --namespace default

--- a/test/verify-env.sh
+++ b/test/verify-env.sh
@@ -62,6 +62,9 @@ fi
 
 echo "Environment verified"
 
+echo "Helm release history:"
+helm history prism-prod || echo "No release history found."
+
 curl -sf http://localhost:8080/api/metrics/live >/dev/null
 curl -sf http://localhost:8080/api/metrics/sandbox >/dev/null
 if [ "${PANIC:-}" = "true" ] && [ "${HEARTBEAT:-}" = "dead" ]; then


### PR DESCRIPTION
## Summary
- set Helm chart version to `1.0.0`
- document using `prism-prod` Helm release name and rollback steps
- mention snapshot creation process and production branch checkout
- ignore deployment snapshots in `.gitignore`
- show Helm history in `verify-env.sh`
- update production deploy script to use `prism-prod`

## Testing
- `bash test/verify-env.sh` *(fails: `helm` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6880e94855cc832c86693051ce655673