### PR TITLE
stub/metrics-prometheus-safe-defaults

### DIFF
--- a/api/routes/metrics.js
+++ b/api/routes/metrics.js
@@ -69,7 +69,12 @@ export default async function metricsRoutes(app, { redis } = {}) {
     const paused = await getPauseState(redis);
     panicGauge.set(paused ? 1 : 0);
     systemPausedGauge.set({ source: 'api' }, paused ? 1 : 0);
-    reply.header('Content-Type', register.contentType);
-    reply.send(await register.metrics());
+    try {
+      reply.header('Content-Type', register.contentType);
+      reply.send(await register.metrics());
+    } catch {
+      reply.header('Content-Type', 'text/plain');
+      reply.send('# No Prometheus metrics available in this environment');
+    }
   });
 }


### PR DESCRIPTION
## Summary
- harden the `/api/metrics` endpoint so it always returns a valid response
- return fallback text when `prom-client` metrics are unavailable

## Testing
- `npm --prefix api test -- --runInBand` *(fails: 6 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_b_688281d8cbec832c8a6e8c006d30e657