### PR TITLE
feat: expose panic metric and grafana charts

### DIFF
--- a/api/__tests__/metrics.mode.test.js
+++ b/api/__tests__/metrics.mode.test.js
@@ -34,5 +34,6 @@ describeLocal('mode specific metrics endpoints', () => {
     const res = await request(app.server).get('/api/metrics');
     expect(res.statusCode).toBe(200);
     expect(res.text).toMatch(/panic_state/);
+    expect(res.text).toMatch(/system_paused\{source="api"\}/);
   });
 });

--- a/api/routes/metrics.js
+++ b/api/routes/metrics.js
@@ -10,9 +10,14 @@ const PROM_SANDBOX_URL = process.env.PROM_SANDBOX_URL || 'http://prometheus-sand
 import { getPauseState } from '../services/pauseState.js';
 
 const panicGauge = new Gauge({ name: 'panic_state', help: '1 if paused, 0 otherwise' });
+const systemPausedGauge = new Gauge({
+  name: 'system_paused',
+  help: 'Trading paused status',
+  labelNames: ['source'],
+});
 const resumeCounter = new Counter({ name: 'resume_event_total', help: 'Total resume events' });
 
-export { panicGauge, resumeCounter };
+export { panicGauge, resumeCounter, systemPausedGauge };
 
 export default async function metricsRoutes(app, { redis } = {}) {
   const seeded = {
@@ -63,6 +68,7 @@ export default async function metricsRoutes(app, { redis } = {}) {
   app.get('/metrics', async (_req, reply) => {
     const paused = await getPauseState(redis);
     panicGauge.set(paused ? 1 : 0);
+    systemPausedGauge.set({ source: 'api' }, paused ? 1 : 0);
     reply.header('Content-Type', register.contentType);
     reply.send(await register.metrics());
   });

--- a/executor/src/main/java/MetricsServer.java
+++ b/executor/src/main/java/MetricsServer.java
@@ -18,8 +18,14 @@ public class MetricsServer {
     public void start(int port) throws IOException {
         server = HttpServer.create(new InetSocketAddress(port), 0);
         server.createContext("/metrics", exchange -> {
-            String resp = "spread_evaluation_latency_ms " + executor.getCurrentLatencyMs() + "\n";
-            byte[] data = resp.getBytes(StandardCharsets.UTF_8);
+            StringBuilder resp = new StringBuilder();
+            resp.append("spread_evaluation_latency_ms ")
+                .append(executor.getCurrentLatencyMs())
+                .append("\n");
+            resp.append("system_paused{source=\"executor\"} ")
+                .append(executor.isPanicActive() ? 1 : 0)
+                .append("\n");
+            byte[] data = resp.toString().getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, data.length);
             try (OutputStream os = exchange.getResponseBody()) {
                 os.write(data);

--- a/infra/grafana/prism-dashboard.json
+++ b/infra/grafana/prism-dashboard.json
@@ -3,6 +3,13 @@
   "panels": [
     {
       "type": "graph",
+      "title": "Trading Status",
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "system_paused{source=\"api\"}" }],
+      "options": {"steppedLine": true}
+    },
+    {
+      "type": "graph",
       "title": "Panic State",
       "datasource": "Prometheus",
       "targets": [{ "expr": "panic_state" }],
@@ -25,6 +32,18 @@
       "title": "Win Rate %",
       "datasource": "Prometheus",
       "targets": [{ "expr": "win_rate_pct" }]
+    },
+    {
+      "type": "graph",
+      "title": "Pod Memory Usage",
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "container_memory_usage_bytes{pod=~\".+\"}" }]
+    },
+    {
+      "type": "graph",
+      "title": "Pod CPU Usage",
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "container_cpu_usage_seconds_total{pod=~\".+\"}" }]
     }
   ],
   "schemaVersion": 36,

--- a/infra/helm/templates/api-deployment.yaml
+++ b/infra/helm/templates/api-deployment.yaml
@@ -52,6 +52,10 @@ metadata:
   name: api
   labels:
     app: api
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+    prometheus.io/path: "/api/metrics"
 spec:
   type: ClusterIP
   selector:

--- a/infra/helm/templates/grafana-dashboard.yaml
+++ b/infra/helm/templates/grafana-dashboard.yaml
@@ -11,6 +11,13 @@ data:
       "panels": [
         {
           "type": "graph",
+          "title": "Trading Status",
+          "datasource": "Prometheus",
+          "targets": [{ "expr": "system_paused{source=\"api\"}" }],
+          "options": {"steppedLine": true}
+        },
+        {
+          "type": "graph",
           "title": "Panic State",
           "datasource": "Prometheus",
           "targets": [{ "expr": "panic_state" }],
@@ -33,6 +40,18 @@ data:
           "title": "Win Rate %",
           "datasource": "Prometheus",
           "targets": [{ "expr": "win_rate_pct" }]
+        },
+        {
+          "type": "graph",
+          "title": "Pod Memory Usage",
+          "datasource": "Prometheus",
+          "targets": [{ "expr": "container_memory_usage_bytes{pod=~\".+\"}" }]
+        },
+        {
+          "type": "graph",
+          "title": "Pod CPU Usage",
+          "datasource": "Prometheus",
+          "targets": [{ "expr": "container_cpu_usage_seconds_total{pod=~\".+\"}" }]
         }
       ],
       "schemaVersion": 36,


### PR DESCRIPTION
## Summary
- add `system_paused` metric in API and executor
- expose metrics at `/api/metrics` via Prometheus annotations
- visualize pause status and pod resource usage in Grafana dashboard
- update tests

## Testing
- `npm test` *(fails: nvidia-smi not found and several test failures)*
- `./gradlew test` *(fails: tests failed due to missing services)*

------
https://chatgpt.com/codex/tasks/task_b_6881071dfa14832c8835a4e84e45921f