### PR TITLE
PR 26: Harden API Container with securityContext

### DIFF
--- a/infra/helm/templates/api-deployment.yaml
+++ b/infra/helm/templates/api-deployment.yaml
@@ -19,6 +19,11 @@ spec:
       containers:
         - name: api
           image: {{ .Values.api.image }}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 3000
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: {{ .Values.api.port }}
           resources: {{- toYaml .Values.api.resources | nindent 12 }}


### PR DESCRIPTION
## Summary
- add securityContext to API container to enforce non-root execution and read-only filesystem

## Testing
- `./test/run-local.sh` *(failed: Python dependencies installation took too long)*

------
https://chatgpt.com/codex/tasks/task_b_6881376d33a8832c9ca9171428710721