### PR TITLE
PR-01: Core API Fixes – /login and /opportunities behavior

### DIFF
--- a/api/__tests__/api.test.js
+++ b/api/__tests__/api.test.js
@@ -52,8 +52,8 @@ describeLocal('API authentication', () => {
     expect(authRes.statusCode).toBe(200);
     expect(authRes.body).toEqual({
       opportunities: [],
-      dryRun: true,
-      timestamp: expect.any(String)
+      executionMode: 'sandbox',
+      lastUpdated: expect.any(String)
     });
   });
 

--- a/api/routes/login.js
+++ b/api/routes/login.js
@@ -1,5 +1,6 @@
 // Login endpoint handling sandbox demo credentials
 import bcrypt from 'bcryptjs';
+import { z } from 'zod';
 import { findByEmail } from './userStore.js';
 import logger from '../services/logger.js';
 
@@ -7,13 +8,43 @@ const SANDBOX_EMAIL = 'demo@prismarbitrage.ai';
 const SANDBOX_PASS = 'demo1234';
 const HARD_CODED_JWT = 'demo-token';
 
+const loginSchema = z.object({
+  email: z.string(),
+  password: z.string().min(1),
+});
+
+const tokenSchema = z.object({
+  token: z.string().min(1),
+});
+
 export default async function loginRoutes(app) {
   // In demo mode use static creds
   const sandboxMode = process.env.SANDBOX_MODE === 'true';
 
   app.post('/login', async (req, reply) => {
-    const { email, password } = req.body;
     const ts = new Date().toISOString();
+    const mode = process.env.EXECUTION_MODE || (sandboxMode ? 'sandbox' : 'live');
+
+    let body = req.body;
+    if (typeof body === 'string') {
+      try { body = JSON.parse(body); } catch { body = {}; }
+    }
+    const result = loginSchema.safeParse(body || {});
+    if (!result.success) {
+      logger.warn(
+        JSON.stringify({
+          event: 'login_attempt',
+          status: 'failure',
+          reason: 'invalid_payload',
+          ip: req.ip,
+          mode,
+          ts,
+        })
+      );
+      return reply.code(400).send({ error: 'invalid credentials' });
+    }
+
+    const { email, password } = result.data;
 
     const cookieOpts = { httpOnly: true };
     if (process.env.NODE_ENV === 'production') {
@@ -46,8 +77,73 @@ export default async function loginRoutes(app) {
     }
 
     logger.warn(
-      JSON.stringify({ event: 'login_attempt', status: 'failure', user: email, reason: 'bad_password', ts })
+      JSON.stringify({
+        event: 'login_attempt',
+        status: 'failure',
+        user: email,
+        reason: 'bad_password',
+        ip: req.ip,
+        mode,
+        ts,
+      })
     );
     reply.code(401).send({ error: 'invalid credentials' });
+  });
+
+  app.post('/login/token', async (req, reply) => {
+    const ts = new Date().toISOString();
+    const mode = process.env.EXECUTION_MODE || (sandboxMode ? 'sandbox' : 'live');
+
+    let tBody = req.body;
+    if (typeof tBody === 'string') {
+      try { tBody = JSON.parse(tBody); } catch { tBody = {}; }
+    }
+    const result = tokenSchema.safeParse(tBody || {});
+    if (!result.success) {
+      logger.warn(
+        JSON.stringify({
+          event: 'login_token_attempt',
+          status: 'failure',
+          reason: 'invalid_payload',
+          ip: req.ip,
+          mode,
+          ts,
+        })
+      );
+      return reply.code(400).send({ error: 'invalid token' });
+    }
+
+    const cookieOpts = { httpOnly: true };
+    if (process.env.NODE_ENV === 'production') {
+      cookieOpts.secure = true;
+    }
+
+    try {
+      const payload = await app.jwt.verify(result.data.token);
+      reply.setCookie('token', result.data.token, cookieOpts);
+      logger.info(
+        JSON.stringify({
+          event: 'login_token_attempt',
+          status: 'success',
+          user: payload?.email || 'unknown',
+          ip: req.ip,
+          mode,
+          ts,
+        })
+      );
+      return { token: result.data.token };
+    } catch {
+      logger.warn(
+        JSON.stringify({
+          event: 'login_token_attempt',
+          status: 'failure',
+          reason: 'invalid_token',
+          ip: req.ip,
+          mode,
+          ts,
+        })
+      );
+      return reply.code(401).send({ error: 'invalid token' });
+    }
   });
 }

--- a/api/routes/opportunities.js
+++ b/api/routes/opportunities.js
@@ -1,18 +1,20 @@
 import logger from '../services/logger.js';
+import { getExecutionMode } from '../config/settings.js';
 
 export default async function opportunitiesRoutes(app, opts) {
   const { redis } = opts;
   const KEY = 'arb:spread:opportunities';
 
   app.get('/opportunities', async (req) => {
+    const executionMode = getExecutionMode(req);
     try {
       const cached = await redis.get(KEY);
       if (!cached) {
         req.log.info('[API] No opportunities available or Redis cache empty');
         return {
           opportunities: [],
-          dryRun: true,
-          timestamp: new Date().toISOString()
+          executionMode,
+          lastUpdated: new Date().toISOString(),
         };
       }
       let opportunities = [];
@@ -22,21 +24,21 @@ export default async function opportunitiesRoutes(app, opts) {
         logger.error(`[REDIS] Failed to read opportunities: ${err.message}`);
         return {
           opportunities: [],
-          dryRun: true,
-          timestamp: new Date().toISOString()
+          executionMode,
+          lastUpdated: new Date().toISOString(),
         };
       }
       return {
         opportunities,
-        dryRun: true,
-        timestamp: new Date().toISOString()
+        executionMode,
+        lastUpdated: new Date().toISOString(),
       };
     } catch (err) {
       logger.error(`[REDIS] Failed to read opportunities: ${err.message}`);
       return {
         opportunities: [],
-        dryRun: true,
-        timestamp: new Date().toISOString()
+        executionMode,
+        lastUpdated: new Date().toISOString(),
       };
     }
   });


### PR DESCRIPTION
## Summary
- validate login credentials with zod
- add JWT-based `/login/token` endpoint
- include execution mode and timestamp in `/opportunities` responses
- update tests for new opportunities format

## Testing
- `pytest`
- `executor/gradlew test -p executor -PtestEnv=local` *(fails: failing tests)*
- `npm test -- --runInBand` *(fails: 10 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6881207301d8832caec73526250737ea