### PR TITLE
esm: convert api/ folder to native ESM format

### DIFF
--- a/api/__tests__/alertManager.test.js
+++ b/api/__tests__/alertManager.test.js
@@ -6,7 +6,8 @@ jest.mock('../../alerts/emailAlert.js', () => ({
   })
 }));
 
-import { sendAlert } from '../../alerts/alertAgent.js';
+import alertAgent from '../../alerts/alertAgent.js';
+const { sendAlert } = alertAgent;
 
 describe('sendAlert error handling', () => {
   beforeEach(() => {

--- a/api/__tests__/panic.resume.alerts.test.js
+++ b/api/__tests__/panic.resume.alerts.test.js
@@ -3,10 +3,13 @@ import Fastify from 'fastify';
 import panicRoutes from '../routes/panic.js';
 import resumeRoutes from '../routes/resume.js';
 import { getControlChannel } from '../config/settings.js';
-import { sendAlert } from '../../alerts/alertAgent.js';
+import alertAgent from '../../alerts/alertAgent.js';
+const { sendAlert } = alertAgent;
 
 jest.mock('../../alerts/alertAgent.js', () => ({
-  sendAlert: jest.fn(async () => {})
+  default: {
+    sendAlert: jest.fn(async () => {})
+  }
 }));
 
 const describeLocal = process.env.TEST_ENV === 'local' || !process.env.TEST_ENV ? describe : describe.skip;

--- a/api/cli/alertModuleUpdate.js
+++ b/api/cli/alertModuleUpdate.js
@@ -1,6 +1,7 @@
 // CLI helper to send model update alerts via Node API
 import minimist from 'minimist';
-import { alertModelUpdate } from '../../alerts/alertAgent.js';
+import alertAgent from '../../alerts/alertAgent.js';
+const { alertModelUpdate } = alertAgent;
 
 const args = minimist(process.argv.slice(2));
 const version = args.version || args.v;

--- a/api/index.js
+++ b/api/index.js
@@ -27,8 +27,10 @@ import opportunitiesRoutes from './routes/opportunities.js';
 import { getControlChannel } from './config/settings.js';
 import { loadSettingsFromRedis } from './services/configManager.js';
 import { baseOpenPaths } from './lib/constants.js';
-import { sendAlert } from '../alerts/alertAgent.js';
-import { sendEmail } from '../alerts/emailAlert.js';
+import alertAgent from '../alerts/alertAgent.js';
+const { sendAlert } = alertAgent;
+import emailAlertPkg from '../alerts/emailAlert.js';
+const { sendEmail } = emailAlertPkg;
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
 import { start as startWsServer } from './services/wsServer.js';
 import {

--- a/api/package.json
+++ b/api/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "jest"
   },
   "dependencies": {

--- a/api/routes/panic.js
+++ b/api/routes/panic.js
@@ -1,5 +1,6 @@
 import { getControlChannel, getExecutionMode, ExecutionMode } from '../config/settings.js';
-import { sendAlert } from '../../alerts/alertAgent.js';
+import alertAgent from '../../alerts/alertAgent.js';
+const { sendAlert } = alertAgent;
 import logger from '../services/logger.js';
 import { setPauseState, getPauseState } from '../services/pauseState.js';
 

--- a/api/routes/resume.js
+++ b/api/routes/resume.js
@@ -1,5 +1,6 @@
 import { requireAdmin } from '../middleware/auth.js';
-import { sendAlert } from '../../alerts/alertAgent.js';
+import alertAgent from '../../alerts/alertAgent.js';
+const { sendAlert } = alertAgent;
 import { getControlChannel } from '../config/settings.js';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- switch alert imports to default CommonJS interop
- add `start` script for the API package

## Testing
- `node api/index.js` *(fails: Cannot find module 'winston')*
- `npm test --silent --prefix api` *(fails: sendAlert undefined errors)*

------
https://chatgpt.com/codex/tasks/task_b_688157669754832c875761d1e576c383