### PR TITLE
Add coverage for panic recovery and sweep endpoints

### DIFF
--- a/api/babel.config.js
+++ b/api/babel.config.js
@@ -1,5 +1,6 @@
 export default {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }],
+    '@babel/preset-typescript',
   ],
 };

--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,6 +1,6 @@
 export default {
   testEnvironment: 'jest-environment-node',
   transform: {
-    '^.+\\.js$': 'babel-jest',
+    '^.+\\.[jt]s$': 'babel-jest',
   }
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -17,6 +17,7 @@
         "ioredis": "5.6.1",
         "nodemailer": "7.0.5",
         "pg": "8.16.3",
+        "prom-client": "15.1.3",
         "winston": "3.17.0",
         "ws": "8.18.3",
         "zod": "4.0.5"
@@ -24,6 +25,7 @@
       "devDependencies": {
         "@babel/core": "7.28.0",
         "@babel/preset-env": "7.28.0",
+        "@babel/preset-typescript": "7.27.1",
         "babel-jest": "30.0.5",
         "jest": "30.0.5",
         "jest-environment-jsdom": "29.6.4",
@@ -1606,6 +1608,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
+      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -1781,6 +1803,26 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/template": {
@@ -4841,6 +4883,12 @@
       "bin": {
         "bcrypt": "bin/bcrypt"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "4.12.2",
@@ -10179,6 +10227,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -11079,6 +11140,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {

--- a/api/package.json
+++ b/api/package.json
@@ -27,6 +27,7 @@
     "@babel/core": "7.28.0",
     "@babel/preset-env": "7.28.0",
     "babel-jest": "30.0.5",
-    "jest-environment-jsdom": "29.6.4"
+    "jest-environment-jsdom": "29.6.4",
+    "@babel/preset-typescript": "7.27.1"
   }
 }

--- a/api/tests/sweep.test.ts
+++ b/api/tests/sweep.test.ts
@@ -1,0 +1,26 @@
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
+
+let buildApp: any;
+let app: any;
+
+beforeAll(async () => {
+  ({ buildApp } = await import('../index.js'));
+  app = await buildApp();
+  await app.listen({ port: 0 });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+test('cold sweep dry-run endpoint', async () => {
+  const res = await request(app.server).post('/api/test/sweep');
+  expect(res.statusCode).toBe(200);
+  expect(res.body.status).toBe('dry-run-complete');
+  expect(typeof res.body.triggered).toBe('boolean');
+  expect(Array.isArray(res.body.actions)).toBe(true);
+});

--- a/dashboard/__tests__/PanicFlow.test.jsx
+++ b/dashboard/__tests__/PanicFlow.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SystemStatusProvider } from '../src/context/SystemStatusContext.jsx';
+import Dashboard from '../src/pages/Dashboard.jsx';
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
+
+describeLocal('panic resume UI', () => {
+  test('status label toggles', async () => {
+    const state = { paused: false };
+    global.fetch = jest.fn((url, opts) => {
+      if (url === '/api/system/status') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ paused: state.paused }) });
+      }
+      if (url === '/api/wallet/balance') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ balance: 0 }) });
+      }
+      if (url === '/api/metrics') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      if (url === '/api/trades/status') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ trades: [] }) });
+      }
+      if (url === '/api/settings') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ sandbox_mode: false }) });
+      }
+      if (url === '/api/panic') {
+        state.paused = true; return Promise.resolve({ ok: true });
+      }
+      if (url.startsWith('/api/resume')) {
+        state.paused = false; return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    await act(async () => {
+      render(
+        <SystemStatusProvider>
+          <Dashboard />
+        </SystemStatusProvider>
+      );
+    });
+
+    expect(screen.getByTestId('system-status')).toHaveTextContent('active');
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /pause trading/i })); });
+    expect(await screen.findByTestId('system-status')).toHaveTextContent('paused');
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /resume trading/i })); });
+    expect(await screen.findByTestId('system-status')).toHaveTextContent('active');
+  });
+});

--- a/executor/src/test/java/PanicResumeLoopTest.java
+++ b/executor/src/test/java/PanicResumeLoopTest.java
@@ -1,0 +1,55 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class PanicResumeLoopTest {
+    static class LocalRedisClient extends RedisClient {
+        java.util.function.Consumer<String> control;
+        LocalRedisClient() { super("localhost", 6379, "feed", (c,m)->{}); }
+        @Override public void start() { }
+        @Override public boolean ping() { return true; }
+        @Override public void subscribeControl(Config config, java.util.function.Consumer<String> handler) { this.control = handler; }
+        void sendControl(String msg) { if (control != null) control.accept(msg); }
+        @Override public boolean isPaused() { return panicFlag.get(); }
+        private final java.util.concurrent.atomic.AtomicBoolean panicFlag = new java.util.concurrent.atomic.AtomicBoolean(false);
+        @Override public boolean publish(String ch, String msg) { return true; }
+    }
+
+    static class DummyExecutor extends Executor {
+        int processed = 0;
+        DummyExecutor(LocalRedisClient c) {
+            super(c, "localhost", 6379, new RiskFilter(), new NearMissLogger(null));
+        }
+        @Override public void start() { setupControlSubscription(); }
+        @Override public void handleMessage(String msg) {
+            super.handleMessage(msg);
+            processed++;
+        }
+    }
+
+    @Test
+    void haltsAndResumesEvaluationLoop() throws Exception {
+        LocalRedisClient client = new LocalRedisClient();
+        DummyExecutor exec = new DummyExecutor(client);
+        exec.start();
+
+        String msg = "{\"pair\":\"A/B\",\"buyExchange\":\"A\",\"sellExchange\":\"B\",\"grossEdge\":1.0,\"netEdge\":1.0}";
+        exec.handleMessage(msg);
+        assertEquals(1, exec.processed);
+
+        client.panicFlag.set(true);
+        client.sendControl("halt");
+        Thread.sleep(50);
+        exec.handleMessage(msg);
+        assertEquals(1, exec.processed, "evaluation should halt when panic");
+
+        client.panicFlag.set(false);
+        client.sendControl("resume");
+        Thread.sleep(50);
+        exec.handleMessage(msg);
+        assertEquals(2, exec.processed, "evaluation should resume after signal");
+    }
+}

--- a/executor/src/test/java/RedisPubSubIntegrationTest.java
+++ b/executor/src/test/java/RedisPubSubIntegrationTest.java
@@ -1,0 +1,40 @@
+package executor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("local")
+public class RedisPubSubIntegrationTest {
+    @Test
+    void receivesResumeMessage() throws Exception {
+        Process redis = new ProcessBuilder("redis-server", "--port", "6390").start();
+        Thread.sleep(500);
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            PrintStream orig = System.out;
+            System.setOut(new PrintStream(out));
+            RedisClient sub = new RedisClient("localhost", 6390, "feed", (c,m)->{});
+            sub.subscribeControl(null, msg -> System.out.println("{\"event\":\"redis_received\",\"message\":\"" + msg + "\"}"));
+            Thread.sleep(500);
+            RedisClient pub = new RedisClient("localhost", 6390, "feed", (c,m)->{});
+            pub.publishControl(null, "resume");
+            boolean logged = false;
+            for (int i=0;i<10;i++) {
+                if (out.toString().contains("\"redis_received\"")) { logged = true; break; }
+                Thread.sleep(100);
+            }
+            System.setOut(orig);
+            assertTrue(logged, "resume message not logged");
+            assertTrue(out.toString().contains("\"message\":\"resume\""));
+            sub.shutdown();
+            pub.shutdown();
+        } finally {
+            redis.destroy();
+        }
+    }
+}

--- a/test/verify-env.sh
+++ b/test/verify-env.sh
@@ -84,3 +84,10 @@ if [ "$code" -ne 200 ] || [ "$(jq -r '.status' "$tmpfile")" != "dry-run-complete
   exit 1
 fi
 rm "$tmpfile"
+
+echo "Running full test suite..."
+
+(cd api && npm test) && echo "✅ API tests passed" || exit 1
+(cd dashboard && npm test) && echo "✅ Dashboard tests passed" || exit 1
+(cd analytics && pytest) && echo "✅ Analytics tests passed" || exit 1
+(cd executor && mvn test) && echo "✅ Executor tests passed" || exit 1


### PR DESCRIPTION
## Summary
- add panic/resume loop test in executor
- verify Redis pub/sub logging in executor
- test dashboard panic resume flow
- test cold sweep dry-run endpoint
- run all package tests in verify script

## Testing
- `npm test --prefix dashboard`
- `pytest analytics`
- `./gradlew test -PtestEnv=local` *(fails: OutOfMemoryError)*


------
https://chatgpt.com/codex/tasks/task_b_6880f5fc1328832c99dd780e62de9146