### PR TITLE
Improve alerting system

### DIFF
--- a/alerts/emailAlert.js
+++ b/alerts/emailAlert.js
@@ -6,6 +6,12 @@ const pass = process.env.SMTP_PASS;
 const recipient = process.env.ALERT_RECIPIENT;
 const host = process.env.SMTP_HOST || 'smtp.gmail.com';
 
+if (user && pass) {
+  logger.info('[SMTP] credentials loaded from environment');
+} else {
+  logger.warn('[SMTP] credentials missing');
+}
+
 logger.info(`Using SMTP host: ${host}`);
 
 const transporter = nodemailer.createTransport({

--- a/api/index.js
+++ b/api/index.js
@@ -273,6 +273,13 @@ async function apiRoutes(api, { redis, pool, panicState }) {
         await setPauseState(redis, false);
         panicState.reason = null;
         await redis.publish(getControlChannel(), 'resume');
+        try {
+          await sendEmail('Resumed trading', 'Trading resumed after panic');
+          logger.info('Resume alert email sent');
+        } catch (err) {
+          logger.warn(`Resume alert email failed: ${err.message}`);
+        }
+        await redis.publish('control-feed', 'resume');
 
         let ack = false;
         const start = Date.now();

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -1,5 +1,5 @@
 import { getControlChannel } from '../config/settings.js';
-import { sendAlert } from '../../alerts/alertAgent.js';
+import { sendEmail } from '../../alerts/emailAlert.js';
 import logger from '../services/logger.js';
 import { setPauseState } from '../services/pauseState.js';
 
@@ -29,10 +29,12 @@ export default async function panicRoutes(app, { redis, panicState }) {
       })
     );
     try {
-      await sendAlert('email', 'Panic brake triggered (test mode)', 'panic');
+      await sendEmail('Panic brake triggered (test mode)', 'Trading halted due to panic');
+      logger.info('Panic alert email sent');
     } catch (err) {
-      logger.error('[ALERT FAILURE] Panic alert email failed to send: missing SMTP config');
+      logger.warn(`Panic alert email failed: ${err.message}`);
     }
+    await redis.publish('control-feed', 'panic');
     return { paused: true, source: 'manual' };
   });
 }

--- a/api/tests/panic.test.ts
+++ b/api/tests/panic.test.ts
@@ -1,0 +1,43 @@
+import Fastify from 'fastify';
+import { jest } from '@jest/globals';
+
+import panicRoutes from '../routes/panic.js';
+import logger from '../services/logger.js';
+import { sendEmail } from '../../alerts/emailAlert.js';
+
+jest.mock('../../alerts/emailAlert.js', () => ({
+  sendEmail: jest.fn(),
+}));
+
+describe('panic route alerting', () => {
+  const publishSpy = jest.fn();
+  const redis = {
+    publish: publishSpy,
+    set: jest.fn(),
+    get: jest.fn(),
+  } as any;
+  const panicState = { reason: null, last: 0 } as any;
+  let app: any;
+
+  beforeAll(async () => {
+    process.env.SANDBOX_MODE = 'true';
+    app = Fastify();
+    await panicRoutes(app, { redis, panicState });
+    await app.ready();
+  });
+
+  test('publishes panic and sends email', async () => {
+    await app.inject({ method: 'POST', url: '/test/panic' });
+    expect(publishSpy).toHaveBeenCalledWith('control-feed', 'panic');
+    expect((sendEmail as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  test('logs warn when email fails', async () => {
+    (sendEmail as jest.Mock).mockRejectedValueOnce(new Error('smtp fail'));
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    await app.inject({ method: 'POST', url: '/test/panic' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('smtp fail'));
+    warnSpy.mockRestore();
+  });
+});
+

--- a/api/tests/resume.test.ts
+++ b/api/tests/resume.test.ts
@@ -1,0 +1,48 @@
+import Fastify from 'fastify';
+import { jest } from '@jest/globals';
+
+import logger from '../services/logger.js';
+import { sendEmail } from '../../alerts/emailAlert.js';
+import { getControlChannel } from '../config/settings.js';
+import { setPauseState } from '../services/pauseState.js';
+
+jest.mock('../../alerts/emailAlert.js', () => ({
+  sendEmail: jest.fn(),
+}));
+
+describe('resume route alerting', () => {
+  const publishSpy = jest.fn();
+  const redis = {
+    publish: publishSpy,
+    set: jest.fn(),
+    get: jest.fn(),
+  } as any;
+  const panicState = { reason: 'loss' } as any;
+  let app: any;
+
+  beforeAll(async () => {
+    process.env.SANDBOX_MODE = 'true';
+    app = Fastify();
+    app.post('/test/resume', async (_req, reply) => {
+      await setPauseState(redis, false);
+      panicState.reason = null;
+      await redis.publish(getControlChannel(), 'resume');
+      try {
+        await sendEmail('Resumed trading', 'Trading resumed after panic');
+        logger.info('Resume alert email sent');
+      } catch (err: any) {
+        logger.warn(`Resume alert email failed: ${err.message}`);
+      }
+      await redis.publish('control-feed', 'resume');
+      return { paused: false };
+    });
+    await app.ready();
+  });
+
+  test('publishes resume and sends email', async () => {
+    await app.inject({ method: 'POST', url: '/test/resume' });
+    expect(publishSpy).toHaveBeenCalledWith('control-feed', 'resume');
+    expect((sendEmail as jest.Mock).mock.calls.length).toBe(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- log SMTP credentials status on startup
- send Redis and email alerts for panic/resume actions
- handle email failures with `logger.warn`
- test panic/resume alert routes

## Testing
- `npm --prefix api test` *(fails: many suites fail)*

------
https://chatgpt.com/codex/tasks/task_b_68810600b00c832cacf69867103fc508