### PR TITLE
PR 21: Fix Cold Wallet Sweeper Busy Flag Lock on Failure (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - ProfitTracker background thread now properly shut down to prevent leaks
 - Added audit logging for all trade attempts: success, fail, rejected, skipped
 
+## PR 21 – Cold Wallet Sweep Resilience Fix
+- Ensures cold sweeper `busy` flag is always cleared after sweep attempt
+- Prevents permanent lockout if an exception is thrown
+- Logs sweep failures for operator awareness
+- Fixes edge case where sweeps were silently disabled
+
 ## [Batch 1] - 2025-07-02
 ### Added
 - Local environment setup

--- a/executor/src/main/java/ColdSweeper.java
+++ b/executor/src/main/java/ColdSweeper.java
@@ -122,18 +122,28 @@ public class ColdSweeper {
     public void sweepToColdWallet(double amountUsd) {
         busy.set(true);
         String address = sweeperConfig.getTestColdWalletAddress();
-        logger.info("Cold wallet sweep triggered for: {} amount {}", maskAddress(address), amountUsd);
-        if (isDryRun) {
-            logger.info("[DRY-RUN MODE] Cold wallet sweep logic verified. No assets moved.");
-            logDryRunSweep("auto", amountUsd);
-        } else {
-            walletClient.withdraw(address, amountUsd);
+        try {
+            logger.info(
+                    "Cold wallet sweep triggered for: {} amount {}",
+                    maskAddress(address),
+                    amountUsd);
+            if (isDryRun) {
+                logger.info(
+                        "[DRY-RUN MODE] Cold wallet sweep logic verified. No assets moved.");
+                logDryRunSweep("auto", amountUsd);
+            } else {
+                walletClient.withdraw(address, amountUsd);
+            }
+            ProfitTracker.resetCumulativeProfit();
+            if (sweepLogger != null) {
+                sweepLogger.logSweep(amountUsd, address, "auto");
+            }
+        } catch (Exception e) {
+            logger.error("[SWEEP ERROR] Sweep failed: {}", e.getMessage());
+            throw e;
+        } finally {
+            busy.set(false);
         }
-        ProfitTracker.resetCumulativeProfit();
-        if (sweepLogger != null) {
-            sweepLogger.logSweep(amountUsd, address, "auto");
-        }
-        busy.set(false);
     }
 
     /**
@@ -144,17 +154,27 @@ public class ColdSweeper {
      */
     public void sweepToColdWallet(String address, double amountUsd) {
         busy.set(true);
-        logger.info("Cold wallet sweep triggered for: {} amount {}", maskAddress(address), amountUsd);
-        if (isDryRun) {
-            logger.info("[DRY-RUN MODE] Cold wallet sweep logic verified. No assets moved.");
-            logDryRunSweep("manual", amountUsd);
-        } else {
-            walletClient.withdraw(address, amountUsd);
+        try {
+            logger.info(
+                    "Cold wallet sweep triggered for: {} amount {}",
+                    maskAddress(address),
+                    amountUsd);
+            if (isDryRun) {
+                logger.info(
+                        "[DRY-RUN MODE] Cold wallet sweep logic verified. No assets moved.");
+                logDryRunSweep("manual", amountUsd);
+            } else {
+                walletClient.withdraw(address, amountUsd);
+            }
+            ProfitTracker.resetCumulativeProfit();
+            if (sweepLogger != null) {
+                sweepLogger.logSweep(amountUsd, address, "manual");
+            }
+        } catch (Exception e) {
+            logger.error("[SWEEP ERROR] Sweep failed: {}", e.getMessage());
+            throw e;
+        } finally {
+            busy.set(false);
         }
-        ProfitTracker.resetCumulativeProfit();
-        if (sweepLogger != null) {
-            sweepLogger.logSweep(amountUsd, address, "manual");
-        }
-        busy.set(false);
     }
 }


### PR DESCRIPTION
## Summary
- ensure `busy` flag cleared via `try`/`finally`
- log sweep failures with `[SWEEP ERROR]` message
- add changelog entry for resilience fix

## Testing
- `bash test/run-local.sh` *(fails: Kubernetes cluster unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_688134e4917c832cac0d5e03a8b7869d