### PR TITLE
PR 25: Remove Unused Executor Interface Implementation (P3 Fix)

### DIFF
--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -30,7 +30,7 @@ import java.sql.SQLException;
  * Executor agent responsible for executing arbitrage opportunities.
  * Implements {@link ResumeHandler.ResumeCapable} to handle resume signals.
  */
-public class Executor implements ResumeHandler.ResumeCapable, java.util.concurrent.Executor {
+public class Executor implements ResumeHandler.ResumeCapable {
     private static final Logger logger = LoggerFactory.getLogger(Executor.class);
 
     private final RedisClient redisClient;
@@ -220,8 +220,6 @@ public class Executor implements ResumeHandler.ResumeCapable, java.util.concurre
         });
     }
 
-    /** {@inheritDoc} */
-    @Override
     public void execute(Runnable command) {
         if (command != null) {
             command.run();


### PR DESCRIPTION
## Summary
- remove misleading Executor interface from `Executor`

## Testing
- `./executor/gradlew test -p executor -PtestEnv=local` *(fails: PanicResumeLoopTest, RedisPubSubIntegrationTest)*

------
https://chatgpt.com/codex/tasks/task_b_688137295fb4832c9b6997b8a6d96178