### PR TITLE
feat(logging): persist logs to host path and add audit trail for panic and config changes

### DIFF
--- a/api/routes/config.js
+++ b/api/routes/config.js
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { requireAdmin } from '../middleware/auth.js';
+import logger from '../services/logger.js';
 
 export const config = {
   maxLoss: 5,
@@ -19,11 +20,18 @@ export default async function configRoutes(app) {
 
   app.post('/config', { preHandler: requireAdmin }, async (req, reply) => {
     const result = schema.safeParse(req.body);
+    const email = req.user?.email || 'unknown';
     if (!result.success || Object.keys(result.data).length === 0) {
+      logger.info(
+        `[AUDIT] ${email} attempted override: ${JSON.stringify(req.body)} \u2013 rejected`
+      );
       reply.code(400);
       return { error: 'invalid config' };
     }
     Object.assign(config, result.data);
+    logger.info(
+      `[AUDIT] ${email} attempted override: ${JSON.stringify(result.data)} \u2013 accepted`
+    );
     return { saved: true };
   });
 }

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -20,13 +20,10 @@ export default async function panicRoutes(app, { redis, panicState }) {
     await setPauseState(redis, true);
     panicState.reason = req.body?.type || null;
     await redis.publish(getControlChannel(), 'halt');
+    const ts = new Date().toISOString();
     logger.warn(
-      JSON.stringify({
-        event: 'panic',
-        reason: panicState.reason || 'manual',
-        value: req.body?.value || 0,
-        ts: new Date().toISOString(),
-      })
+      `[AUDIT] panic triggered by ${req.user?.email || 'unknown'} ` +
+        `${JSON.stringify({ reason: panicState.reason || 'manual', value: req.body?.value || 0 })} at ${ts}`
     );
     try {
       await sendAlert('email', 'Panic brake triggered (test mode)', 'panic');

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -10,7 +10,7 @@ import { resumeCounter } from './metrics.js';
 
 export default async function resumeRoutes(app, opts) {
   const { redis, panicState } = opts;
-  const logDir = process.env.LOG_DIR || '/var/log/prism-arbitrage';
+  const logDir = process.env.LOG_DIR || '/var/log/prism';
   const resumeLog = path.join(logDir, 'resume.log');
   if (!fs.existsSync(logDir)) {
     fs.mkdirSync(logDir, { recursive: true });
@@ -47,11 +47,17 @@ export default async function resumeRoutes(app, opts) {
     const confirm = req.query.confirm === 'true';
     if (!confirm && (panicState.reason === 'loss' || panicState.reason === 'latency')) {
       logAttempt('resume_needs_override', user, { reason: panicState.reason });
+      logger.info(
+        `[AUDIT] ${user} attempted override: ${JSON.stringify({ confirm: false, reason: panicState.reason })} \u2013 rejected`
+      );
       reply.code(403);
       return { override_required: true };
     }
 
     if (confirm) {
+      logger.info(
+        `[AUDIT] ${user} attempted override: ${JSON.stringify({ confirm: true, reason: panicState.reason })} \u2013 accepted`
+      );
       await redis.set('resume_confirmed', 'true', 'EX', 60);
     }
 
@@ -90,9 +96,8 @@ export default async function resumeRoutes(app, opts) {
     }
     logAttempt('resume_success', user);
     resumeCounter.inc();
-    logger.info(
-      JSON.stringify({ event: 'resume', ts: new Date().toISOString() })
-    );
+    const ts = new Date().toISOString();
+    logger.info(`[AUDIT] ${user} resumed trading at ${ts}`);
     return { resumed: true };
   }
   );

--- a/api/services/logger.js
+++ b/api/services/logger.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import winston from 'winston';
 import createLogger from '../../lib/logger.js';
 
-const logDir = process.env.LOG_DIR || '/var/log/prism-arbitrage';
+const logDir = process.env.LOG_DIR || '/var/log/prism';
 if (!fs.existsSync(logDir)) {
   fs.mkdirSync(logDir, { recursive: true });
 }
@@ -23,6 +23,7 @@ class HttpTransport extends winston.Transport {
 
 const logger = createLogger(service);
 logger.add(new winston.transports.File({ filename: `${logDir}/${service}.log` }));
+// TODO: implement log rotation for logs in logDir
 const forwardUrl = process.env.LOKI_URL || process.env.LOG_FORWARD_URL;
 if (forwardUrl) {
   logger.add(new HttpTransport({ url: forwardUrl }));

--- a/executor/src/main/java/ResumeController.java
+++ b/executor/src/main/java/ResumeController.java
@@ -48,7 +48,8 @@ public class ResumeController {
         this.executor = executor;
         this.checker = checker == null ? new SystemHealthChecker() : checker;
         this.redis = redis;
-        String dir = System.getenv().getOrDefault("LOG_DIR", "/var/log/prism-arbitrage");
+        String dir = System.getenv().getOrDefault("LOG_DIR", "/var/log/prism");
+        // TODO: implement log rotation for files in this directory
         this.resumeLog = java.nio.file.Paths.get(dir, "resume.log");
     }
 

--- a/infra/helm/templates/api-deployment.yaml
+++ b/infra/helm/templates/api-deployment.yaml
@@ -26,8 +26,8 @@ spec:
             - secretRef:
                 name: api-secrets
           volumeMounts:
-            - name: prism-logs
-              mountPath: /var/log/prism-arbitrage
+            - name: logs
+              mountPath: /var/log/prism
           readinessProbe:
             httpGet:
               path: /health
@@ -41,10 +41,9 @@ spec:
             failureThreshold: 3
             periodSeconds: 10
       volumes:
-        - name: prism-logs
+        - name: logs
           hostPath:
             path: /var/log/prism-arbitrage
-            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/infra/helm/templates/executor-deployment.yaml
+++ b/infra/helm/templates/executor-deployment.yaml
@@ -26,8 +26,8 @@ spec:
             - secretRef:
                 name: prod-secrets
           volumeMounts:
-            - name: prism-logs
-              mountPath: /var/log/prism-arbitrage
+            - name: logs
+              mountPath: /var/log/prism
           readinessProbe:
             exec:
               command: ["pgrep", "-f", "Executor"]
@@ -39,7 +39,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
       volumes:
-        - name: prism-logs
+        - name: logs
           hostPath:
             path: /var/log/prism-arbitrage
-            type: DirectoryOrCreate


### PR DESCRIPTION
## Summary
- update log directory mounting for api & executor deployments
- add audit trail logging in config, panic, and resume routes
- use /var/log/prism for persistent log files
- tweak executor resume controller log path
- add TODO note for log rotation

## Testing
- `npm test` *(fails: cannot find module 'winston')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `./gradlew test` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_6881069404dc832c9b811d252c946a99