### PR TITLE
Rewrite local development docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [batch-3] - Documentation Rewrite
+- Replaced README and docs for local deployment and secrets
+
 
 All notable changes to this project will be documented in this file.
 

--- a/README.md
+++ b/README.md
@@ -1,134 +1,50 @@
-# 🪙 Prism Arbitrage Platform
+# Prism Arbitrage
 
-![CI](https://github.com/QuantumFluxAlgo/crypto-arbitrage/actions/workflows/ci.yml/badge.svg)
-![Release](https://github.com/QuantumFluxAlgo/crypto-arbitrage/actions/workflows/release.yml/badge.svg)
-![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Sentry](https://img.shields.io/badge/sentry-monitoring-orange)
+Prism is a dry-run crypto trading platform built to run on Kubernetes. All services are containerized and deployed together using Helm. The default execution mode is `sandbox`, which processes mock trades while exercising the full control flow.
 
----
+This repository assumes development inside a Multipass Ubuntu VM. A local cluster is created with [kind](https://kind.sigs.k8s.io/) and images are loaded directly into the node. Secrets remain unsealed in the VM for simplicity.
 
-## Overview
+## Quick Start
 
-**Prism** is a Kubernetes based multi-agent platform for high frequency crypto arbitrage. A Node.js API and React dashboard drive operation while a Java executor performs trades and Python analytics expose performance metrics. Ten plus CEXs and four DEXs are supported via a Redis feed aggregator.
+```bash
+# inside the VM
+git clone <repo-url> ~/Documents/crypto-arbitrage
+cd ~/Documents/crypto-arbitrage
 
----
-
-## Quick Setup
-
-1. Clone the repository and install all tools:
-   ```bash
-   git clone https://github.com/prism-arbitrage/crypto-arbitrage.git
-   cd crypto-arbitrage
-   ./scripts/setup_env.sh
-   ```
-2. Run the full test suite:
-   ```bash
-   ./test/run-local.sh
-   ```
-3. Launch the local sandbox:
-   ```bash
-   ./scripts/start-sandbox.sh
-   ```
-  Open <http://localhost:5173> for the dashboard.
-
----
-
-## Local Sandbox Deployment
-
-For a full local cluster using Kind in Multipass, follow the guide in
-[docs/local-deployment.md](docs/local-deployment.md). It covers building the
-Docker images, loading them into your Kind node, and installing the Helm chart
-in dry-run mode.
-
----
-
-## Execution Modes
-
-- **DRY_RUN** – Local mock mode using ghost trades and fake wallets.
-- **SANDBOX** – Kubernetes deploy with sealed secrets but no live orders.
-- **LIVE** – Real trades; startup aborts if any required secrets are missing.
-
-### Test Login (Dry Run & Sandbox)
-
-When `DRY_RUN=true` or running the sandbox, the API exposes a fake login for testing.
-
-```text
-POST /api/login
-{ "email": "admin@prism.one", "password": "test123" }
+# copy dummy environment
+cp .env.sandbox.example .env.sandbox
 ```
 
-Use the returned JWT token for authenticated endpoints when testing locally or in the sandbox.
+Build the container images:
 
-`EXECUTION_MODE` controls the mode for every service.
+```bash
+docker build -t arb-api ./api
+docker build -t arb-dashboard ./dashboard
+docker build -t arb-executor ./executor
+docker build -t arb-feed-aggregator ./feed-aggregator
+docker build -t arb-analytics ./analytics
+```
 
----
+Create and prepare the cluster:
 
-## Feature Summary
+```bash
+kind create cluster --name prism
+kind load docker-image arb-api arb-dashboard arb-executor arb-feed-aggregator arb-analytics --name prism
+kubectl apply -f prod-secret.yaml
+```
 
-- Real time spread detection across 10+ CEXs and 4 DEXs
-- React SPA dashboard with mobile layout
-- Python analytics service with optional GPU acceleration
-- Secrets stored via SealedSecrets
-- Optional Prometheus and Grafana monitoring
-- Automatic cold wallet sweeps
+Deploy everything with Helm:
 
----
+```bash
+helm install prism ./infra/helm --values infra/helm/values.yaml
+```
 
-## API Overview
+The dashboard will be available at `http://localhost:3000` from the VM. Log in with the credentials defined in `.env.sandbox`.
 
-| Method | Path | Notes |
-|-------|------|------|
-| `GET` | `/opportunities` | Returns `{ opportunities: [...], executionMode: 'live', lastUpdated: 'ISO' }` |
-| `POST`/`PATCH` | `/settings` | Validated inputs update runtime config |
-| `POST` | `/panic` | Triggers a panic brake when allowed |
-| `POST` | `/resume` | Clears panic state. Live mode requires `confirm=true` |
-| `GET` | `/metrics` | Prometheus metrics including `pnl_total`, `sharpe_ratio` |
+## Documentation
 
-The API denies unauthenticated writes except when sandbox mode explicitly exposes them. `/resume` and `/panic` are guarded by the current execution mode.
-
----
-
-## Panic and Resume
-
-- Panic can be issued from the dashboard or `/panic` endpoint.
-- The executor listens on a Redis pub/sub channel and halts when `halt` is published.
-- Resuming trading shows a confirmation modal in the dashboard. The UI polls until the backend replies with `{ status: 'resumed', confirmed: true, mode: 'live' }`.
-- In live mode, missing `confirm=true` results in `{ error: 'confirmation_required' }`.
-
----
-
-## Cold Wallet Sweeps
-
-Profit is swept to a cold wallet when either of the following is met:
-
-- Profit ≥ £5,000
-- Profit ≥ 30% of total capital
-
-In DRY_RUN or SANDBOX mode the sweeper logs the action without moving funds:
-`{"event":"cold_wallet_sweep","mode":"DRY_RUN",...}`.
-
----
-
-## Metrics
-
-The analytics service exposes fresh Prometheus metrics at `/metrics`. Key series include:
-
-- `pnl_total` – cumulative realised PnL
-- `sharpe_ratio` – strategy sharpe ratio
-- `panic_triggered_total` – count of panic events
-
-Metrics are labelled by execution mode and scraped by Prometheus.
-
----
-
-## Contribution Flow
-
-1. Create branches as `fix/pr-##-<area>` (replace `##` with the issue number).
-2. Commit messages follow the style `fix(api): panic route guards updated`.
-3. Run `./test/run-local.sh` before pushing and open a PR against `develop`.
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for full guidelines.
-
----
+- [Environment Configuration](docs/environment-config.md)
+- [Local Deployment Guide](docs/local-deployment.md)
+- [Secrets Reference](docs/secrets-reference.md)
 
 Released under the [MIT](LICENSE) license.

--- a/docs/environment-config.md
+++ b/docs/environment-config.md
@@ -1,6 +1,12 @@
 # Environment Configuration
 
-The `.env.sandbox` file enables sandbox mode for local deployments.
+All local development uses the `.env.sandbox` file found in the repository root. Copy the example to start:
+
+```bash
+cp .env.sandbox.example .env.sandbox
+```
+
+Default values:
 
 ```env
 EXECUTION_MODE=sandbox
@@ -10,14 +16,6 @@ EXTERNAL_API_KEY=dummy
 INTERNAL_TOKEN=test-token
 ```
 
-Use `cp .env.sandbox.example .env.sandbox` to start and then modify values as needed.
+Edit these values if needed. The sandbox mode does not connect to a real database. Redis requires the password `testpassword` and is exposed only inside the cluster.
 
-## Sandbox Environment (.env.sandbox)
-
-Use this to run Prism Arbitrage in local dry-run mode:
-
-EXECUTION_MODE=sandbox
-REDIS_URL=redis://default:testpassword@redis:6379
-POSTGRES_URL=mocked
-EXTERNAL_API_KEY=dummy
-INTERNAL_TOKEN=test-token
+Resource requests in `infra/helm/values.yaml` are already tuned for kind (10m CPU, 64Mi memory). Adjust them only if your VM has more capacity.

--- a/docs/local-deployment.md
+++ b/docs/local-deployment.md
@@ -1,53 +1,54 @@
-# Local Sandbox Deployment
+# Local Deployment Guide
 
-This guide walks through running the Prism platform entirely locally using Kind inside a Multipass VM.
+These instructions run the entire stack in sandbox mode inside a Multipass Ubuntu VM. The Kubernetes cluster uses [kind](https://kind.sigs.k8s.io/) and the services are installed with [Helm](https://helm.sh/).
 
-## 1. Build Docker Images
+## 1. Install Prerequisites
 
-```bash
-# from repository root
-podman build -t api-local ./api
-podman build -t arb-dashboard ./dashboard
-podman build -t arb-executor ./executor
-podman build -t arb-feed-aggregator ./feed-aggregator
-podman build -t arb-analytics ./analytics
-```
+Inside the VM install Docker, kind, kubectl and Helm. Use your package manager or download the official binaries.
 
-## 2. Load Images into Kind
+## 2. Build Images
+
+Run these commands from the repository root:
 
 ```bash
-kind load docker-image api-local arb-dashboard arb-executor arb-feed-aggregator arb-analytics --name prism
+docker build -t arb-api ./api
+docker build -t arb-dashboard ./dashboard
+docker build -t arb-executor ./executor
+docker build -t arb-feed-aggregator ./feed-aggregator
+docker build -t arb-analytics ./analytics
 ```
 
-## 3. Apply Dummy Secrets
+## 3. Create the Cluster
 
-Create a file `prod-secret.yaml` with the Redis password and any other dummy values you require. Apply it before installing the chart:
+```bash
+kind create cluster --name prism
+```
+
+## 4. Load Images
+
+```bash
+kind load docker-image arb-api arb-dashboard arb-executor arb-feed-aggregator arb-analytics --name prism
+```
+
+## 5. Apply Secrets
+
+Edit `prod-secret.yaml` and replace each value with a safe dummy string. Then apply it:
 
 ```bash
 kubectl apply -f prod-secret.yaml
 ```
 
-## 4. Deploy the Helm Chart
+## 6. Deploy with Helm
 
 ```bash
-helm install arb ./infra/helm --values infra/helm/values.yaml
+helm install prism ./infra/helm --values infra/helm/values.yaml
 ```
 
-The services will start in dry-run sandbox mode. The dashboard is available at `http://localhost:3000` on the VM.
+After a short wait the dashboard will be reachable at `http://localhost:3000`. Services run with low resource requests so they fit easily on the kind node.
 
-### API Sandbox Boot
+To remove everything:
 
-- When running in Kind, the API logs:
-  `[sandbox] API starting in dry-run mode (no DB, no trades)`
-- Redis must be available at:
-  `redis://default:testpassword@redis:6379`
-- Postgres is not required in this mode
-
-### Test Login
-
-To use the UI in sandbox:
-
-Email: admin@prism.one
-Password: test123
-
-Token returned: `test-token`
+```bash
+helm uninstall prism
+kind delete cluster --name prism
+```

--- a/docs/secrets-reference.md
+++ b/docs/secrets-reference.md
@@ -1,0 +1,29 @@
+# Secrets Reference
+
+Local deployments use an unsealed Kubernetes secret named `prod-secrets`. The file `prod-secret.yaml` contains placeholder values and should never be committed with real credentials.
+
+Example contents:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prod-secrets
+  namespace: default
+type: Opaque
+stringData:
+  BINANCE_KEY: dummy-key
+  BINANCE_SECRET: dummy-secret
+  SMTP_USER: user@example.com
+  SMTP_PASS: pass123
+  JWT_SECRET: changeme
+  WALLET_ADDRESS: test-wallet
+```
+
+Apply it before deploying the chart:
+
+```bash
+kubectl apply -f prod-secret.yaml
+```
+
+For production, seal the secret with `kubeseal` and commit the resulting `sealed-secret.yaml` instead. The sandbox `.env.sandbox` file holds matching dummy tokens for the API and dashboard.


### PR DESCRIPTION
## Summary
- overhaul README for sandbox development with kind
- rewrite environment configuration doc
- rewrite local deployment doc
- add secrets reference doc
- note doc changes in changelog

## Testing
- `DRY_RUN=true bash test/run-local.sh` *(fails: `helm` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6887b0a9428c832ca438cdf7822ed8e9