### PR TITLE
fix(api): enforce safe risk control config and make panic/resume logic idempotent

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -266,12 +266,13 @@ async function apiRoutes(api, { redis, pool, panicState }) {
         }
         const paused = await getPauseState(redis);
         if (!paused) {
-          reply.code(400);
-          return { error: 'not paused' };
+          reply.code(409);
+          return { error: 'System is not paused' };
         }
         await redis.set(RESUME_FAILED_KEY, 'false');
         await setPauseState(redis, false);
         panicState.reason = null;
+        logger.info('[RESUME SIGNAL RECEIVED]');
         await redis.publish(getControlChannel(), 'resume');
 
         let ack = false;

--- a/api/routes/config.js
+++ b/api/routes/config.js
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 import { requireAdmin } from '../middleware/auth.js';
+import logger from '../services/logger.js';
+
+export const MAX_LOSS_LIMIT = 15;
+export const MIN_LATENCY_MS = 200;
+export const MAX_LATENCY_MS = 3000;
 
 export const config = {
   maxLoss: 5,
@@ -10,19 +15,38 @@ export const config = {
 export default async function configRoutes(app) {
   const schema = z
     .object({
-      maxLoss: z.number().min(0).max(25).optional(),
-      maxLatency: z.number().min(100).max(5000).optional(),
+      maxLoss: z.number().min(0).max(MAX_LOSS_LIMIT).optional(),
+      maxLatency: z
+        .number()
+        .min(MIN_LATENCY_MS)
+        .max(MAX_LATENCY_MS)
+        .optional(),
     })
     .strict();
 
   app.get('/config', async () => config);
 
   app.post('/config', { preHandler: requireAdmin }, async (req, reply) => {
+    const user = req.user?.email || 'unknown';
+    const ts = new Date().toISOString();
     const result = schema.safeParse(req.body);
+
     if (!result.success || Object.keys(result.data).length === 0) {
+      for (const [k, v] of Object.entries(req.body || {})) {
+        logger.warn(
+          `[CONFIG OVERRIDE] ts=${ts} user=${user} key=${k} value=${v} outcome=rejected`
+        );
+      }
       reply.code(400);
       return { error: 'invalid config' };
     }
+
+    for (const [k, v] of Object.entries(result.data)) {
+      logger.info(
+        `[CONFIG OVERRIDE] ts=${ts} user=${user} key=${k} value=${v} outcome=accepted`
+      );
+    }
+
     Object.assign(config, result.data);
     return { saved: true };
   });

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -1,12 +1,16 @@
 import { getControlChannel } from '../config/settings.js';
 import { sendAlert } from '../../alerts/alertAgent.js';
 import logger from '../services/logger.js';
-import { setPauseState } from '../services/pauseState.js';
+import { setPauseState, getPauseState } from '../services/pauseState.js';
 
 export default async function panicRoutes(app, { redis, panicState }) {
   app.post('/test/panic', async (req, reply) => {
     if (process.env.SANDBOX_MODE !== 'true') {
       return reply.code(403).send();
+    }
+    const alreadyPaused = await getPauseState(redis);
+    if (alreadyPaused) {
+      return { message: 'Already paused' };
     }
     const now = Date.now();
     if (now - (panicState.last || 0) < 30000) {
@@ -18,6 +22,7 @@ export default async function panicRoutes(app, { redis, panicState }) {
     panicState.last = now;
     await redis.set('panic_last_ts', String(now));
     await setPauseState(redis, true);
+    logger.warn('[PANIC TRIGGERED]');
     panicState.reason = req.body?.type || null;
     await redis.publish(getControlChannel(), 'halt');
     logger.warn(

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -3,9 +3,8 @@ import { sendAlert } from '../../alerts/alertAgent.js';
 import { getControlChannel } from '../config/settings.js';
 import fs from 'fs';
 import path from 'path';
-import { ensurePaused } from '../middleware/validate.js';
 import logger from '../services/logger.js';
-import { setPauseState, RESUME_ACK_KEY, RESUME_FAILED_KEY } from '../services/pauseState.js';
+import { getPauseState, setPauseState, RESUME_ACK_KEY, RESUME_FAILED_KEY } from '../services/pauseState.js';
 import { resumeCounter } from './metrics.js';
 
 export default async function resumeRoutes(app, opts) {
@@ -28,9 +27,16 @@ export default async function resumeRoutes(app, opts) {
 
   app.post(
     '/resume',
-    { preHandler: [requireAdmin, ensurePaused(redis)] },
+    { preHandler: requireAdmin },
     async (req, reply) => {
     const user = req.user?.email || 'unknown';
+
+    const paused = await getPauseState(redis);
+    if (!paused) {
+      logAttempt('resume_not_paused', user);
+      reply.code(409);
+      return { error: 'System is not paused' };
+    }
 
     const health = await app.inject({ method: 'GET', url: '/api/system/health' });
     let healthy = false;
@@ -59,6 +65,7 @@ export default async function resumeRoutes(app, opts) {
     await redis.set(RESUME_FAILED_KEY, 'false');
     await redis.publish(channel, 'resume');
     await setPauseState(redis, false);
+    logger.info('[RESUME SIGNAL RECEIVED]');
     panicState.reason = null;
 
     let ack = false;

--- a/api/tests/config.test.ts
+++ b/api/tests/config.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
+
+let buildApp: any;
+let app: any;
+let cookie: string;
+
+beforeAll(async () => {
+  ({ buildApp } = await import('../index.js'));
+  app = await buildApp();
+  await app.listen({ port: 0 });
+  const login = await request(app.server)
+    .post('/api/login')
+    .send({ email: 'user', password: 'pass' });
+  cookie = login.headers['set-cookie'][0].split(';')[0];
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+test('rejects invalid config values', async () => {
+  const res1 = await request(app.server)
+    .post('/api/config')
+    .set('Cookie', cookie)
+    .send({ maxLoss: 20 });
+  expect(res1.statusCode).toBe(400);
+
+  const res2 = await request(app.server)
+    .post('/api/config')
+    .set('Cookie', cookie)
+    .send({ maxLatency: 100 });
+  expect(res2.statusCode).toBe(400);
+
+  const res3 = await request(app.server)
+    .post('/api/config')
+    .set('Cookie', cookie)
+    .send({ maxLatency: 5000 });
+  expect(res3.statusCode).toBe(400);
+});
+
+ test('accepts valid config values', async () => {
+  const res = await request(app.server)
+    .post('/api/config')
+    .set('Cookie', cookie)
+    .send({ maxLoss: 10, maxLatency: 500 });
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ saved: true });
+});
+

--- a/api/tests/panic.test.ts
+++ b/api/tests/panic.test.ts
@@ -1,0 +1,27 @@
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
+
+let buildApp: any;
+let app: any;
+
+beforeAll(async () => {
+  ({ buildApp } = await import('../index.js'));
+  app = await buildApp();
+  await app.listen({ port: 0 });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+test('panic endpoint idempotency', async () => {
+  const first = await request(app.server).post('/api/test/panic');
+  expect(first.statusCode).toBe(200);
+  const second = await request(app.server).post('/api/test/panic');
+  expect(second.statusCode).toBe(200);
+  expect(second.body.message).toBe('Already paused');
+});
+

--- a/api/tests/resume.test.ts
+++ b/api/tests/resume.test.ts
@@ -1,0 +1,32 @@
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
+
+let buildApp: any;
+let app: any;
+
+beforeAll(async () => {
+  ({ buildApp } = await import('../index.js'));
+  app = await buildApp();
+  await app.listen({ port: 0 });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+test('resume endpoint idempotency', async () => {
+  // not paused initially
+  const res1 = await request(app.server).post('/api/test/resume');
+  expect(res1.statusCode).toBe(409);
+
+  await request(app.server).post('/api/test/panic');
+  const res2 = await request(app.server).post('/api/test/resume');
+  expect(res2.statusCode).toBe(200);
+
+  const res3 = await request(app.server).post('/api/test/resume');
+  expect(res3.statusCode).toBe(409);
+});
+


### PR DESCRIPTION
## Summary
- enforce stricter config validation and log overrides
- log panic/resume behaviour and make them idempotent
- test that invalid config is rejected and panic/resume endpoints behave idempotently

## Testing
- `npm test` *(fails: Cannot find module 'winston', test suites failing)*

------
https://chatgpt.com/codex/tasks/task_b_688105bb8510832c9fa2853188919734