### PR TITLE
fix/settings-endpoint-validation

### DIFF
--- a/api/__tests__/settings.validation.test.js
+++ b/api/__tests__/settings.validation.test.js
@@ -78,10 +78,10 @@ describeLocal("settings validation", () => {
     const res = await request(app.server)
       .patch("/api/settings")
       .set("Cookie", cookie)
-      .send({ maxLossPct: 99 });
+      .send({ maxLossPct: 150 });
     expect(res.statusCode).toBe(400);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[SETTINGS-REJECTED] maxLossPct=99 exceeds limit"),
+      expect.stringContaining("field=maxLossPct"),
     );
   });
 
@@ -92,18 +92,29 @@ describeLocal("settings validation", () => {
       .send({ latencyMaxMs: 9999 });
     expect(res.statusCode).toBe(400);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[SETTINGS-REJECTED] latencyMaxMs=9999 exceeds limit"),
+      expect.stringContaining("field=latencyMaxMs"),
     );
   });
 
-  test("rejects unsafe coinExposureLimit", async () => {
+  test("rejects unsafe exposureCapPct", async () => {
     const res = await request(app.server)
       .patch("/api/settings")
       .set("Cookie", cookie)
-      .send({ coinExposureLimit: 50 });
+      .send({ exposureCapPct: 150 });
     expect(res.statusCode).toBe(400);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[SETTINGS-REJECTED] coinExposureLimit=50 exceeds limit"),
+      expect.stringContaining("field=exposureCapPct"),
+    );
+  });
+
+  test("rejects invalid mode", async () => {
+    const res = await request(app.server)
+      .patch("/api/settings")
+      .set("Cookie", cookie)
+      .send({ mode: "WRONG" });
+    expect(res.statusCode).toBe(400);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("field=mode"),
     );
   });
 
@@ -120,10 +131,10 @@ describeLocal("settings validation", () => {
       .patch("/api/settings")
       .set("Cookie", cookie)
       .send({
+        mode: "AUTO",
         maxLossPct: 10,
         latencyMaxMs: 500,
-        coinExposureLimit: 20,
-        personality_mode: "Aggressive",
+        exposureCapPct: 20,
         sweep_cadence: "Daily",
       });
     expect(res.statusCode).toBe(200);

--- a/api/routes/settings.js
+++ b/api/routes/settings.js
@@ -41,6 +41,8 @@ export default async function settingsRoutes(app, opts) {
       maxLossPct: z.number().optional(),
       latencyMaxMs: z.number().optional(),
       coinExposureLimit: z.number().optional(),
+      exposureCapPct: z.number().optional(),
+      mode: z.string().optional(),
     })
     .strict();
 
@@ -54,38 +56,72 @@ export default async function settingsRoutes(app, opts) {
     const operator = req.user?.email || req.user?.id || req.ip;
     const mode = getExecutionMode(req);
 
-    if (typeof data.maxLossPct === "number" && data.maxLossPct > 20) {
-      logger.warn(
-        `[SETTINGS-REJECTED] maxLossPct=${data.maxLossPct} exceeds limit mode=${mode} operator=${operator}`
-      );
-      reply.code(400);
-      return { error: "maxLossPct exceeds limit" };
+    if (typeof data.mode === "string") {
+      const modes = ["REALISTIC", "AGGRESSIVE", "AUTO"];
+      if (!modes.includes(data.mode)) {
+        logger.warn(
+          `[SETTINGS-REJECTED] user=${operator} field=mode value=${data.mode}`
+        );
+        reply.code(400);
+        return { error: "Invalid setting: mode" };
+      }
+      const map = {
+        REALISTIC: "Realistic",
+        AGGRESSIVE: "Aggressive",
+        AUTO: "Auto",
+      };
+      data.personality_mode = map[data.mode];
     }
 
-    if (typeof data.latencyMaxMs === "number" && data.latencyMaxMs > 1000) {
-      logger.warn(
-        `[SETTINGS-REJECTED] latencyMaxMs=${data.latencyMaxMs} exceeds limit mode=${mode} operator=${operator}`
-      );
-      reply.code(400);
-      return { error: "latencyMaxMs exceeds limit" };
+    if (typeof data.exposureCapPct === "number") {
+      data.coinExposureLimit = data.exposureCapPct;
+      if (data.exposureCapPct < 0 || data.exposureCapPct > 100) {
+        logger.warn(
+          `[SETTINGS-REJECTED] user=${operator} field=exposureCapPct value=${data.exposureCapPct}`
+        );
+        reply.code(400);
+        return { error: "Invalid setting: exposureCapPct" };
+      }
     }
 
-    if (typeof data.coinExposureLimit === "number" && data.coinExposureLimit > 30) {
-      logger.warn(
-        `[SETTINGS-REJECTED] coinExposureLimit=${data.coinExposureLimit} exceeds limit mode=${mode} operator=${operator}`
-      );
-      reply.code(400);
-      return { error: "coinExposureLimit exceeds limit" };
+    if (typeof data.maxLossPct === "number") {
+      if (data.maxLossPct < 0 || data.maxLossPct > 100) {
+        logger.warn(
+          `[SETTINGS-REJECTED] user=${operator} field=maxLossPct value=${data.maxLossPct}`
+        );
+        reply.code(400);
+        return { error: "Invalid setting: maxLossPct" };
+      }
+    }
+
+    if (typeof data.latencyMaxMs === "number") {
+      if (data.latencyMaxMs < 50 || data.latencyMaxMs > 5000) {
+        logger.warn(
+          `[SETTINGS-REJECTED] user=${operator} field=latencyMaxMs value=${data.latencyMaxMs}`
+        );
+        reply.code(400);
+        return { error: "Invalid setting: latencyMaxMs" };
+      }
+    }
+
+    if (typeof data.coinExposureLimit === "number") {
+      if (data.coinExposureLimit < 0 || data.coinExposureLimit > 100) {
+        logger.warn(
+          `[SETTINGS-REJECTED] user=${operator} field=coinExposureLimit value=${data.coinExposureLimit}`
+        );
+        reply.code(400);
+        return { error: "Invalid setting: coinExposureLimit" };
+      }
     }
 
     if (typeof data.personality_mode === "string") {
       const modes = ["Realistic", "Aggressive", "Auto"];
       if (!modes.includes(data.personality_mode)) {
         logger.warn(
-          `[SETTINGS-REJECTED] personality_mode=${data.personality_mode} invalid mode=${mode} operator=${operator}`
+          `[SETTINGS-REJECTED] user=${operator} field=personality_mode value=${data.personality_mode}`
         );
         reply.code(400);
-        return { error: "invalid personality_mode" };
+        return { error: "Invalid setting: personality_mode" };
       }
     }
 
@@ -140,6 +176,14 @@ export default async function settingsRoutes(app, opts) {
         settings.sandbox_mode = req.body.sandbox_mode;
       }
     }
+    if (typeof req.body.mode === "string") {
+      const map = {
+        REALISTIC: "Realistic",
+        AGGRESSIVE: "Aggressive",
+        AUTO: "Auto",
+      };
+      req.body.personality_mode = map[req.body.mode];
+    }
     if (typeof req.body.personality_mode === "string") {
       if (req.body.personality_mode !== settings.personality_mode) {
         settings.personality_mode = req.body.personality_mode;
@@ -176,7 +220,9 @@ export default async function settingsRoutes(app, opts) {
         logger.error('Failed to publish latency update', err);
       }
     }
-    if (typeof req.body.coinExposureLimit === "number") {
+    if (typeof req.body.exposureCapPct === "number") {
+      settings.coinExposureLimit = req.body.exposureCapPct;
+    } else if (typeof req.body.coinExposureLimit === "number") {
       settings.coinExposureLimit = req.body.coinExposureLimit;
     }
 

--- a/api/test/config.test.ts
+++ b/api/test/config.test.ts
@@ -49,7 +49,7 @@ test('rejects unsafe MAX_LOSS_PCT', async () => {
   const res = await request(app.server)
     .patch('/api/settings')
     .set('Cookie', cookie)
-    .send({ maxLossPct: 99 });
+    .send({ maxLossPct: 150 });
   expect(res.statusCode).toBe(400);
   expect(warnSpy).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- validate `/api/settings` updates for fields: `maxLossPct`, `latencyMaxMs`, `exposureCapPct`, and `mode`
- log invalid attempts with user info and reject entire request
- expand tests to cover new validation rules

## Testing
- `npm test` *(fails: Test Suites: 6 failed, 13 passed, 19 total)*

------
https://chatgpt.com/codex/tasks/task_b_688280166bcc832ca17c799890b0179d