### PR TITLE
PR 30: Finalize Execution Mode Logic and Eliminate Legacy Drift

### DIFF
--- a/api/config/settings.js
+++ b/api/config/settings.js
@@ -8,8 +8,8 @@ export const ExecutionMode = Object.freeze({
 
 export const settings = {
   schema_version: 1,
-  // SANDBOX_MODE forces dry-run when true
-  sandbox_mode: process.env.SANDBOX_MODE === "true",
+  // SANDBOX_MODE forces sandbox trading when true
+  sandbox_mode: process.env.SANDBOX_MODE === 'true',
   canary_mode: false,
   useEnsemble: true,
   shadowOnly: false,
@@ -25,10 +25,26 @@ export const settings = {
 // Used by logging such as `[DRY-RUN] Skipping cold wallet transfer`.
 export function getExecutionMode(req) {
   const sessionMode = req?.session?.mode;
-  if (sessionMode === ExecutionMode.LIVE || sessionMode === ExecutionMode.SANDBOX) {
+  if (
+    sessionMode === ExecutionMode.LIVE ||
+    sessionMode === ExecutionMode.SANDBOX ||
+    sessionMode === ExecutionMode.DRY_RUN
+  ) {
     return sessionMode;
   }
-  return settings.sandbox_mode ? ExecutionMode.SANDBOX : ExecutionMode.LIVE;
+  const envMode = String(process.env.EXECUTION_MODE || '')
+    .toLowerCase()
+    .replace('_', '-');
+  if (envMode === 'dry-run') {
+    return ExecutionMode.DRY_RUN;
+  }
+  if (envMode === 'sandbox') {
+    return ExecutionMode.SANDBOX;
+  }
+  if (envMode === 'live') {
+    return ExecutionMode.LIVE;
+  }
+  return settings.sandbox_mode ? ExecutionMode.DRY_RUN : ExecutionMode.LIVE;
 }
 
 export function getControlChannel() {

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -1,14 +1,12 @@
-import { getControlChannel } from '../config/settings.js';
+import { getControlChannel, getExecutionMode, ExecutionMode } from '../config/settings.js';
 import { sendAlert } from '../../alerts/alertAgent.js';
 import logger from '../services/logger.js';
 import { setPauseState, getPauseState } from '../services/pauseState.js';
 
 export default async function panicRoutes(app, { redis, panicState }) {
   app.post('/test/panic', async (req, reply) => {
-    const mode =
-      process.env.EXECUTION_MODE ||
-      (process.env.SANDBOX_MODE === 'true' ? 'dry-run-sandbox' : 'live');
-    const allowed = ['dry-run-sandbox', 'dry-run-server'];
+    const mode = getExecutionMode(req);
+    const allowed = [ExecutionMode.DRY_RUN, ExecutionMode.SANDBOX];
     if (!allowed.includes(mode)) {
       return reply.code(403).send();
     }

--- a/api/routes/settings.js
+++ b/api/routes/settings.js
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import logger from "../services/logger.js";
 import { setMode as setRiskFilterMode } from "../services/riskFilter.js";
-import { getControlChannel } from "../config/settings.js";
+import { getControlChannel, getExecutionMode } from "../config/settings.js";
 import { getConfigSource, loadSettingsFromRedis } from "../services/configManager.js";
 
 export let settings = {
@@ -21,7 +21,11 @@ export let settings = {
 
 export default async function settingsRoutes(app, opts) {
   const { redis } = opts;
-  app.get("/settings", async () => ({ ...settings, source: getConfigSource() }));
+  app.get("/settings", async (req) => ({
+    ...settings,
+    mode: getExecutionMode(req),
+    source: getConfigSource(),
+  }));
 
   const schema = z
     .object({
@@ -48,9 +52,7 @@ export default async function settingsRoutes(app, opts) {
     }
     const data = result.data;
     const operator = req.user?.email || req.user?.id || req.ip;
-    const mode =
-      process.env.EXECUTION_MODE ||
-      (process.env.SANDBOX_MODE === "true" ? "dry-run-sandbox" : "live");
+    const mode = getExecutionMode(req);
 
     if (typeof data.maxLossPct === "number" && data.maxLossPct > 20) {
       logger.warn(
@@ -103,9 +105,7 @@ export default async function settingsRoutes(app, opts) {
 
   const saveSettings = async (req) => {
     const operator = req.user?.email || req.user?.id || req.ip;
-    const mode =
-      process.env.EXECUTION_MODE ||
-      (process.env.SANDBOX_MODE === "true" ? "dry-run-sandbox" : "live");
+    const mode = getExecutionMode(req);
     logger.audit(
       JSON.stringify({
         event: 'settings_update_request',

--- a/dashboard/src/Layout/Header.jsx
+++ b/dashboard/src/Layout/Header.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 export default function Header() {
-  const [sandbox, setSandbox] = useState(false);
+  const [mode, setMode] = useState(null);
 
   useEffect(() => {
     async function fetchSettings() {
@@ -9,7 +9,7 @@ export default function Header() {
         const res = await fetch('/api/settings');
         if (res.ok) {
           const data = await res.json();
-          setSandbox(Boolean(data.sandbox_mode));
+          setMode(data.mode);
         }
       } catch (err) {
         console.error('Failed to fetch settings', err);
@@ -21,9 +21,9 @@ export default function Header() {
 
   return (
     <header className="relative">
-      {sandbox && (
+      {mode === 'DRY_RUN' && (
         <div className="absolute right-2 top-2 bg-error text-white px-3 py-1 rounded">
-          SANDBOX MODE - FAKE DATA
+          Running in DRY_RUN mode
         </div>
       )}
     </header>

--- a/executor/src/main/java/Executor.java
+++ b/executor/src/main/java/Executor.java
@@ -591,13 +591,6 @@ public class Executor implements ResumeHandler.ResumeCapable {
     }
 
     /**
-     * @return whether sandbox mode is active
-     */
-    public boolean isSandboxMode() {
-        return sandboxMode;
-    }
-
-    /**
      * Cleanly shutdown all resources and connections.
      */
     public void shutdown() {


### PR DESCRIPTION
## Summary
- update execution mode parser to recognize DRY_RUN
- update panic endpoint to use ExecutionMode enum
- expose runtime mode in settings route
- show DRY_RUN banner in dashboard
- remove unused isSandboxMode() from Executor

## Testing
- `npm --prefix dashboard test -- --runInBand`
- `npm --prefix api test -- --runInBand` *(failed: Cannot find module 'winston')*
- `pytest`
- `./executor/gradlew test -p executor` *(failed: failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_6881479934d8832cba9724cc2b8932a8