### PR TITLE
fix/frontend-login-and-proxy-cleanup

### DIFF
--- a/dashboard/src/__tests__/Login.test.jsx
+++ b/dashboard/src/__tests__/Login.test.jsx
@@ -61,10 +61,17 @@ test('sends credentials to /api/login and stores token', async () => {
     fireEvent.click(screen.getByRole('button', { name: /log in/i }));
   });
 
-  expect(axios.post).toHaveBeenCalledWith('/api/login', {
-    email: 'user@example.com',
-    password: 'secret',
-  });
+  expect(axios.post).toHaveBeenCalledWith(
+    '/api/login',
+    {
+      email: 'user@example.com',
+      password: 'secret',
+    },
+    {
+      withCredentials: true,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
 
   await waitFor(() => {
     expect(localStorage.getItem('token')).toBe('abc123');

--- a/dashboard/src/context/AuthContext.jsx
+++ b/dashboard/src/context/AuthContext.jsx
@@ -22,13 +22,31 @@ export const AuthProvider = ({ children }) => {
 
   const login = async (email, password) => {
     try {
-      const res = await axios.post('/api/login', { email, password });
+      const res = await axios.post(
+        '/api/login',
+        { email, password },
+        {
+          withCredentials: true,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
       localStorage.setItem('token', res.data.token);
       setIsLoggedIn(true);
-      navigate('/dashboard');
+      return res.data;
     } catch (error) {
-      console.error('Login failed', error);
-      throw error;
+      let message = 'Network error';
+      if (error.response) {
+        if (error.response.status === 401) {
+          message = 'Invalid email or password';
+        } else if (error.response.status >= 500) {
+          message = 'Server error. Try again later.';
+        } else if (error.response.data?.message) {
+          message = error.response.data.message;
+        } else {
+          message = 'Login failed';
+        }
+      }
+      throw new Error(message);
     }
   };
 

--- a/dashboard/src/pages/Login.jsx
+++ b/dashboard/src/pages/Login.jsx
@@ -22,8 +22,7 @@ export default function Login() {
       await login(email, password);
       navigate("/dashboard");
     } catch (err) {
-      // Display a friendly error if login fails
-      setError(err?.message || "Invalid email or password");
+      setError(err.message);
     }
   };
 

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- proxy `/api` to local backend and run dev server on port 3000
- send login requests with JSON and credentials
- surface clear login errors
- update login tests for new axios call

## Testing
- `yarn test` in `dashboard`
- `yarn dev` *(confirmed server starts on port 3000)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_688273a32a38832ca959fb30ab3a5d9d