### PR TITLE
Add dry-run environment mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,11 @@
 STATUSCAKE_API_TOKEN=
 # Contact group ID for StatusCake alerts
 STATUSCAKE_CONTACT_GROUP=
+
+# Local dry-run testing defaults
+DRY_RUN=true
+JWT_SECRET=localtestsecret
+SMTP_USER=dummy@example.com
+SMTP_PASS=dummypass
+BINANCE_KEY=dummy
+BINANCE_SECRET=dummy

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@
 - **SANDBOX** – Kubernetes deploy with sealed secrets but no live orders.
 - **LIVE** – Real trades; startup aborts if any required secrets are missing.
 
+### Dry Run Login
+
+When `DRY_RUN=true`, the API exposes a fake login for local testing.
+
+```text
+POST /api/login
+{ "email": "admin@prism.one", "password": "test123" }
+```
+
+Use the returned JWT token for authenticated endpoints during dry runs.
+
 `EXECUTION_MODE` controls the mode for every service.
 
 ---

--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@
 - **SANDBOX** – Kubernetes deploy with sealed secrets but no live orders.
 - **LIVE** – Real trades; startup aborts if any required secrets are missing.
 
-### Dry Run Login
+### Test Login (Dry Run & Sandbox)
 
-When `DRY_RUN=true`, the API exposes a fake login for local testing.
+When `DRY_RUN=true` or running the sandbox, the API exposes a fake login for testing.
 
 ```text
 POST /api/login
 { "email": "admin@prism.one", "password": "test123" }
 ```
 
-Use the returned JWT token for authenticated endpoints during dry runs.
+Use the returned JWT token for authenticated endpoints when testing locally or in the sandbox.
 
 `EXECUTION_MODE` controls the mode for every service.
 

--- a/api/__tests__/api.test.js
+++ b/api/__tests__/api.test.js
@@ -30,13 +30,13 @@ describeLocal('API authentication', () => {
     expect(res.statusCode).toBe(401);
   });
     
-  test('sandbox login works with demo credentials', async () => {
+  test('sandbox login works with test credentials', async () => {
     const res = await request(app.server)
       .post('/api/login')
-      .send({ email: 'demo@prismarbitrage.ai', password: 'demo1234' });
-     expect(res.statusCode).toBe(200);
-     expect(res.body).toEqual({ token: 'demo-token' });
-    });
+      .send({ email: 'admin@prism.one', password: 'test123' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('token');
+  });
 
   test('/opportunities requires auth', async () => {
     const unauth = await request(app.server).get('/api/opportunities');

--- a/api/index.js
+++ b/api/index.js
@@ -31,6 +31,7 @@ import { loadSettingsFromRedis } from './services/configManager.js';
 import { baseOpenPaths } from './lib/constants.js';
 import { sendAlert, sendEmail } from './services/alertManager.js';
 import auditLogger, { logReplayCLI } from './middleware/auditLogger.js';
+import { verifyJwt } from './middleware/auth.js';
 import { start as startWsServer } from './services/wsServer.js';
 import {
   getPauseState,
@@ -56,6 +57,24 @@ if (process.env.NODE_ENV === 'production') {
   }
   if (process.env.SANDBOX_MODE === 'true') {
     console.error('SANDBOX_MODE must be disabled in production');
+    process.exit(1);
+  }
+}
+
+const requiredSecrets = [
+  'BINANCE_KEY',
+  'BINANCE_SECRET',
+  'JWT_SECRET',
+  'SMTP_USER',
+  'SMTP_PASS',
+];
+
+if (process.env.DRY_RUN === 'true') {
+  console.log('🧪 DRY_RUN mode enabled');
+} else {
+  const missing = requiredSecrets.filter(k => !process.env[k]);
+  if (missing.length) {
+    console.error(`Missing required secrets: ${missing.join(', ')}`);
     process.exit(1);
   }
 }
@@ -166,12 +185,12 @@ async function apiRoutes(api, { redis, pool, panicState }) {
     ];
     if (openPaths.includes(req.url)) return;
     try {
-      await req.jwtVerify();
+      await verifyJwt(req, reply);
       if (req.url === '/api/resume') {
         req.log.info('[RESUME] Resume command received by authorized user');
       }
     } catch {
-      reply.code(401).send({ error: 'unauthorized' });
+      return; // verifyJwt already handled response
     }
   });
 
@@ -196,10 +215,10 @@ async function apiRoutes(api, { redis, pool, panicState }) {
     }
 
     try {
-      await req.jwtVerify();
+      await verifyJwt(req, reply);
     } catch {
       logger.warn(`[UNAUTHORIZED] ${req.method} ${req.url} rejected`);
-      return reply.code(401).send({ error: 'Unauthorized' });
+      return;
     }
 
     if (!req.user || (!req.user.id && !req.user.email)) {

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -2,7 +2,7 @@ import logger from '../services/logger.js';
 
 export async function requireAdmin(req, reply) {
   const mode = process.env.EXECUTION_MODE || (process.env.SANDBOX_MODE === 'true' ? 'sandbox' : 'live');
-  if (mode === 'sandbox') {
+  if (mode === 'sandbox' || process.env.DRY_RUN === 'true') {
     return;
   }
   if (req.user && (req.user.role === 'admin' || req.user.isAdmin)) {
@@ -10,4 +10,17 @@ export async function requireAdmin(req, reply) {
   }
   logger.warn(`[RESUME-BLOCKED] mode=${mode} ip=${req.ip}`);
   reply.code(401).send({ error: 'unauthorized' });
+}
+
+export async function verifyJwt(req, reply) {
+  if (process.env.DRY_RUN === 'true') {
+    req.user = { email: 'admin@prism.one', role: 'admin', dryRun: true };
+    return;
+  }
+  try {
+    await req.jwtVerify();
+  } catch {
+    reply.code(401).send({ error: 'unauthorized' });
+    throw new Error('unauthorized');
+  }
 }

--- a/api/routes/login.js
+++ b/api/routes/login.js
@@ -20,6 +20,7 @@ const tokenSchema = z.object({
 export default async function loginRoutes(app) {
   // In demo mode use static creds
   const sandboxMode = process.env.SANDBOX_MODE === 'true';
+  const dryRun = process.env.DRY_RUN === 'true';
 
   app.post('/login', async (req, reply) => {
     const ts = new Date().toISOString();
@@ -49,6 +50,12 @@ export default async function loginRoutes(app) {
     const cookieOpts = { httpOnly: true };
     if (process.env.NODE_ENV === 'production') {
       cookieOpts.secure = true;
+    }
+
+    if (dryRun && email === 'admin@prism.one' && password === 'test123') {
+      const token = app.jwt.sign({ email, role: 'admin', dryRun: true });
+      reply.setCookie('token', token, cookieOpts);
+      return { token };
     }
 
     if (sandboxMode && email === SANDBOX_EMAIL && password === SANDBOX_PASS) {

--- a/api/routes/login.js
+++ b/api/routes/login.js
@@ -1,12 +1,11 @@
-// Login endpoint handling sandbox demo credentials
+// Login endpoint handling test credentials for sandbox or dry run
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
 import { findByEmail } from './userStore.js';
 import logger from '../services/logger.js';
 
-const SANDBOX_EMAIL = 'demo@prismarbitrage.ai';
-const SANDBOX_PASS = 'demo1234';
-const HARD_CODED_JWT = 'demo-token';
+const TEST_EMAIL = 'admin@prism.one';
+const TEST_PASS = 'test123';
 
 const loginSchema = z.object({
   email: z.string(),
@@ -52,18 +51,17 @@ export default async function loginRoutes(app) {
       cookieOpts.secure = true;
     }
 
-    if (dryRun && email === 'admin@prism.one' && password === 'test123') {
-      const token = app.jwt.sign({ email, role: 'admin', dryRun: true });
+    if ((dryRun || sandboxMode) && email === TEST_EMAIL && password === TEST_PASS) {
+      const token = app.jwt.sign({
+        email,
+        role: 'admin',
+        dryRun: dryRun || sandboxMode,
+      });
       reply.setCookie('token', token, cookieOpts);
-      return { token };
-    }
-
-    if (sandboxMode && email === SANDBOX_EMAIL && password === SANDBOX_PASS) {
-      reply.setCookie('token', HARD_CODED_JWT, cookieOpts);
       logger.info(
         JSON.stringify({ event: 'login_attempt', status: 'success', user: email, ts })
       );
-      return { token: HARD_CODED_JWT };
+      return { token };
     }
 
     const user = findByEmail(email);

--- a/api/routes/testOps.js
+++ b/api/routes/testOps.js
@@ -4,6 +4,7 @@ import {
   setPauseState,
   RESUME_ACK_KEY,
 } from '../services/pauseState.js';
+import { settings as currentSettings } from './settings.js';
 
 export default async function testOpsRoutes(app, opts) {
   const { redis, panicState } = opts;
@@ -38,5 +39,27 @@ export default async function testOpsRoutes(app, opts) {
     }
     req.log.info('Dry-run sweep triggered');
     return { status: 'dry-run', triggered: true };
+  });
+
+  app.post('/test/reset', async (req) => {
+    if (process.env.DRY_RUN !== 'true') {
+      return { status: 'forbidden' };
+    }
+    Object.assign(currentSettings, {
+      schema_version: 1,
+      canary_mode: false,
+      useEnsemble: true,
+      shadowOnly: false,
+      ghost_mode: false,
+      sandbox_mode: process.env.SANDBOX_MODE === 'true',
+      personality_mode: 'Realistic',
+      sweep_cadence: 'None',
+      maxLoss: 0,
+      maxLossPct: 0,
+      latencyMaxMs: 250,
+      coinExposureLimit: 10,
+    });
+    req.log.info('✅ Test state reset');
+    return { status: 'reset' };
   });
 }

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -8,7 +8,7 @@ The dashboard is a mobile‑friendly React single‑page app served from the `/a
 
 1. Browse to the dashboard URL and you will be redirected to **/login**.
 2. Enter your email and password. The form posts to `/api/login` and the API returns a JWT which is stored in a secure cookie.
-3. In sandbox mode the demo account `demo@prismarbitrage.ai` with password `demo1234` is accepted as shown in the [login route](/api/routes/login.js) lines 7‑9.
+3. In sandbox mode use the same test account `admin@prism.one` with password `test123` as shown in the [login route](/api/routes/login.js).
 4. After a successful login the token is also stored in `localStorage` to keep you logged in across refreshes.
 5. If the token becomes invalid the next API call returns HTTP `401` and the app routes back to `/login`.
 

--- a/docs/dry_run_mode.md
+++ b/docs/dry_run_mode.md
@@ -1,0 +1,30 @@
+# Dry Run Mode
+
+To enable local testing without real secrets, create a `.env` file with the following defaults:
+
+```
+DRY_RUN=true
+JWT_SECRET=localtestsecret
+SMTP_USER=dummy@example.com
+SMTP_PASS=dummypass
+BINANCE_KEY=dummy
+BINANCE_SECRET=dummy
+```
+
+## Login
+
+Send a POST request to `/api/login` with:
+
+```json
+{ "email": "admin@prism.one", "password": "test123" }
+```
+
+The response includes a JWT for subsequent requests.
+
+## Reset Test State
+
+Use `POST /api/test/reset` to restore in-memory settings to their defaults. On success the server logs:
+
+```
+✅ Test state reset
+```

--- a/docs/dry_run_mode.md
+++ b/docs/dry_run_mode.md
@@ -19,7 +19,7 @@ Send a POST request to `/api/login` with:
 { "email": "admin@prism.one", "password": "test123" }
 ```
 
-The response includes a JWT for subsequent requests.
+The response includes a JWT for subsequent requests. The same credentials work in sandbox mode.
 
 ## Reset Test State
 

--- a/test/verify-env.sh
+++ b/test/verify-env.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+if [ "$DRY_RUN" != "true" ]; then
+  echo "❌ DRY_RUN must be enabled for local test" >&2
+  exit 1
+fi
+
 # fail fast if any development secrets are committed
 for dir in api executor dashboard; do
   if [ -f "$dir/.env" ]; then


### PR DESCRIPTION
## Summary
- add sample DRY_RUN variables
- document dry run mode for local testing
- guard API startup when missing secrets unless DRY_RUN
- allow fake login and bypass auth when DRY_RUN
- expose /test/reset endpoint for state cleanup
- require DRY_RUN in verify-env.sh
- document dry-run login credentials in README

## Testing
- `npm --prefix api test -- --runInBand` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_68837d8ebc08832c97ba9a3e3425a15e