### PR TITLE
PR-05: Secrets & Config Enforcement – Live Mode Startup Safety

### DIFF
--- a/executor/src/main/java/ConfigManager.java
+++ b/executor/src/main/java/ConfigManager.java
@@ -33,6 +33,10 @@ public class ConfigManager {
         this.maxLossPct = maxLossPct;
         this.latencyMaxMs = latencyMaxMs;
         this.coinExposureLimit = coinExposureLimit;
+
+        if (!verifyLiveSecrets()) {
+            System.exit(1);
+        }
     }
 
     public double getMaxLossPct() {
@@ -95,6 +99,54 @@ public class ConfigManager {
                     StandardOpenOption.CREATE, StandardOpenOption.APPEND);
         } catch (IOException e) {
             logger.error("Failed to write rejection log: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Verify required secrets are present when running in live mode.
+     * Visible for tests.
+     *
+     * @return true if all required secrets exist or not running live
+     */
+    static boolean verifyLiveSecrets() {
+        return verifyLiveSecrets(System.getenv());
+    }
+
+    /** Visible for tests to allow injecting environment map. */
+    static boolean verifyLiveSecrets(java.util.Map<String, String> env) {
+        String modeProp = System.getProperty("EXECUTION_MODE");
+        String mode = modeProp != null ? modeProp
+                : env.getOrDefault("EXECUTION_MODE", "live");
+        if (!"live".equalsIgnoreCase(mode)) {
+            return true;
+        }
+
+        java.util.List<String> missing = new java.util.ArrayList<>();
+        checkKey(env, missing, "BINANCE_KEY");
+        checkKey(env, missing, "BINANCE_SECRET");
+        checkKey(env, missing, "WALLET_ADDRESS");
+
+        boolean alertsActive = env.containsKey("ALERT_RECIPIENT")
+                || env.containsKey("SMTP_USER");
+        if (alertsActive) {
+            checkKey(env, missing, "SMTP_USER");
+        }
+
+        if (!missing.isEmpty()) {
+            logger.error("[FATAL] Missing required secrets in Live Mode. Aborting startup. Missing keys: {}",
+                    String.join(", ", missing));
+            return false;
+        }
+        return true;
+    }
+
+    private static void checkKey(java.util.Map<String, String> env,
+                                 java.util.List<String> missing,
+                                 String key) {
+        String val = env.get(key);
+        if (val == null || val.isBlank() || "dummy123".equalsIgnoreCase(val)
+                || "<REPLACE_ME>".equalsIgnoreCase(val)) {
+            missing.add(key);
         }
     }
 }

--- a/executor/src/test/java/ConfigManagerTest.java
+++ b/executor/src/test/java/ConfigManagerTest.java
@@ -10,11 +10,32 @@ public class ConfigManagerTest {
 
     @Test
     void unsafeConfigIsRejectedDuringReload() throws Exception {
+        System.setProperty("EXECUTION_MODE", "sandbox");
         ConfigManager mgr = new ConfigManager("localhost", 6379, 3.0, 200.0, 10.0);
         String badJson = "{\"maxLossPct\":7.0,\"latencyMaxMs\":200,\"coinExposureLimit\":20}";
         mgr.applyJson(badJson);
         assertEquals(3.0, mgr.getMaxLossPct(), 1e-9);
         assertEquals(200.0, mgr.getLatencyMaxMs(), 1e-9);
         assertEquals(10.0, mgr.getCoinExposureLimit(), 1e-9);
+        System.clearProperty("EXECUTION_MODE");
+    }
+
+    @Test
+    void verifySecretsFailsWhenMissingInLiveMode() {
+        java.util.Map<String, String> env = new java.util.HashMap<>();
+        env.put("EXECUTION_MODE", "live");
+        assertFalse(ConfigManager.verifyLiveSecrets(env));
+    }
+
+    @Test
+    void verifySecretsPassesWithAllSecrets() {
+        java.util.Map<String, String> env = new java.util.HashMap<>();
+        env.put("EXECUTION_MODE", "live");
+        env.put("BINANCE_KEY", "abc");
+        env.put("BINANCE_SECRET", "def");
+        env.put("WALLET_ADDRESS", "0x123");
+        env.put("SMTP_USER", "a@b.com");
+        env.put("ALERT_RECIPIENT", "ops@b.com");
+        assertTrue(ConfigManager.verifyLiveSecrets(env));
     }
 }


### PR DESCRIPTION
## Summary
- verify required secrets before allowing Live Mode startup
- abort JVM startup if any secret is missing
- add tests covering secret checks

## Testing
- `./gradlew test -PtestEnv=local` *(fails: ExecutorMaxOpenTradesTest, RedisPubSubIntegrationTest, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_688120f2cae4832c8de6b059a6838e11