### PR TITLE
Add audit logging and update log paths

### DIFF
--- a/analytics/logger.py
+++ b/analytics/logger.py
@@ -4,7 +4,8 @@ import os
 import urllib.parse
 
 level = os.getenv("LOG_LEVEL", "INFO").upper()
-log_dir = os.getenv("LOG_DIR", "/var/log/prism-arbitrage")
+log_dir = os.getenv("LOG_DIR", "/var/log/prism")
+# NOTE: logs in this directory may be rotated via logrotate in the future
 os.makedirs(log_dir, exist_ok=True)
 handlers = [
     logging.StreamHandler(),

--- a/api/routes/config.js
+++ b/api/routes/config.js
@@ -33,7 +33,7 @@ export default async function configRoutes(app) {
 
     if (!result.success || Object.keys(result.data).length === 0) {
       for (const [k, v] of Object.entries(req.body || {})) {
-        logger.warn(
+        logger.audit(
           `[CONFIG OVERRIDE] ts=${ts} user=${user} key=${k} value=${v} outcome=rejected`
         );
       }
@@ -42,7 +42,7 @@ export default async function configRoutes(app) {
     }
 
     for (const [k, v] of Object.entries(result.data)) {
-      logger.info(
+      logger.audit(
         `[CONFIG OVERRIDE] ts=${ts} user=${user} key=${k} value=${v} outcome=accepted`
       );
     }

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -19,10 +19,14 @@ export default async function panicRoutes(app, { redis, panicState }) {
       );
       return { paused: true, ignored: true };
     }
+    const user = req.user?.email || 'unknown';
     panicState.last = now;
     await redis.set('panic_last_ts', String(now));
     await setPauseState(redis, true);
     logger.warn('[PANIC TRIGGERED]');
+    logger.audit(
+      `[PANIC] ts=${new Date().toISOString()} user=${user} reason=${req.body?.type || 'manual'}`
+    );
     panicState.reason = req.body?.type || null;
     await redis.publish(getControlChannel(), 'halt');
     logger.warn(

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -9,7 +9,8 @@ import { resumeCounter } from './metrics.js';
 
 export default async function resumeRoutes(app, opts) {
   const { redis, panicState } = opts;
-  const logDir = process.env.LOG_DIR || '/var/log/prism-arbitrage';
+  const logDir = process.env.LOG_DIR || '/var/log/prism';
+  // log rotation will be managed externally
   const resumeLog = path.join(logDir, 'resume.log');
   if (!fs.existsSync(logDir)) {
     fs.mkdirSync(logDir, { recursive: true });
@@ -23,6 +24,7 @@ export default async function resumeRoutes(app, opts) {
       ...extra,
     };
     fs.appendFile(resumeLog, JSON.stringify(entry) + '\n', () => {});
+    logger.audit(`[RESUME] ${event} user=${operator} ${JSON.stringify(extra)}`);
   }
 
   app.post(
@@ -58,6 +60,7 @@ export default async function resumeRoutes(app, opts) {
     }
 
     if (confirm) {
+      logAttempt('resume_override_attempt', user, { reason: panicState.reason });
       await redis.set('resume_confirmed', 'true', 'EX', 60);
     }
 

--- a/api/services/logger.js
+++ b/api/services/logger.js
@@ -3,7 +3,8 @@ import axios from 'axios';
 import winston from 'winston';
 import createLogger from '../../lib/logger.js';
 
-const logDir = process.env.LOG_DIR || '/var/log/prism-arbitrage';
+const logDir = process.env.LOG_DIR || '/var/log/prism';
+// TODO: configure external log rotation
 if (!fs.existsSync(logDir)) {
   fs.mkdirSync(logDir, { recursive: true });
 }

--- a/executor/src/main/java/ResumeController.java
+++ b/executor/src/main/java/ResumeController.java
@@ -48,7 +48,8 @@ public class ResumeController {
         this.executor = executor;
         this.checker = checker == null ? new SystemHealthChecker() : checker;
         this.redis = redis;
-        String dir = System.getenv().getOrDefault("LOG_DIR", "/var/log/prism-arbitrage");
+        String dir = System.getenv().getOrDefault("LOG_DIR", "/var/log/prism");
+        // TODO: add log rotation policy for this directory
         this.resumeLog = java.nio.file.Paths.get(dir, "resume.log");
     }
 

--- a/feed-aggregator/logger.js
+++ b/feed-aggregator/logger.js
@@ -3,7 +3,8 @@ const axios = require('axios');
 const winston = require('winston');
 const createLogger = require('../lib/logger.js');
 
-const logDir = process.env.LOG_DIR || '/var/log/prism-arbitrage';
+const logDir = process.env.LOG_DIR || '/var/log/prism';
+// TODO: handle log rotation with logrotate
 if (!fs.existsSync(logDir)) {
   fs.mkdirSync(logDir, { recursive: true });
 }

--- a/infra/helm/templates/api-deployment.yaml
+++ b/infra/helm/templates/api-deployment.yaml
@@ -27,7 +27,7 @@ spec:
                 name: prod-secrets
           volumeMounts:
             - name: prism-logs
-              mountPath: /var/log/prism-arbitrage
+              mountPath: /var/log/prism
           readinessProbe:
             httpGet:
               path: /health
@@ -43,7 +43,7 @@ spec:
       volumes:
         - name: prism-logs
           hostPath:
-            path: /var/log/prism-arbitrage
+            path: /var/log/prism
             type: DirectoryOrCreate
 ---
 apiVersion: v1

--- a/infra/helm/templates/executor-deployment.yaml
+++ b/infra/helm/templates/executor-deployment.yaml
@@ -27,7 +27,7 @@ spec:
                 name: prod-secrets
           volumeMounts:
             - name: prism-logs
-              mountPath: /var/log/prism-arbitrage
+              mountPath: /var/log/prism
           readinessProbe:
             exec:
               command: ["pgrep", "-f", "Executor"]
@@ -41,5 +41,5 @@ spec:
       volumes:
         - name: prism-logs
           hostPath:
-            path: /var/log/prism-arbitrage
+            path: /var/log/prism
             type: DirectoryOrCreate

--- a/infra/k8s/api.yaml
+++ b/infra/k8s/api.yaml
@@ -22,7 +22,7 @@ spec:
             - containerPort: 8080
           volumeMounts:
             - name: prism-logs
-              mountPath: /var/log/prism-arbitrage
+              mountPath: /var/log/prism
           livenessProbe:
             httpGet:
               path: /api/metrics
@@ -50,7 +50,7 @@ spec:
       volumes:
         - name: prism-logs
           hostPath:
-            path: /var/log/prism-arbitrage
+            path: /var/log/prism
             type: DirectoryOrCreate
 ---
 apiVersion: v1

--- a/infra/k8s/executor.yaml
+++ b/infra/k8s/executor.yaml
@@ -27,7 +27,7 @@ spec:
                 name: prod-secrets
           volumeMounts:
             - name: prism-logs
-              mountPath: /var/log/prism-arbitrage
+              mountPath: /var/log/prism
           readinessProbe:
             exec:
               command: ["pgrep", "-f", "Executor"]
@@ -41,5 +41,5 @@ spec:
       volumes:
         - name: prism-logs
           hostPath:
-            path: /var/log/prism-arbitrage
+            path: /var/log/prism
             type: DirectoryOrCreate

--- a/lib/alerts.js
+++ b/lib/alerts.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const Redis = require('ioredis');
 const createLogger = require('./logger.js');
 
-const logDir = process.env.LOG_DIR || '/var/log/prism-arbitrage';
+const logDir = process.env.LOG_DIR || '/var/log/prism';
+// Logs in this directory will be rotated externally in the future
 if (!fs.existsSync(logDir)) {
   fs.mkdirSync(logDir, { recursive: true });
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,7 +1,13 @@
 const winston = require('winston');
 
+// Logs are persisted to /var/log/prism. Rotation will be managed via
+// an external logrotate configuration in a future release.
+
+const levels = { error: 0, warn: 1, audit: 2, info: 3, debug: 4 };
+
 function createLogger(service = 'app') {
-  return winston.createLogger({
+  const logger = winston.createLogger({
+    levels,
     level: process.env.LOG_LEVEL || 'info',
     defaultMeta: { service },
     format: winston.format.combine(
@@ -10,6 +16,8 @@ function createLogger(service = 'app') {
     ),
     transports: [new winston.transports.Console()],
   });
+  logger.audit = (...args) => logger.log('audit', ...args);
+  return logger;
 }
 
 module.exports = createLogger;


### PR DESCRIPTION
## Summary
- persist logs under `/var/log/prism`
- note future log rotation in logger config
- emit audit logs for resume override attempts
- audit configuration overrides and resume/panic actions
- update API and executor deployments to mount host log directory

## Testing
- `bash codex-setup.sh` *(fails: test failures)*
- `npm --prefix api test` *(fails to run tests)*
- `npm --prefix feed-aggregator test` *(fails: 2 failed)*
- `pytest` *(fails: 2 failed)*

------
https://chatgpt.com/codex/tasks/task_b_688109880da0832c96faa926000bfd73