### PR TITLE
PR-03: Execution Engine Fixes – Strategy Limits & Adapter Reconnect

### DIFF
--- a/executor/src/main/java/ExchangeAdapter.java
+++ b/executor/src/main/java/ExchangeAdapter.java
@@ -1,5 +1,9 @@
 package executor;
 
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Abstraction for exchange specific order and balance operations.
  */
@@ -62,6 +66,46 @@ public interface ExchangeAdapter {
      */
     default void cancel(String orderId) {
         // no-op
+    }
+
+    /**
+     * Attempt to establish a WebSocket connection with retry logic. If all
+     * attempts fail, a REST fallback is executed. Any failure of the fallback
+     * escalates to the caller via {@link RuntimeException}.
+     *
+     * @param wsConnect   runnable that performs the WebSocket connect
+     * @param restFallback runnable that performs the REST fallback
+     * @param exchangeName exchange identifier used in logs
+     */
+    default void connectWithRetry(Runnable wsConnect, Runnable restFallback, String exchangeName) {
+        Logger log = LoggerFactory.getLogger(getClass());
+        int maxRetries = 5;
+        long delay = 1000L;
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                wsConnect.run();
+                return;
+            } catch (Exception e) {
+                log.warn("WebSocket attempt {}/{} failed for {} at {}", attempt, maxRetries, exchangeName, Instant.now(), e);
+                if (attempt == maxRetries) {
+                    log.error("WebSocket unavailable for {} – falling back to REST", exchangeName);
+                    try {
+                        restFallback.run();
+                        return;
+                    } catch (Exception restEx) {
+                        log.error("REST fallback failed for {} at {}", exchangeName, Instant.now(), restEx);
+                        throw new RuntimeException("REST fallback failed for " + exchangeName, restEx);
+                    }
+                }
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                delay = Math.min(delay * 2, 10000L);
+            }
+        }
     }
 }
 

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -244,6 +244,21 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
             return;
         }
 
+        // Pre-trade panic checks
+        dailyLossPct = ProfitTracker.getDailyLossPct();
+        if (dailyLossPct > config.getLossCapPct()) {
+            logger.error("[PANIC] Loss cap breached mode={} value={} cap={}",
+                    config.getExecutionMode(), dailyLossPct, config.getLossCapPct());
+            triggerPanic();
+            return;
+        }
+        if (averageLatencyMs > config.getLatencyMaxMs()) {
+            logger.error("[PANIC] Latency ceiling violated mode={} value={} cap={}",
+                    config.getExecutionMode(), averageLatencyMs, config.getLatencyMaxMs());
+            triggerPanic();
+            return;
+        }
+
         if (!redisClient.ping()) {
             logger.warn("[DRY-RUN ENFORCEMENT] Trade blocked: Redis unavailable");
             return;
@@ -268,11 +283,8 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         recordMetrics(opp, result);
 
         if (!sandboxMode && PanicBrake.shouldHalt(redisClient, config, dailyLossPct, averageLatencyMs, winRate)) {
-            if (isPanic.compareAndSet(false, true)) {
-                logger.error("PANIC BRAKE TRIGGERED - trading paused");
-                AlertManager.sendAlert("PANIC", "BRAKE TRIGGERED");
-                redisClient.publish("alerts", "PANIC BRAKE TRIGGERED");
-            }
+            logger.error("[PANIC] Brake triggered mode={}", config.getExecutionMode());
+            triggerPanic();
         }
     }
 
@@ -496,6 +508,7 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
     public void resumeFromPanic() {
         if (sandboxMode) {
             logger.info("[DRY-RUN] resume ignored");
+            redisClient.setResumeAck();
             return;
         }
         if (isPanic.compareAndSet(true, false)) {
@@ -521,6 +534,21 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
      */
     public boolean isPanicActive() {
         return isPanic.get();
+    }
+
+    /**
+     * Trigger a panic halt. In LIVE mode a pause command is broadcast so
+     * that all agents stop executing trades. Dry-run modes simply set the
+     * local flag to simulate panic without affecting other services.
+     */
+    private void triggerPanic() {
+        if (isPanic.compareAndSet(false, true)) {
+            if (!config.isDryRun()) {
+                redisClient.publish(controlChannel, "pause");
+            }
+            AlertManager.sendAlert("PANIC", "TRIGGERED");
+            redisClient.publish("alerts", "PANIC TRIGGERED");
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- enforce loss/latency limits in `Executor`
- add panic trigger helper and log execution mode
- allow resume ack in dry-run
- add websocket reconnect logic with capped retries

## Testing
- `./gradlew test` *(fails: ExecutorDryRunModeTest, ExecutorMaxOpenTradesTest, PanicResumeLoopTest)*

------
https://chatgpt.com/codex/tasks/task_b_688120c18bec832caae918e8f63834da