### PR TITLE
PR-02: Operational Controls Fixes – Panic, Resume, Settings Logic

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -258,8 +258,17 @@ async function apiRoutes(api, { redis, pool, panicState }) {
 
   api.register(alertRoutes, { redis });
 
+  const panicTestAllowed =
+    isTest ||
+    ['dry-run-sandbox', 'dry-run-server'].includes(
+      process.env.EXECUTION_MODE ||
+        (process.env.SANDBOX_MODE === 'true' ? 'dry-run-sandbox' : 'live')
+    );
+  if (panicTestAllowed) {
+    api.register(panicRoutes, { redis, panicState });
+  }
+
     if (isTest) {
-      api.register(panicRoutes, { redis, panicState });
       api.post('/test/resume', async (_req, reply) => {
         if (process.env.SANDBOX_MODE !== 'true') {
           return reply.code(403).send();

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -5,7 +5,11 @@ import { setPauseState, getPauseState } from '../services/pauseState.js';
 
 export default async function panicRoutes(app, { redis, panicState }) {
   app.post('/test/panic', async (req, reply) => {
-    if (process.env.SANDBOX_MODE !== 'true') {
+    const mode =
+      process.env.EXECUTION_MODE ||
+      (process.env.SANDBOX_MODE === 'true' ? 'dry-run-sandbox' : 'live');
+    const allowed = ['dry-run-sandbox', 'dry-run-server'];
+    if (!allowed.includes(mode)) {
       return reply.code(403).send();
     }
     const alreadyPaused = await getPauseState(redis);
@@ -19,13 +23,15 @@ export default async function panicRoutes(app, { redis, panicState }) {
       );
       return { paused: true, ignored: true };
     }
-    const user = req.user?.email || 'unknown';
+    const user = req.user?.email || req.user?.id || req.ip || 'unknown';
     panicState.last = now;
     await redis.set('panic_last_ts', String(now));
     await setPauseState(redis, true);
-    logger.warn('[PANIC TRIGGERED]');
+    const reason = req.body?.type || 'manual override';
+    const source = req.body?.source || 'api';
+    logger.warn(`[PANIC TRIGGERED] mode=${mode} source=${source}`);
     logger.audit(
-      `[PANIC] ts=${new Date().toISOString()} user=${user} reason=${req.body?.type || 'manual'}`
+      `[PANIC] ts=${new Date().toISOString()} mode=${mode} user=${user} source=${source} reason=${reason}`
     );
     panicState.reason = req.body?.type || null;
     try {
@@ -37,8 +43,10 @@ export default async function panicRoutes(app, { redis, panicState }) {
     logger.warn(
       JSON.stringify({
         event: 'panic',
-        reason: panicState.reason || 'manual',
+        reason: panicState.reason || 'manual override',
         value: req.body?.value || 0,
+        mode,
+        source,
         ts: new Date().toISOString(),
       })
     );
@@ -48,6 +56,6 @@ export default async function panicRoutes(app, { redis, panicState }) {
     } catch (err) {
       logger.error(`[ALERT FAILURE] Panic alert email failed to send: ${err.message}`);
     }
-    return { paused: true, source: 'manual' };
+    return { status: 'panic_triggered', mode, reason };
   });
 }

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -16,15 +16,18 @@ export default async function resumeRoutes(app, opts) {
     fs.mkdirSync(logDir, { recursive: true });
   }
 
-  function logAttempt(event, operator, extra = {}) {
+  function logAttempt(event, operator, mode, extra = {}) {
     const entry = {
       timestamp: new Date().toISOString(),
       event,
       operator,
+      mode,
       ...extra,
     };
     fs.appendFile(resumeLog, JSON.stringify(entry) + '\n', () => {});
-    logger.audit(`[RESUME] ${event} user=${operator} ${JSON.stringify(extra)}`);
+    logger.audit(
+      `[RESUME] ${event} mode=${mode} user=${operator} ${JSON.stringify(extra)}`
+    );
   }
 
   app.post(
@@ -32,10 +35,15 @@ export default async function resumeRoutes(app, opts) {
     { preHandler: requireAdmin },
     async (req, reply) => {
     const user = req.user?.email || 'unknown';
+    const mode =
+      process.env.EXECUTION_MODE ||
+      (process.env.SANDBOX_MODE === 'true' ? 'dry-run-sandbox' : 'live');
+    const source = req.body?.source || 'api';
+    logAttempt('resume_attempt', user, mode, { source });
 
     const paused = await getPauseState(redis);
     if (!paused) {
-      logAttempt('resume_not_paused', user);
+      logAttempt('resume_not_paused', user, mode);
       reply.code(409);
       return { error: 'System is not paused' };
     }
@@ -47,20 +55,25 @@ export default async function resumeRoutes(app, opts) {
       healthy = body.healthy === true;
     } catch {}
     if (health.statusCode !== 200 || !healthy) {
-      logAttempt('resume_blocked_health', user);
+      logAttempt('resume_blocked_health', user, mode);
       reply.code(403);
       return { error: 'System not healthy \u2014 resume denied' };
     }
 
-    const confirm = req.query.confirm === 'true';
+    const confirm = req.body?.confirm === true;
+    if (mode === 'live' && !confirm) {
+      logAttempt('resume_missing_confirm', user, mode);
+      reply.code(400);
+      return { error: 'confirmation_required' };
+    }
     if (!confirm && (panicState.reason === 'loss' || panicState.reason === 'latency')) {
-      logAttempt('resume_needs_override', user, { reason: panicState.reason });
+      logAttempt('resume_needs_override', user, mode, { reason: panicState.reason });
       reply.code(403);
       return { override_required: true };
     }
 
     if (confirm) {
-      logAttempt('resume_override_attempt', user, { reason: panicState.reason });
+      logAttempt('resume_override_attempt', user, mode, { reason: panicState.reason });
       await redis.set('resume_confirmed', 'true', 'EX', 60);
     }
 
@@ -105,12 +118,12 @@ export default async function resumeRoutes(app, opts) {
     } else {
       req.log.info(`[DRY-RUN] Resume alert: ${msg}`);
     }
-    logAttempt('resume_success', user);
+    logAttempt('resume_success', user, mode, { confirmed: confirm, source });
     resumeCounter.inc();
     logger.info(
       JSON.stringify({ event: 'resume', ts: new Date().toISOString() })
     );
-    return { resumed: true };
+    return { status: 'resumed', confirmed: confirm, mode };
   }
   );
 }

--- a/api/routes/settings.js
+++ b/api/routes/settings.js
@@ -47,16 +47,14 @@ export default async function settingsRoutes(app, opts) {
       return { error: "invalid settings" };
     }
     const data = result.data;
+    const operator = req.user?.email || req.user?.id || req.ip;
+    const mode =
+      process.env.EXECUTION_MODE ||
+      (process.env.SANDBOX_MODE === "true" ? "dry-run-sandbox" : "live");
 
     if (typeof data.maxLossPct === "number" && data.maxLossPct > 20) {
       logger.warn(
-        JSON.stringify({
-          event: "unauthorized_config_change",
-          field: "maxLossPct",
-          value: data.maxLossPct,
-          status: "rejected",
-          ts: new Date().toISOString(),
-        })
+        `[SETTINGS-REJECTED] maxLossPct=${data.maxLossPct} exceeds limit mode=${mode} operator=${operator}`
       );
       reply.code(400);
       return { error: "maxLossPct exceeds limit" };
@@ -64,13 +62,7 @@ export default async function settingsRoutes(app, opts) {
 
     if (typeof data.latencyMaxMs === "number" && data.latencyMaxMs > 1000) {
       logger.warn(
-        JSON.stringify({
-          event: "unauthorized_config_change",
-          field: "latencyMaxMs",
-          value: data.latencyMaxMs,
-          status: "rejected",
-          ts: new Date().toISOString(),
-        })
+        `[SETTINGS-REJECTED] latencyMaxMs=${data.latencyMaxMs} exceeds limit mode=${mode} operator=${operator}`
       );
       reply.code(400);
       return { error: "latencyMaxMs exceeds limit" };
@@ -78,13 +70,7 @@ export default async function settingsRoutes(app, opts) {
 
     if (typeof data.coinExposureLimit === "number" && data.coinExposureLimit > 30) {
       logger.warn(
-        JSON.stringify({
-          event: "unauthorized_config_change",
-          field: "coinExposureLimit",
-          value: data.coinExposureLimit,
-          status: "rejected",
-          ts: new Date().toISOString(),
-        })
+        `[SETTINGS-REJECTED] coinExposureLimit=${data.coinExposureLimit} exceeds limit mode=${mode} operator=${operator}`
       );
       reply.code(400);
       return { error: "coinExposureLimit exceeds limit" };
@@ -94,13 +80,7 @@ export default async function settingsRoutes(app, opts) {
       const modes = ["Realistic", "Aggressive", "Auto"];
       if (!modes.includes(data.personality_mode)) {
         logger.warn(
-          JSON.stringify({
-            event: "unauthorized_config_change",
-            field: "personality_mode",
-            value: data.personality_mode,
-            status: "rejected",
-            ts: new Date().toISOString(),
-          })
+          `[SETTINGS-REJECTED] personality_mode=${data.personality_mode} invalid mode=${mode} operator=${operator}`
         );
         reply.code(400);
         return { error: "invalid personality_mode" };
@@ -111,13 +91,7 @@ export default async function settingsRoutes(app, opts) {
       const allowed = ["Daily", "Monthly", "None"];
       if (!allowed.includes(data.sweep_cadence)) {
         logger.warn(
-          JSON.stringify({
-            event: "unauthorized_config_change",
-            field: "sweep_cadence",
-            value: data.sweep_cadence,
-            status: "rejected",
-            ts: new Date().toISOString(),
-          })
+          `[SETTINGS-REJECTED] sweep_cadence=${data.sweep_cadence} invalid mode=${mode} operator=${operator}`
         );
         reply.code(400);
         return { error: "invalid sweep_cadence" };
@@ -128,6 +102,19 @@ export default async function settingsRoutes(app, opts) {
   };
 
   const saveSettings = async (req) => {
+    const operator = req.user?.email || req.user?.id || req.ip;
+    const mode =
+      process.env.EXECUTION_MODE ||
+      (process.env.SANDBOX_MODE === "true" ? "dry-run-sandbox" : "live");
+    logger.audit(
+      JSON.stringify({
+        event: 'settings_update_request',
+        operator,
+        mode,
+        changes: req.body,
+        ts: new Date().toISOString(),
+      })
+    );
     if (typeof req.body.schema_version === "number") {
       settings.schema_version = req.body.schema_version;
     }
@@ -205,6 +192,14 @@ export default async function settingsRoutes(app, opts) {
     }
 
     await loadSettingsFromRedis(redis);
+    logger.audit(
+      JSON.stringify({
+        event: 'settings_updated',
+        operator,
+        mode,
+        ts: new Date().toISOString(),
+      })
+    );
     return { saved: true };
   };
 


### PR DESCRIPTION
## Summary
- adjust settings route logging for better context
- expand panic test accessibility and add mode-aware logs
- tighten resume confirmation in live mode

## Testing
- `npm --prefix api test --silent` *(fails: Exceeded timeout and assertions)*

------
https://chatgpt.com/codex/tasks/task_b_6881209b5d08832cb75dfe15f65cd48e