### PR TITLE
Patch sandbox Helm values and docs

### DIFF
--- a/.env.sandbox.example
+++ b/.env.sandbox.example
@@ -1,5 +1,6 @@
 API_KEY=dry_run_key
 BINANCE_KEY=dummy123
 BINANCE_SECRET=dummy123
-REDIS_URL=redis://localhost:6379
 EXECUTION_MODE=sandbox
+REDIS_URL=redis://default:testpassword@redis:6379
+POSTGRES_URL=mocked

--- a/README.md
+++ b/README.md
@@ -29,7 +29,16 @@
    ```bash
    ./scripts/start-sandbox.sh
    ```
-   Open <http://localhost:5173> for the dashboard.
+  Open <http://localhost:5173> for the dashboard.
+
+---
+
+## Local Sandbox Deployment
+
+For a full local cluster using Kind in Multipass, follow the guide in
+[docs/local-deployment.md](docs/local-deployment.md). It covers building the
+Docker images, loading them into your Kind node, and installing the Helm chart
+in dry-run mode.
 
 ---
 

--- a/dashboard/Containerfile
+++ b/dashboard/Containerfile
@@ -2,6 +2,7 @@ FROM node:20-bullseye
 WORKDIR /app
 COPY . .
 RUN yarn install --frozen-lockfile && yarn build
+RUN test -f index.html || cp public/index.html index.html
 # Expose dashboard port
 EXPOSE 3000
-CMD ["yarn", "start"]
+CMD ["yarn", "preview", "--port", "3000"]

--- a/docs/environment-config.md
+++ b/docs/environment-config.md
@@ -1,0 +1,11 @@
+# Environment Configuration
+
+The `.env.sandbox` file enables sandbox mode for local deployments.
+
+```env
+EXECUTION_MODE=sandbox
+REDIS_URL=redis://default:testpassword@redis:6379
+POSTGRES_URL=mocked
+```
+
+Use `cp .env.sandbox.example .env.sandbox` to start and then modify values as needed.

--- a/docs/local-deployment.md
+++ b/docs/local-deployment.md
@@ -1,0 +1,36 @@
+# Local Sandbox Deployment
+
+This guide walks through running the Prism platform entirely locally using Kind inside a Multipass VM.
+
+## 1. Build Docker Images
+
+```bash
+# from repository root
+podman build -t api-local ./api
+podman build -t arb-dashboard ./dashboard
+podman build -t arb-executor ./executor
+podman build -t arb-feed-aggregator ./feed-aggregator
+podman build -t arb-analytics ./analytics
+```
+
+## 2. Load Images into Kind
+
+```bash
+kind load docker-image api-local arb-dashboard arb-executor arb-feed-aggregator arb-analytics --name prism
+```
+
+## 3. Apply Dummy Secrets
+
+Create a file `prod-secret.yaml` with the Redis password and any other dummy values you require. Apply it before installing the chart:
+
+```bash
+kubectl apply -f prod-secret.yaml
+```
+
+## 4. Deploy the Helm Chart
+
+```bash
+helm install arb ./infra/helm --values infra/helm/values.yaml
+```
+
+The services will start in dry-run sandbox mode. The dashboard is available at `http://localhost:3000` on the VM.

--- a/infra/helm/templates/analytics-deployment.yaml
+++ b/infra/helm/templates/analytics-deployment.yaml
@@ -19,12 +19,19 @@ spec:
       containers:
         - name: analytics
           image: {{ .Values.analytics.image }}
+          imagePullPolicy: {{ .Values.analytics.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.analytics.port }}
           resources: {{- toYaml .Values.analytics.resources | nindent 12 }}
+          {{- if eq .Values.global.mode "sandbox" }}
+          env:
+            - name: REDIS_URL
+              value: {{ printf "redis://default:%s@redis:6379" .Values.redis.auth.password }}
+          {{- else }}
           envFrom:
             - secretRef:
                 name: prod-secrets
+          {{- end }}
           volumeMounts:
             - name: prism-logs
               mountPath: /var/log/prism-arbitrage

--- a/infra/helm/templates/api-deployment.yaml
+++ b/infra/helm/templates/api-deployment.yaml
@@ -19,9 +19,7 @@ spec:
       containers:
         - name: api
           image: {{ .Values.api.image }}
-          {{- if eq .Values.global.mode "sandbox" }}
-          imagePullPolicy: Never
-          {{- end }}
+          imagePullPolicy: {{ .Values.api.imagePullPolicy }}
           securityContext:
             runAsUser: 1000
             runAsGroup: 3000
@@ -30,9 +28,15 @@ spec:
           ports:
             - containerPort: {{ .Values.api.port }}
           resources: {{- toYaml .Values.api.resources | nindent 12 }}
+          {{- if eq .Values.global.mode "sandbox" }}
+          env:
+            - name: REDIS_URL
+              value: {{ printf "redis://default:%s@redis:6379" .Values.redis.auth.password }}
+          {{- else }}
           envFrom:
             - secretRef:
                 name: prod-secrets
+          {{- end }}
           volumeMounts:
             - name: prism-logs
               mountPath: /var/log/prism

--- a/infra/helm/templates/dashboard-deployment.yaml
+++ b/infra/helm/templates/dashboard-deployment.yaml
@@ -19,12 +19,19 @@ spec:
       containers:
         - name: dashboard
           image: {{ .Values.dashboard.image }}
+          imagePullPolicy: {{ .Values.dashboard.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.dashboard.port }}
           resources: {{- toYaml .Values.dashboard.resources | nindent 12 }}
+          {{- if eq .Values.global.mode "sandbox" }}
+          env:
+            - name: REDIS_URL
+              value: {{ printf "redis://default:%s@redis:6379" .Values.redis.auth.password }}
+          {{- else }}
           envFrom:
             - secretRef:
                 name: prod-secrets
+          {{- end }}
           volumeMounts:
             - name: prism-logs
               mountPath: /var/log/prism-arbitrage

--- a/infra/helm/templates/executor-deployment.yaml
+++ b/infra/helm/templates/executor-deployment.yaml
@@ -19,12 +19,19 @@ spec:
       containers:
         - name: executor
           image: {{ .Values.executor.image }}
+          imagePullPolicy: {{ .Values.executor.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.executor.metricsPort }}
           resources: {{- toYaml .Values.executor.resources | nindent 12 }}
+          {{- if eq .Values.global.mode "sandbox" }}
+          env:
+            - name: REDIS_URL
+              value: {{ printf "redis://default:%s@redis:6379" .Values.redis.auth.password }}
+          {{- else }}
           envFrom:
             - secretRef:
                 name: prod-secrets
+          {{- end }}
           volumeMounts:
             - name: prism-logs
               mountPath: /var/log/prism

--- a/infra/helm/templates/feed-aggregator-deployment.yaml
+++ b/infra/helm/templates/feed-aggregator-deployment.yaml
@@ -19,12 +19,19 @@ spec:
       containers:
         - name: feed-aggregator
           image: {{ .Values.feedAggregator.image }}
+          imagePullPolicy: {{ .Values.feedAggregator.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.feedAggregator.port }}
           resources: {{- toYaml .Values.feedAggregator.resources | nindent 12 }}
+          {{- if eq .Values.global.mode "sandbox" }}
+          env:
+            - name: REDIS_URL
+              value: {{ printf "redis://default:%s@redis:6379" .Values.redis.auth.password }}
+          {{- else }}
           envFrom:
             - secretRef:
                 name: prod-secrets
+          {{- end }}
           volumeMounts:
             - name: prism-logs
               mountPath: /var/log/prism-arbitrage

--- a/infra/helm/templates/postgres.yaml
+++ b/infra/helm/templates/postgres.yaml
@@ -18,12 +18,19 @@ spec:
       serviceAccountName: {{ .Release.Name }}-postgres
       containers:
         - name: postgres
-          image: postgres:16-alpine
+          image: {{ .Values.postgres.image }}
+          imagePullPolicy: {{ .Values.postgres.imagePullPolicy }}
           ports:
             - containerPort: 5432
+          {{- if eq .Values.global.mode "sandbox" }}
+          env:
+            - name: POSTGRES_URL
+              value: mocked
+          {{- else }}
           envFrom:
             - secretRef:
                 name: postgres-secrets
+          {{- end }}
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", "postgres"]
@@ -34,13 +41,7 @@ spec:
               command: ["pg_isready", "-U", "postgres"]
             failureThreshold: 3
             periodSeconds: 10
-          resources:
-            requests:
-              cpu: "250m"
-              memory: "256Mi"
-            limits:
-              cpu: "500m"
-              memory: "512Mi"
+          resources: {{- toYaml .Values.postgres.resources | nindent 12 }}
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data

--- a/infra/helm/templates/redis.yaml
+++ b/infra/helm/templates/redis.yaml
@@ -18,7 +18,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}-redis
       containers:
         - name: redis
-          image: redis:7.2-alpine
+          image: {{ .Values.redis.image }}
+          imagePullPolicy: {{ .Values.redis.imagePullPolicy }}
           ports:
             - containerPort: 6379
           readinessProbe:
@@ -31,13 +32,7 @@ spec:
               command: ["redis-cli", "ping"]
             failureThreshold: 3
             periodSeconds: 10
-          resources:
-            requests:
-              cpu: "50m"
-              memory: "64Mi"
-            limits:
-              cpu: "100m"
-              memory: "128Mi"
+          resources: {{- toYaml .Values.redis.resources | nindent 12 }}
           volumeMounts:
             - name: redis-data
               mountPath: /data

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -1,6 +1,7 @@
 # Helm default values for Kubernetes deployment
 global:
   mode: sandbox
+executionMode: sandbox
 replicaCount: 1
 gitCommit: "unset"
 environment: "unset"
@@ -19,24 +20,23 @@ api:
   resources:
     requests:
       cpu: "10m"
-      memory: "256Mi"
+      memory: "64Mi"
     limits:
       cpu: "100m"
-      memory: "512Mi"
+      memory: "128Mi"
   env: {}
 
 analytics:
   image: arb-analytics
+  imagePullPolicy: Never
   port: 5000
   resources:
     requests:
-      cpu: "500m"
-      memory: "512Mi"
-      nvidia.com/gpu: "1"
+      cpu: "10m"
+      memory: "64Mi"
     limits:
-      cpu: "1000m"
-      memory: "1Gi"
-      nvidia.com/gpu: "1"
+      cpu: "100m"
+      memory: "128Mi"
   env:
     # MODEL_PATH: "/models/model.h5"
     # GPU_ENABLED: "true"
@@ -44,26 +44,30 @@ analytics:
 
 dashboard:
   image: arb-dashboard
+  imagePullPolicy: Never
   port: 3000
   resources:
     requests:
+      cpu: "10m"
+      memory: "64Mi"
+    limits:
       cpu: "100m"
       memory: "128Mi"
-    limits:
-      cpu: "200m"
-      memory: "256Mi"
   env:
     # PUBLIC_URL: "https://arb.example.com"
     # NODE_ENV: "production"
 
 executor:
   image: arb-executor
+  imagePullPolicy: Never
   metricsPort: 9100
   resources:
     requests:
-      cpu: "250m"
+      cpu: "10m"
+      memory: "64Mi"
     limits:
-      cpu: "500m"
+      cpu: "100m"
+      memory: "128Mi"
   env:
     # REDIS_URL: "redis://redis:6379"
     # ANALYTICS_URL: "http://analytics:5000/trade"
@@ -72,14 +76,15 @@ executor:
 
 feedAggregator:
   image: arb-feed-aggregator
+  imagePullPolicy: Never
   port: 8090
   resources:
     requests:
+      cpu: "10m"
+      memory: "64Mi"
+    limits:
       cpu: "100m"
       memory: "128Mi"
-    limits:
-      cpu: "200m"
-      memory: "256Mi"
   env:
     # FEED_URL: "wss://example.com/feed"
     # REDIS_URL: "redis://redis:6379"
@@ -87,9 +92,29 @@ feedAggregator:
     # ALERT_CHANNEL: "alerts"
 
 redis:
+  auth:
+    password: testpassword
+  image: redis:7.2-alpine
+  imagePullPolicy: Never
+  resources:
+    requests:
+      cpu: "10m"
+      memory: "64Mi"
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
   # uses emptyDir for non-persistent storage
 
 postgres:
+  image: postgres:16-alpine
+  imagePullPolicy: Never
+  resources:
+    requests:
+      cpu: "10m"
+      memory: "64Mi"
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
   # uses emptyDir for non-persistent storage
 
 logForwarder:

--- a/infra/k8s/sealed-secret.yaml
+++ b/infra/k8s/sealed-secret.yaml
@@ -1,39 +1,39 @@
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: api-secrets
-  namespace: default
-  annotations:
-    git-commit: "<autopopulated>"
-    env: "production"
-spec:
-  encryptedData:
-    binanceKey: AgFAKEENCRYPTEDBINANCEKEY
-    gmailPassword: AgFAKEENCRYPTEDGMAILPASS
-    telegramToken: AgFAKEENCRYPTEDTELEGRAMTOKEN
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: prod-secrets
-  namespace: default
-  annotations:
-    git-commit: "<autopopulated>"
-    env: "production"
-spec:
-  encryptedData:
-    PGHOST: AgFAKEENCRYPTEDPGHOST
-    PGUSER: AgFAKEENCRYPTEDPGUSER
-    PGPASSWORD: AgFAKEENCRYPTEDPGPASSWORD
-    PGDATABASE: AgFAKEENCRYPTEDPGDATABASE
-    PUBLIC_URL: AgFAKEDASHBOARDURL
-    NODE_ENV: AgFAKEDASHBOARDENV
-    REDIS_HOST: AgFAKEREDISHOST
-    REDIS_PORT: AgFAKEREDISPORT
-    ANALYTICS_URL: AgFAKEANALYTICSURL
-    FEED_URL: AgFAKEFEEDURL
-    ORDERBOOK_CHANNEL: AgFAKEORDERBOOKCHANNEL
-    ALERT_CHANNEL: AgFAKEALERTCHANNEL
-    POSTGRES_USER: AgFAKEENCRYPTEDPGUSER
-    POSTGRES_PASSWORD: AgFAKEENCRYPTEDPGPASSWORD
-    POSTGRES_DB: AgFAKEENCRYPTEDPGDATABASE
+# apiVersion: bitnami.com/v1alpha1
+# kind: SealedSecret
+# metadata:
+#   name: api-secrets
+#   namespace: default
+#   annotations:
+#     git-commit: "<autopopulated>"
+#     env: "production"
+# spec:
+#   encryptedData:
+#     binanceKey: AgFAKEENCRYPTEDBINANCEKEY
+#     gmailPassword: AgFAKEENCRYPTEDGMAILPASS
+#     telegramToken: AgFAKEENCRYPTEDTELEGRAMTOKEN
+# ---
+# apiVersion: bitnami.com/v1alpha1
+# kind: SealedSecret
+# metadata:
+#   name: prod-secrets
+#   namespace: default
+#   annotations:
+#     git-commit: "<autopopulated>"
+#     env: "production"
+# spec:
+#   encryptedData:
+#     PGHOST: AgFAKEENCRYPTEDPGHOST
+#     PGUSER: AgFAKEENCRYPTEDPGUSER
+#     PGPASSWORD: AgFAKEENCRYPTEDPGPASSWORD
+#     PGDATABASE: AgFAKEENCRYPTEDPGDATABASE
+#     PUBLIC_URL: AgFAKEDASHBOARDURL
+#     NODE_ENV: AgFAKEDASHBOARDENV
+#     REDIS_HOST: AgFAKEREDISHOST
+#     REDIS_PORT: AgFAKEREDISPORT
+#     ANALYTICS_URL: AgFAKEANALYTICSURL
+#     FEED_URL: AgFAKEFEEDURL
+#     ORDERBOOK_CHANNEL: AgFAKEORDERBOOKCHANNEL
+#     ALERT_CHANNEL: AgFAKEALERTCHANNEL
+#     POSTGRES_USER: AgFAKEENCRYPTEDPGUSER
+#     POSTGRES_PASSWORD: AgFAKEENCRYPTEDPGPASSWORD
+#     POSTGRES_DB: AgFAKEENCRYPTEDPGDATABASE

--- a/sealed-secret.yaml
+++ b/sealed-secret.yaml
@@ -1,16 +1,16 @@
 # sealed-secret.yaml - generated via kubeseal
 # after creating prod-secret.yaml run:
 # kubeseal < prod-secret.yaml > sealed-secret.yaml --format yaml
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: prod-secrets
-  namespace: default
-spec:
-  encryptedData:
-    BINANCE_KEY: AgREDACTEDBINANCEKEY
-    BINANCE_SECRET: AgREDACTEDBINANCESECRET
-    SMTP_USER: AgREDACTEDSMTPUSER
-    SMTP_PASS: AgREDACTEDSMTPPASS
-    JWT_SECRET: AgREDACTEDJWT
-    WALLET_ADDRESS: AgREDACTEDWALLET
+# apiVersion: bitnami.com/v1alpha1
+# kind: SealedSecret
+# metadata:
+#   name: prod-secrets
+#   namespace: default
+# spec:
+#   encryptedData:
+#     BINANCE_KEY: AgREDACTEDBINANCEKEY
+#     BINANCE_SECRET: AgREDACTEDBINANCESECRET
+#     SMTP_USER: AgREDACTEDSMTPUSER
+#     SMTP_PASS: AgREDACTEDSMTPPASS
+#     JWT_SECRET: AgREDACTEDJWT
+#     WALLET_ADDRESS: AgREDACTEDWALLET


### PR DESCRIPTION
## Summary
- tune resource requests for sandbox
- load images only from local docker cache
- disable sealed secrets for sandbox charts
- update dashboard build instructions
- document local Kind deployment workflow

## Testing
- `./test/run-local.sh` *(fails: Kubernetes cluster unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6887a92add8c832c990b9a49fe06dc83