### PR TITLE
Enable sandbox API mode with dummy secrets

### DIFF
--- a/.env.sandbox.example
+++ b/.env.sandbox.example
@@ -1,6 +1,5 @@
-API_KEY=dry_run_key
-BINANCE_KEY=dummy123
-BINANCE_SECRET=dummy123
 EXECUTION_MODE=sandbox
 REDIS_URL=redis://default:testpassword@redis:6379
 POSTGRES_URL=mocked
+EXTERNAL_API_KEY=dummy
+INTERNAL_TOKEN=test-token

--- a/api/index.js
+++ b/api/index.js
@@ -106,13 +106,18 @@ async function buildApp() {
         ping: async () => 'PONG',
       };
     } else {
-      pool = new Pool({
-        host: process.env.PGHOST || 'localhost',
-        port: process.env.PGPORT || 5432,
-        database: process.env.PGDATABASE || 'arbdb',
-        user: process.env.PGUSER || 'postgres',
-        password: process.env.PGPASSWORD || '',
-      });
+      if (process.env.EXECUTION_MODE === 'sandbox') {
+        console.log('[sandbox] API starting in dry-run mode (no DB, no trades)');
+        pool = { query: async () => ({ rows: [] }), end: async () => {} };
+      } else {
+        pool = new Pool({
+          host: process.env.PGHOST || 'localhost',
+          port: process.env.PGPORT || 5432,
+          database: process.env.PGDATABASE || 'arbdb',
+          user: process.env.PGUSER || 'postgres',
+          password: process.env.PGPASSWORD || '',
+        });
+      }
       const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
       try {
         const { hostname, port } = new URL(redisUrl);

--- a/api/routes/login.js
+++ b/api/routes/login.js
@@ -51,6 +51,14 @@ export default async function loginRoutes(app) {
       cookieOpts.secure = true;
     }
 
+    if (
+      process.env.EXECUTION_MODE === 'sandbox' &&
+      email === TEST_EMAIL &&
+      password === TEST_PASS
+    ) {
+      return reply.send({ token: 'test-token' });
+    }
+
     if ((dryRun || sandboxMode) && email === TEST_EMAIL && password === TEST_PASS) {
       const token = app.jwt.sign({
         email,

--- a/docs/environment-config.md
+++ b/docs/environment-config.md
@@ -6,6 +6,18 @@ The `.env.sandbox` file enables sandbox mode for local deployments.
 EXECUTION_MODE=sandbox
 REDIS_URL=redis://default:testpassword@redis:6379
 POSTGRES_URL=mocked
+EXTERNAL_API_KEY=dummy
+INTERNAL_TOKEN=test-token
 ```
 
 Use `cp .env.sandbox.example .env.sandbox` to start and then modify values as needed.
+
+## Sandbox Environment (.env.sandbox)
+
+Use this to run Prism Arbitrage in local dry-run mode:
+
+EXECUTION_MODE=sandbox
+REDIS_URL=redis://default:testpassword@redis:6379
+POSTGRES_URL=mocked
+EXTERNAL_API_KEY=dummy
+INTERNAL_TOKEN=test-token

--- a/docs/local-deployment.md
+++ b/docs/local-deployment.md
@@ -34,3 +34,20 @@ helm install arb ./infra/helm --values infra/helm/values.yaml
 ```
 
 The services will start in dry-run sandbox mode. The dashboard is available at `http://localhost:3000` on the VM.
+
+### API Sandbox Boot
+
+- When running in Kind, the API logs:
+  `[sandbox] API starting in dry-run mode (no DB, no trades)`
+- Redis must be available at:
+  `redis://default:testpassword@redis:6379`
+- Postgres is not required in this mode
+
+### Test Login
+
+To use the UI in sandbox:
+
+Email: admin@prism.one
+Password: test123
+
+Token returned: `test-token`

--- a/infra/k8s/prod-secrets.yaml
+++ b/infra/k8s/prod-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prod-secrets
+type: Opaque
+stringData:
+  EXECUTION_MODE: sandbox
+  REDIS_URL: redis://default:testpassword@redis:6379
+  POSTGRES_URL: mocked
+  EXTERNAL_API_KEY: dummy
+  INTERNAL_TOKEN: test-token


### PR DESCRIPTION
## Summary
- support EXECUTION_MODE=sandbox in API startup
- add fallback login token for sandbox UI usage
- provide prod-secrets.yaml for Kind
- document sandbox environment and login details
- update sandbox `.env` example

## Testing
- `npm test` *(root)*
- `npm test` *(api)* *(fails: Jest config issues)*
- `pytest` *(fails: tensorflow missing)*

------
https://chatgpt.com/codex/tasks/task_b_6887ad74bf14832c970bf5fa9ebb6443