### PR TITLE
Add dry-run environment mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,11 @@
 STATUSCAKE_API_TOKEN=
 # Contact group ID for StatusCake alerts
 STATUSCAKE_CONTACT_GROUP=
+
+# Local dry-run testing defaults
+DRY_RUN=true
+JWT_SECRET=localtestsecret
+SMTP_USER=dummy@example.com
+SMTP_PASS=dummypass
+BINANCE_KEY=dummy
+BINANCE_SECRET=dummy

--- a/api/index.js
+++ b/api/index.js
@@ -31,6 +31,7 @@ import { loadSettingsFromRedis } from './services/configManager.js';
 import { baseOpenPaths } from './lib/constants.js';
 import { sendAlert, sendEmail } from './services/alertManager.js';
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
+import { verifyJwt } from './middleware/auth.js';
 import { start as startWsServer } from './services/wsServer.js';
 import {
   getPauseState,
@@ -56,6 +57,24 @@ if (process.env.NODE_ENV === 'production') {
   }
   if (process.env.SANDBOX_MODE === 'true') {
     console.error('SANDBOX_MODE must be disabled in production');
+    process.exit(1);
+  }
+}
+
+const requiredSecrets = [
+  'BINANCE_KEY',
+  'BINANCE_SECRET',
+  'JWT_SECRET',
+  'SMTP_USER',
+  'SMTP_PASS',
+];
+
+if (process.env.DRY_RUN === 'true') {
+  console.log('🧪 DRY_RUN mode enabled');
+} else {
+  const missing = requiredSecrets.filter(k => !process.env[k]);
+  if (missing.length) {
+    console.error(`Missing required secrets: ${missing.join(', ')}`);
     process.exit(1);
   }
 }
@@ -166,12 +185,12 @@ async function apiRoutes(api, { redis, pool, panicState }) {
     ];
     if (openPaths.includes(req.url)) return;
     try {
-      await req.jwtVerify();
+      await verifyJwt(req, reply);
       if (req.url === '/api/resume') {
         req.log.info('[RESUME] Resume command received by authorized user');
       }
     } catch {
-      reply.code(401).send({ error: 'unauthorized' });
+      return; // verifyJwt already handled response
     }
   });
 
@@ -196,10 +215,10 @@ async function apiRoutes(api, { redis, pool, panicState }) {
     }
 
     try {
-      await req.jwtVerify();
+      await verifyJwt(req, reply);
     } catch {
       logger.warn(`[UNAUTHORIZED] ${req.method} ${req.url} rejected`);
-      return reply.code(401).send({ error: 'Unauthorized' });
+      return;
     }
 
     if (!req.user || (!req.user.id && !req.user.email)) {

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -2,7 +2,7 @@ import logger from '../services/logger.js';
 
 export async function requireAdmin(req, reply) {
   const mode = process.env.EXECUTION_MODE || (process.env.SANDBOX_MODE === 'true' ? 'sandbox' : 'live');
-  if (mode === 'sandbox') {
+  if (mode === 'sandbox' || process.env.DRY_RUN === 'true') {
     return;
   }
   if (req.user && (req.user.role === 'admin' || req.user.isAdmin)) {
@@ -10,4 +10,17 @@ export async function requireAdmin(req, reply) {
   }
   logger.warn(`[RESUME-BLOCKED] mode=${mode} ip=${req.ip}`);
   reply.code(401).send({ error: 'unauthorized' });
+}
+
+export async function verifyJwt(req, reply) {
+  if (process.env.DRY_RUN === 'true') {
+    req.user = { email: 'admin@prism.one', role: 'admin', dryRun: true };
+    return;
+  }
+  try {
+    await req.jwtVerify();
+  } catch {
+    reply.code(401).send({ error: 'unauthorized' });
+    throw new Error('unauthorized');
+  }
 }

--- a/api/routes/login.js
+++ b/api/routes/login.js
@@ -20,6 +20,7 @@ const tokenSchema = z.object({
 export default async function loginRoutes(app) {
   // In demo mode use static creds
   const sandboxMode = process.env.SANDBOX_MODE === 'true';
+  const dryRun = process.env.DRY_RUN === 'true';
 
   app.post('/login', async (req, reply) => {
     const ts = new Date().toISOString();
@@ -49,6 +50,12 @@ export default async function loginRoutes(app) {
     const cookieOpts = { httpOnly: true };
     if (process.env.NODE_ENV === 'production') {
       cookieOpts.secure = true;
+    }
+
+    if (dryRun && email === 'admin@prism.one' && password === 'test123') {
+      const token = app.jwt.sign({ email, role: 'admin', dryRun: true });
+      reply.setCookie('token', token, cookieOpts);
+      return { token };
     }
 
     if (sandboxMode && email === SANDBOX_EMAIL && password === SANDBOX_PASS) {

--- a/api/routes/testOps.js
+++ b/api/routes/testOps.js
@@ -4,6 +4,7 @@ import {
   setPauseState,
   RESUME_ACK_KEY,
 } from '../services/pauseState.js';
+import { settings as currentSettings } from './settings.js';
 
 export default async function testOpsRoutes(app, opts) {
   const { redis, panicState } = opts;
@@ -38,5 +39,27 @@ export default async function testOpsRoutes(app, opts) {
     }
     req.log.info('Dry-run sweep triggered');
     return { status: 'dry-run', triggered: true };
+  });
+
+  app.post('/test/reset', async (req) => {
+    if (process.env.DRY_RUN !== 'true') {
+      return { status: 'forbidden' };
+    }
+    Object.assign(currentSettings, {
+      schema_version: 1,
+      canary_mode: false,
+      useEnsemble: true,
+      shadowOnly: false,
+      ghost_mode: false,
+      sandbox_mode: process.env.SANDBOX_MODE === 'true',
+      personality_mode: 'Realistic',
+      sweep_cadence: 'None',
+      maxLoss: 0,
+      maxLossPct: 0,
+      latencyMaxMs: 250,
+      coinExposureLimit: 10,
+    });
+    req.log.info('✅ Test state reset');
+    return { status: 'reset' };
   });
 }

--- a/docs/dry_run_mode.md
+++ b/docs/dry_run_mode.md
@@ -1,0 +1,30 @@
+# Dry Run Mode
+
+To enable local testing without real secrets, create a `.env` file with the following defaults:
+
+```
+DRY_RUN=true
+JWT_SECRET=localtestsecret
+SMTP_USER=dummy@example.com
+SMTP_PASS=dummypass
+BINANCE_KEY=dummy
+BINANCE_SECRET=dummy
+```
+
+## Login
+
+Send a POST request to `/api/login` with:
+
+```json
+{ "email": "admin@prism.one", "password": "test123" }
+```
+
+The response includes a JWT for subsequent requests.
+
+## Reset Test State
+
+Use `POST /api/test/reset` to restore in-memory settings to their defaults. On success the server logs:
+
+```
+✅ Test state reset
+```

--- a/test/verify-env.sh
+++ b/test/verify-env.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+if [ "$DRY_RUN" != "true" ]; then
+  echo "❌ DRY_RUN must be enabled for local test" >&2
+  exit 1
+fi
+
 # fail fast if any development secrets are committed
 for dir in api executor dashboard; do
   if [ -f "$dir/.env" ]; then


### PR DESCRIPTION
## Summary
- add sample DRY_RUN variables
- document dry run mode for local testing
- guard API startup when missing secrets unless DRY_RUN
- allow fake login and bypass auth when DRY_RUN
- expose /test/reset endpoint for state cleanup
- require DRY_RUN in verify-env.sh

## Testing
- `npm --prefix api test -- --runInBand` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_68837d8ebc08832c97ba9a3e3425a15e