### PR TITLE
test(api): add unit tests for risk override limits and panic/resume state handling

### DIFF
--- a/api/test/config.test.ts
+++ b/api/test/config.test.ts
@@ -1,0 +1,63 @@
+import request from 'supertest';
+import { jest } from '@jest/globals';
+import logger from '../services/logger.js';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
+
+let buildApp: any;
+let app: any;
+let cookie: string;
+let infoSpy: jest.SpiedFunction<typeof logger.info>;
+let warnSpy: jest.SpiedFunction<typeof logger.warn>;
+
+beforeAll(async () => {
+  infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+  warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  ({ buildApp } = await import('../index.js'));
+  app = await buildApp();
+  await app.listen({ port: 0 });
+  const login = await request(app.server)
+    .post('/api/login')
+    .send({ email: 'user', password: 'pass' });
+  cookie = login.headers['set-cookie'][0].split(';')[0];
+});
+
+afterAll(async () => {
+  await app.close();
+  infoSpy.mockRestore();
+  warnSpy.mockRestore();
+});
+
+beforeEach(() => {
+  infoSpy.mockClear();
+  warnSpy.mockClear();
+});
+
+test('accepts safe MAX_LOSS_PCT', async () => {
+  const res = await request(app.server)
+    .patch('/api/settings')
+    .set('Cookie', cookie)
+    .send({ maxLossPct: 10 });
+  expect(res.statusCode).toBe(200);
+  expect(infoSpy).not.toHaveBeenCalled();
+  expect(warnSpy).not.toHaveBeenCalled();
+});
+
+test('rejects unsafe MAX_LOSS_PCT', async () => {
+  const res = await request(app.server)
+    .patch('/api/settings')
+    .set('Cookie', cookie)
+    .send({ maxLossPct: 99 });
+  expect(res.statusCode).toBe(400);
+  expect(warnSpy).toHaveBeenCalled();
+});
+
+test('writes override log', async () => {
+  await request(app.server)
+    .patch('/api/settings')
+    .set('Cookie', cookie)
+    .send({ maxLossPct: 10 });
+  expect(warnSpy).not.toHaveBeenCalled();
+});

--- a/api/test/panic.test.ts
+++ b/api/test/panic.test.ts
@@ -1,0 +1,62 @@
+import request from 'supertest';
+import { jest } from '@jest/globals';
+import logger from '../services/logger.js';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
+
+let buildApp: any;
+let app: any;
+let infoSpy: jest.SpiedFunction<typeof logger.info>;
+let warnSpy: jest.SpiedFunction<typeof logger.warn>;
+let cookie: string;
+
+beforeAll(async () => {
+  infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+  warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  ({ buildApp } = await import('../index.js'));
+  app = await buildApp();
+  await app.listen({ port: 0 });
+  const login = await request(app.server)
+    .post('/api/login')
+    .send({ email: 'user', password: 'pass' });
+  cookie = login.headers['set-cookie'][0].split(';')[0];
+});
+
+afterAll(async () => {
+  await app.close();
+  infoSpy.mockRestore();
+  warnSpy.mockRestore();
+});
+
+beforeEach(() => {
+  infoSpy.mockClear();
+  warnSpy.mockClear();
+});
+
+test('panic endpoint sets paused state', async () => {
+  const res = await request(app.server).post('/api/test/panic');
+  expect(res.statusCode).toBe(200);
+  expect(res.body.paused).toBe(true);
+  const status = await request(app.server)
+    .get('/api/system/status')
+    .set('Cookie', cookie);
+  expect(status.body.paused).toBe(true);
+  expect(warnSpy).toHaveBeenCalled();
+});
+
+test('second panic call is ignored', async () => {
+  await request(app.server).post('/api/test/panic');
+  const res = await request(app.server).post('/api/test/panic');
+  expect(res.body.ignored).toBe(true);
+  expect(infoSpy).toHaveBeenCalled();
+});
+
+test('redis flag set to true', async () => {
+  await request(app.server).post('/api/test/panic');
+  const status = await request(app.server)
+    .get('/api/system/status')
+    .set('Cookie', cookie);
+  expect(status.body.paused).toBe(true);
+});

--- a/api/test/resume.test.ts
+++ b/api/test/resume.test.ts
@@ -1,0 +1,59 @@
+import request from 'supertest';
+import { jest } from '@jest/globals';
+import logger from '../services/logger.js';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
+
+jest.setTimeout(10000);
+
+let buildApp: any;
+let app: any;
+let infoSpy: jest.SpiedFunction<typeof logger.info>;
+let cookie: string;
+
+beforeAll(async () => {
+  infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+  ({ buildApp } = await import('../index.js'));
+  app = await buildApp();
+  await app.listen({ port: 0 });
+  const login = await request(app.server)
+    .post('/api/login')
+    .send({ email: 'user', password: 'pass' });
+  cookie = login.headers['set-cookie'][0].split(';')[0];
+});
+
+afterAll(async () => {
+  await app.close();
+  infoSpy.mockRestore();
+});
+
+beforeEach(() => {
+  infoSpy.mockClear();
+});
+
+test('resume only works when paused', async () => {
+  await request(app.server).post('/api/test/panic');
+  const res = await request(app.server).post('/api/test/resume');
+  expect(res.statusCode).toBe(200);
+  const status = await request(app.server)
+    .get('/api/system/status')
+    .set('Cookie', cookie);
+  expect(status.body.paused).toBe(false);
+  expect(infoSpy).toHaveBeenCalled();
+});
+
+test('resume fails when not paused', async () => {
+  const res = await request(app.server).post('/api/test/resume');
+  expect(res.statusCode).toBe(400);
+});
+
+test('resume clears redis flag', async () => {
+  await request(app.server).post('/api/test/panic');
+  await request(app.server).post('/api/test/resume');
+  const status = await request(app.server)
+    .get('/api/system/status')
+    .set('Cookie', cookie);
+  expect(status.body.paused).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add config override tests to ensure limits and logging
- cover panic endpoint debounce and Redis pause state
- verify resume endpoint behavior and state toggling

## Testing
- `TEST_ENV=ci npm test`

------
https://chatgpt.com/codex/tasks/task_b_688106b5b5c8832c8324ad39bed5dcd4