### PR TITLE
PR 19: Enforce JWT on /resume Endpoint in All Modes (P2 Fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ##Released
+- PR 19 – Fix Sandbox Resume Auth Bypass
+  - Enforced JWT auth on `/resume` for all modes including sandbox
+  - Split out optional `/demo/resume` for UI-only testing (guarded by EXECUTION_MODE)
+  - Prevents unauthorized resume in test/demo environments
+  - Logs resume actions only after auth verification
 - Add real-time panic brake and execution mode banner to operator dashboard
 - Enforce system health validation before allowing panic resume actions
 - Enforced system health check and confirmation step for resume logic (API + executor)

--- a/api/index.js
+++ b/api/index.js
@@ -158,12 +158,15 @@ async function apiRoutes(api, { redis, pool, panicState }) {
   api.addHook('onRequest', async (req, reply) => {
     const openPaths = [
       ...baseOpenPaths,
-      ...(process.env.EXECUTION_MODE === 'sandbox' ? ['/api/resume'] : []),
+      ...(process.env.EXECUTION_MODE === 'sandbox' ? ['/api/demo/resume'] : []),
       ...(isTest ? ['/api/test/panic', '/api/test/resume', '/api/test/sweep', '/api/test/alert'] : []),
     ];
     if (openPaths.includes(req.url)) return;
     try {
       await req.jwtVerify();
+      if (req.url === '/api/resume') {
+        req.log.info('[RESUME] Resume command received by authorized user');
+      }
     } catch {
       reply.code(401).send({ error: 'unauthorized' });
     }
@@ -174,7 +177,7 @@ async function apiRoutes(api, { redis, pool, panicState }) {
     if (!['POST', 'PUT', 'DELETE'].includes(req.method)) return;
     const openPaths = [
       ...baseOpenPaths,
-      ...(process.env.EXECUTION_MODE === 'sandbox' ? ['/api/resume'] : []),
+      ...(process.env.EXECUTION_MODE === 'sandbox' ? ['/api/demo/resume'] : []),
       ...(isTest ? ['/api/test/panic', '/api/test/resume', '/api/test/sweep', '/api/test/alert'] : []),
     ];
     if (openPaths.includes(req.url)) return;
@@ -268,11 +271,11 @@ async function apiRoutes(api, { redis, pool, panicState }) {
     api.register(panicRoutes, { redis, panicState });
   }
 
-    if (isTest) {
-      api.post('/test/resume', async (_req, reply) => {
-        if (process.env.SANDBOX_MODE !== 'true') {
-          return reply.code(403).send();
-        }
+  if (isTest) {
+    api.post('/test/resume', async (_req, reply) => {
+      if (process.env.SANDBOX_MODE !== 'true') {
+        return reply.code(403).send();
+      }
         const paused = await getPauseState(redis);
         if (!paused) {
           reply.code(409);
@@ -324,8 +327,15 @@ async function apiRoutes(api, { redis, pool, panicState }) {
           await sendAlert('email', 'Test panic alert', 'test');
         } catch {}
         return { status: 'sent', type: 'test', ts };
-      });
-    }
+    });
+  }
+
+  if (process.env.EXECUTION_MODE === 'sandbox') {
+    api.post('/demo/resume', async () => {
+      logger.info('[RESUME] Demo resume endpoint hit');
+      return { status: 'demo-only', mode: 'sandbox' };
+    });
+  }
 
   api.register(userRoutes, { prefix: '/users' });
   api.register(infraRoutes, { redis, pool });


### PR DESCRIPTION
## Summary
- always require JWT on `/resume`
- add optional `/demo/resume` for sandbox previews
- log when an authenticated user hits `/resume`
- update changelog

## Testing
- `./test/run-local.sh` *(fails: helm command not found)*
- `npm test` in `api` *(fails: 10 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_b_688133d2136c832cbb8c0d1725a1e42e