### PR TITLE
Add alert logs for panic/resume

### DIFF
--- a/alerts/emailAlert.js
+++ b/alerts/emailAlert.js
@@ -7,6 +7,11 @@ const recipient = process.env.ALERT_RECIPIENT;
 const host = process.env.SMTP_HOST || 'smtp.gmail.com';
 
 logger.info(`Using SMTP host: ${host}`);
+if (user && pass) {
+  logger.info('SMTP credentials loaded');
+} else {
+  logger.warn('SMTP credentials missing');
+}
 
 const transporter = nodemailer.createTransport({
   host,

--- a/api/__tests__/panic.resume.alerts.test.js
+++ b/api/__tests__/panic.resume.alerts.test.js
@@ -1,0 +1,58 @@
+import { jest } from '@jest/globals';
+import Fastify from 'fastify';
+import panicRoutes from '../routes/panic.js';
+import resumeRoutes from '../routes/resume.js';
+import { getControlChannel } from '../config/settings.js';
+import { sendAlert } from '../../alerts/alertAgent.js';
+
+jest.mock('../../alerts/alertAgent.js', () => ({
+  sendAlert: jest.fn(async () => {})
+}));
+
+const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SANDBOX_MODE = 'true';
+
+function createRedis(initialPaused = 'false') {
+  const store = { 'arb:paused_state': initialPaused };
+  return {
+    publish: jest.fn(async () => 1),
+    get: jest.fn(async key => store[key]),
+    set: jest.fn(async (key, val) => { store[key] = val; return 'OK'; }),
+    del: jest.fn(async key => { delete store[key]; return 1; })
+  };
+}
+
+describeLocal('panic and resume alerts', () => {
+  test('panic publishes halt and sends email', async () => {
+    const redis = createRedis('false');
+    const app = Fastify();
+    await app.register(panicRoutes, { redis, panicState: {} });
+    await app.listen({ port: 0 });
+
+    await app.inject({ method: 'POST', url: '/test/panic', payload: { type: 'loss' } });
+
+    expect(redis.publish).toHaveBeenCalledWith(getControlChannel(), 'halt');
+    expect(sendAlert).toHaveBeenCalledWith('email', expect.any(String), 'panic');
+    await app.close();
+  });
+
+  test('resume publishes resume notice and sends email', async () => {
+    const redis = createRedis('true');
+    const panicState = { reason: null };
+    const app = Fastify();
+    app.get('/api/system/health', async () => ({ healthy: true }));
+    await app.register(resumeRoutes, { redis, panicState });
+    await app.listen({ port: 0 });
+
+    await app.inject({ method: 'POST', url: '/resume' });
+
+    const channel = getControlChannel();
+    expect(redis.publish).toHaveBeenCalledWith(channel, 'resume');
+    expect(redis.publish).toHaveBeenCalledWith(channel, expect.stringContaining('Trading resumed'));
+    expect(sendAlert).toHaveBeenCalledWith('email', expect.stringContaining('Trading resumed'), 'resume');
+    await app.close();
+  });
+});
+

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -24,7 +24,12 @@ export default async function panicRoutes(app, { redis, panicState }) {
     await setPauseState(redis, true);
     logger.warn('[PANIC TRIGGERED]');
     panicState.reason = req.body?.type || null;
-    await redis.publish(getControlChannel(), 'halt');
+    try {
+      await redis.publish(getControlChannel(), 'halt');
+      logger.info('Published panic halt to control-feed');
+    } catch (err) {
+      logger.error('Failed to publish panic halt', err);
+    }
     logger.warn(
       JSON.stringify({
         event: 'panic',
@@ -35,8 +40,9 @@ export default async function panicRoutes(app, { redis, panicState }) {
     );
     try {
       await sendAlert('email', 'Panic brake triggered (test mode)', 'panic');
+      logger.info('Panic email alert sent');
     } catch (err) {
-      logger.error('[ALERT FAILURE] Panic alert email failed to send: missing SMTP config');
+      logger.error(`[ALERT FAILURE] Panic alert email failed to send: ${err.message}`);
     }
     return { paused: true, source: 'manual' };
   });

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -86,11 +86,18 @@ export default async function resumeRoutes(app, opts) {
     }
     const msg = `Trading resumed by ${user} at ${new Date().toISOString()}`;
     await redis.publish('alerts', msg);
+    try {
+      await redis.publish(channel, msg);
+      logger.info('Published resume notice to control-feed');
+    } catch (err) {
+      logger.warn('Failed to publish resume notice', err);
+    }
     if (process.env.SANDBOX_MODE !== 'true') {
       try {
         await sendAlert('email', msg, 'resume');
+        req.log.info('Resume email alert sent');
       } catch (err) {
-        req.log.error('Resume alert failed', err);
+        req.log.warn('Resume alert failed', err);
       }
     } else {
       req.log.info(`[DRY-RUN] Resume alert: ${msg}`);


### PR DESCRIPTION
## Summary
- log presence of SMTP credentials on startup
- publish to control-feed with logging from panic and resume
- warn on resume alert failure
- test panic/resume alert behaviour

## Testing
- `bash test/run-local.sh` *(fails: helm not found)*

------
https://chatgpt.com/codex/tasks/task_b_688109ecef00832c9c2d6f56f8f8c307