### PR TITLE
PR 28: Final Audit Cleanup – Add DRY_RUN Mode and Remove Stale FillTracker TODO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ##Released
+- **PR 28 – Final Audit Cleanup (Modes + TODO)**
+  - Added `DRY_RUN` enum constant to ExecutionMode
+  - Updated config logic to separate dry-run from sandbox clearly
+  - Removed stale TODO from FillTracker and documented cancel fallback behavior
 - **PR 27 – Redis Recovery Integration Test**
   - Added automated test for Redis outage and reconnection handling
   - Confirms system resumes processing pub/sub commands after Redis restarts

--- a/executor/src/main/java/Config.java
+++ b/executor/src/main/java/Config.java
@@ -41,9 +41,9 @@ public class Config {
     }
 
     /**
-     * @return true when running in sandbox/dry-run mode
+     * @return true when running in dry-run modes (sandbox or server)
      */
     public boolean isDryRun() {
-        return executionMode == ExecutionMode.SANDBOX;
+        return executionMode == ExecutionMode.SANDBOX || executionMode == ExecutionMode.DRY_RUN;
     }
 }

--- a/executor/src/main/java/ExecutionMode.java
+++ b/executor/src/main/java/ExecutionMode.java
@@ -2,5 +2,6 @@ package executor;
 
 public enum ExecutionMode {
     LIVE,
-    SANDBOX
+    SANDBOX,
+    DRY_RUN
 }

--- a/executor/src/main/java/FillTracker.java
+++ b/executor/src/main/java/FillTracker.java
@@ -53,7 +53,7 @@ public class FillTracker {
         if (ctx == null) {
             return false;
         }
-        // TODO: integrate async exchange ACK once available
+        // Cancel fallback enforces IOC semantics if async ACK fails
         CompletableFuture<Boolean> fut = CompletableFuture.supplyAsync(() -> {
             double filled = 0.0;
             if (ctx.adapter instanceof MockExchangeAdapter) {

--- a/executor/src/main/java/Main.java
+++ b/executor/src/main/java/Main.java
@@ -70,8 +70,14 @@ public class Main {
         String mode = System.getenv().getOrDefault("PERSONALITY_MODE", "REALISTIC");
         RiskFilter riskFilter = new RiskFilter(mode);
         String execMode = System.getenv().getOrDefault("EXECUTION_MODE", "live");
-        ExecutionMode executionMode = execMode.equalsIgnoreCase("sandbox") || execMode.equalsIgnoreCase("dry-run")
-                ? ExecutionMode.SANDBOX : ExecutionMode.LIVE;
+        ExecutionMode executionMode;
+        if (execMode.equalsIgnoreCase("sandbox")) {
+            executionMode = ExecutionMode.SANDBOX;
+        } else if (execMode.equalsIgnoreCase("dry-run")) {
+            executionMode = ExecutionMode.DRY_RUN;
+        } else {
+            executionMode = ExecutionMode.LIVE;
+        }
         Config configObj = new Config(executionMode);
         NearMissLogger nearMissLogger = new NearMissLogger(conn);
         TradeLogger tradeLogger = new TradeLogger(conn);

--- a/executor/src/test/java/ColdSweeperTest.java
+++ b/executor/src/test/java/ColdSweeperTest.java
@@ -51,7 +51,7 @@ public class ColdSweeperTest {
         PrintStream orig = System.err;
         System.setErr(new PrintStream(err));
         try {
-            ColdSweeper sweeper = new ColdSweeper(0, 0, wallet, new ColdSweeperConfig(), null, new Config(ExecutionMode.SANDBOX));
+            ColdSweeper sweeper = new ColdSweeper(0, 0, wallet, new ColdSweeperConfig(), null, new Config(ExecutionMode.DRY_RUN));
             sweeper.sweepToColdWallet(10.0);
         } finally {
             System.setErr(orig);

--- a/executor/src/test/java/DryRunPanicResumeTest.java
+++ b/executor/src/test/java/DryRunPanicResumeTest.java
@@ -17,7 +17,7 @@ public class DryRunPanicResumeTest {
 
     static class DummyExecutor extends Executor {
         DummyExecutor() {
-            super(new DummyRedis(), "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.SANDBOX));
+            super(new DummyRedis(), "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.DRY_RUN));
         }
         @Override public void start() {}
     }

--- a/executor/src/test/java/ExecutorDryRunModeTest.java
+++ b/executor/src/test/java/ExecutorDryRunModeTest.java
@@ -21,7 +21,7 @@ public class ExecutorDryRunModeTest {
     static class DummyExecutor extends Executor {
         DummyRedisClient client;
         DummyExecutor(DummyRedisClient c) {
-            super(c, "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.SANDBOX));
+            super(c, "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.DRY_RUN));
             this.client = c;
         }
         @Override public void start() {}

--- a/executor/src/test/java/ExecutorTest.java
+++ b/executor/src/test/java/ExecutorTest.java
@@ -75,7 +75,7 @@ public class ExecutorTest {
         PrintStream orig = System.err;
         System.setErr(new PrintStream(err));
         try {
-            ColdSweeper sweeper = new ColdSweeper(0, 0, wallet, new ColdSweeperConfig(), null, new Config(ExecutionMode.SANDBOX));
+            ColdSweeper sweeper = new ColdSweeper(0, 0, wallet, new ColdSweeperConfig(), null, new Config(ExecutionMode.DRY_RUN));
             sweeper.sweepToColdWallet(10.0);
         } finally {
             System.setErr(orig);

--- a/executor/src/test/java/PanicBrakeTest.java
+++ b/executor/src/test/java/PanicBrakeTest.java
@@ -69,7 +69,7 @@ public class PanicBrakeTest {
     @Test
     void doesNotPublishPauseInDryRun() {
         DummyRedis redis = new DummyRedis();
-        Config config = new Config(ExecutionMode.SANDBOX);
+        Config config = new Config(ExecutionMode.DRY_RUN);
         assertTrue(PanicBrake.shouldHalt(redis, config, 6.0, 100.0, 0.8));
         assertNull(redis.channel);
         assertNull(redis.message);

--- a/executor/src/test/java/PanicResumeLifecycleTest.java
+++ b/executor/src/test/java/PanicResumeLifecycleTest.java
@@ -22,7 +22,7 @@ public class PanicResumeLifecycleTest {
     static class DummyExecutor extends Executor {
         DummyRedis client;
         DummyExecutor(DummyRedis c) {
-            super(c, "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.SANDBOX));
+            super(c, "localhost", 6379, new RiskFilter(), new NearMissLogger(null), new Config(ExecutionMode.DRY_RUN));
             this.client = c;
             setSandboxMode(true);
         }

--- a/executor/src/test/java/RebalancerTest.java
+++ b/executor/src/test/java/RebalancerTest.java
@@ -42,7 +42,7 @@ public class RebalancerTest {
         PrintStream orig = System.err;
         System.setErr(new PrintStream(err));
         try {
-            Rebalancer r = new Rebalancer(250.0, adapters, new Config(ExecutionMode.SANDBOX));
+            Rebalancer r = new Rebalancer(250.0, adapters, new Config(ExecutionMode.DRY_RUN));
             r.scan(balances, 5000.0);
         } finally {
             System.setErr(orig);


### PR DESCRIPTION
## Summary
- add `DRY_RUN` enum constant to `ExecutionMode`
- update `Config.isDryRun()` to check both sandbox and dry run
- parse EXECUTION_MODE properly in `Main`
- clarify cancel fallback in `FillTracker`
- adjust tests to use new mode
- document update in `CHANGELOG`

## Testing
- `./test/run-local.sh` *(fails: helm not found / environment unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_688142199c98832c9c3c1516327b094c