### PR TITLE
Setup Helm version snapshots and rollback script

### DIFF
--- a/infra/helm/Chart.yaml
+++ b/infra/helm/Chart.yaml
@@ -1,3 +1,3 @@
 name: crypto-arbitrage
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.1.0
+appVersion: 1.1.0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# deploy.sh - Deploy Helm release with snapshotting
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHART_DIR="$ROOT_DIR/infra/helm"
+
+# Extract version from Chart.yaml
+VERSION=$(grep '^version:' "$CHART_DIR/Chart.yaml" | awk '{print $2}')
+SNAPSHOT_DIR="/ops/snapshots/prism-prod-$VERSION"
+
+mkdir -p "$SNAPSHOT_DIR"
+
+# Capture current commit from main branch
+git -C "$ROOT_DIR" rev-parse HEAD > "$SNAPSHOT_DIR/commit.txt"
+
+# Copy active values.yaml
+cp "$CHART_DIR/values.yaml" "$SNAPSHOT_DIR/values.yaml"
+
+# Record release notes
+if [ -n "${RELEASE_NOTES:-}" ]; then
+  echo "$RELEASE_NOTES" > "$SNAPSHOT_DIR/notes.md"
+else
+  read -rp "Enter release notes: " NOTES
+  echo "$NOTES" > "$SNAPSHOT_DIR/notes.md"
+fi
+
+cd "$CHART_DIR"
+helm upgrade --install prism-prod . --namespace default
+
+helm history prism-prod
+
+echo "To rollback: helm rollback prism-prod <REVISION>"


### PR DESCRIPTION
## Summary
- bump Helm chart version
- add deploy script to capture release snapshots and enforce naming

## Testing
- `bash test/verify-env.sh`

------
https://chatgpt.com/codex/tasks/task_b_688106608d74832c9a4a3024908f0b8b