### PR TITLE
feat: add consistency UI card

### DIFF
--- a/packages/ui-consistency/__tests__/format.spec.ts
+++ b/packages/ui-consistency/__tests__/format.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { formatConsistency, percent } from '../src/format';
+
+describe('formatConsistency', () => {
+  it('formats eligible, totals and ratios', () => {
+    const r = formatConsistency({
+      window: 8,
+      totalPnL: 1420,
+      bestDayPnL: 410,
+      bestDayShare: 410/1420,
+      profitDayCount: 7,
+      eligible: true,
+      days: []
+    } as any);
+    expect(r.eligibleText).toBe('Eligible');
+    expect(r.totalPnLText).toBe('$1420.00');
+    expect(r.bestDayPctText).toBe('28.9%');
+    expect(r.profitDaysText).toBe('7/8');
+  });
+
+  it('percent helper', () => {
+    expect(percent(0.3)).toBe('30.0%');
+    expect(percent(NaN)).toBe('0%');
+  });
+});

--- a/packages/ui-consistency/package.json
+++ b/packages/ui-consistency/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@prism-apex-tool/ui-consistency",
+  "private": true,
+  "type": "commonjs",
+  "version": "0.0.1",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/ui-consistency/src/ConsistencyCard.tsx
+++ b/packages/ui-consistency/src/ConsistencyCard.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { useConsistency } from './useConsistency';
+import { formatConsistency } from './format';
+
+export interface ConsistencyCardProps {
+  endpoint?: string;   // default '/report/consistency'
+  windowSize?: number; // default 8
+  title?: string;      // default 'Payout Consistency'
+}
+
+export function ConsistencyCard(props: ConsistencyCardProps) {
+  const endpoint = props.endpoint ?? '/report/consistency';
+  const windowSize = props.windowSize ?? 8;
+  const title = props.title ?? 'Payout Consistency';
+  const { data, status, error } = useConsistency(endpoint, windowSize);
+
+  const box: React.CSSProperties = {
+    border: '1px solid #e5e7eb', borderRadius: 12, padding: 16,
+    display: 'flex', flexDirection: 'column', gap: 8, background: '#fff'
+  };
+  const row: React.CSSProperties = { display: 'flex', justifyContent: 'space-between', gap: 12 };
+  const pill = (ok: boolean): React.CSSProperties => ({
+    padding: '2px 8px', borderRadius: 999, fontSize: 12,
+    color: ok ? '#065f46' : '#991b1b',
+    background: ok ? '#d1fae5' : '#fee2e2',
+    border: `1px solid ${ok ? '#10b981' : '#ef4444'}`
+  });
+  const sub: React.CSSProperties = { color: '#6b7280', fontSize: 12 };
+
+  if (status === 'loading' || status === 'idle') {
+    return <div style={box}><div style={row}><strong>{title}</strong><span style={sub}>Loading…</span></div></div>;
+  }
+  if (status === 'error') {
+    return <div style={box}><div style={row}><strong>{title}</strong><span style={sub}>Error</span></div><code style={{fontSize:12,color:'#991b1b'}}>{error}</code></div>;
+  }
+  if (status === 'empty' || !data) {
+    return <div style={box}>
+      <div style={row}><strong>{title}</strong><span style={pill(false)}>No Data</span></div>
+      <div style={sub}>Add daily PnL to <code>var/pnl/daily.json</code> to see eligibility.</div>
+    </div>;
+  }
+
+  const f = formatConsistency(data);
+  const list: React.CSSProperties = { listStyle: 'none', padding: 0, margin: 0, display:'grid', gap:6 };
+
+  return (
+    <div style={box}>
+      <div style={row}>
+        <strong>{title}</strong>
+        <span style={pill(data.eligible)}>{f.eligibleText}</span>
+      </div>
+
+      <ul style={list}>
+        <li style={row}><span>Total PnL (last {data.window}d)</span><strong>{f.totalPnLText}</strong></li>
+        <li style={row}><span>Best Day % of Total</span><strong>{f.bestDayPctText}</strong></li>
+        <li style={row}><span>Profit Days</span><strong>{f.profitDaysText}</strong></li>
+      </ul>
+
+      {data.days?.length ? (
+        <div style={{marginTop:8}}>
+          <div style={sub}>Recent PnL</div>
+          <ul style={{...list, gridTemplateColumns:'repeat(4, minmax(0,1fr))'}}>
+            {data.days.slice(-8).map(d => (
+              <li key={d.date} style={{ textAlign:'center', padding:6, border:'1px solid #e5e7eb', borderRadius:8, background:'#f9fafb' }}>
+                <div style={{fontSize:12, color:'#6b7280'}}>{d.date.slice(5)}</div>
+                <div style={{fontWeight:600, color: d.pnl>=0 ? '#065f46' : '#991b1b'}}>
+                  {d.pnl>=0 ? '+' : '-'}${Math.abs(d.pnl).toFixed(0)}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default ConsistencyCard;

--- a/packages/ui-consistency/src/format.ts
+++ b/packages/ui-consistency/src/format.ts
@@ -1,0 +1,21 @@
+import type { ConsistencyResult } from './types';
+
+export function percent(n: number, decimals = 1): string {
+  if (!Number.isFinite(n)) return '0%';
+  return `${(n * 100).toFixed(decimals)}%`;
+}
+
+export function formatConsistency(r: ConsistencyResult) {
+  return {
+    eligibleText: r.eligible ? 'Eligible' : 'Not eligible',
+    totalPnLText: currency(r.totalPnL),
+    bestDayPctText: percent(r.bestDayPnL > 0 && r.totalPnL > 0 ? r.bestDayPnL / r.totalPnL : 0),
+    profitDaysText: `${r.profitDayCount}/${r.window}`,
+  };
+}
+
+function currency(n: number): string {
+  const sign = n < 0 ? '-' : '';
+  const v = Math.abs(n);
+  return `${sign}$${v.toFixed(2)}`;
+}

--- a/packages/ui-consistency/src/index.ts
+++ b/packages/ui-consistency/src/index.ts
@@ -1,0 +1,3 @@
+export * from './ConsistencyCard';
+export * from './useConsistency';
+export * from './types';

--- a/packages/ui-consistency/src/types.ts
+++ b/packages/ui-consistency/src/types.ts
@@ -1,0 +1,10 @@
+export interface DailyPnL { date: string; pnl: number }
+export interface ConsistencyResult {
+  window: number;
+  totalPnL: number;
+  bestDayPnL: number;
+  bestDayShare: number; // 0..1
+  profitDayCount: number;
+  eligible: boolean;
+  days: DailyPnL[];
+}

--- a/packages/ui-consistency/src/useConsistency.ts
+++ b/packages/ui-consistency/src/useConsistency.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import type { ConsistencyResult } from './types';
+
+export function useConsistency(endpoint = '/report/consistency', windowSize = 8) {
+  const [data, setData] = useState<ConsistencyResult | null>(null);
+  const [status, setStatus] = useState<'idle'|'loading'|'ok'|'empty'|'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    async function run() {
+      setStatus('loading');
+      setError(null);
+      try {
+        const res = await fetch(`${endpoint}?window=${windowSize}`, { method: 'GET' });
+        if (res.status === 204) {
+          if (alive) { setStatus('empty'); setData(null); }
+          return;
+        }
+        if (!res.ok) {
+          const txt = await res.text().catch(() => res.statusText);
+          throw new Error(txt || `HTTP ${res.status}`);
+        }
+        const json = await res.json();
+        if (alive) { setData(json); setStatus('ok'); }
+      } catch (e:any) {
+        if (alive) { setError(String(e?.message ?? e)); setStatus('error'); }
+      }
+    }
+    run();
+    return () => { alive = false; };
+  }, [endpoint, windowSize]);
+
+  return { data, status, error };
+}


### PR DESCRIPTION
## Summary
- add reusable ConsistencyCard component for payout eligibility
- include format helpers, fetch hook, and types
- provide simple unit test for formatter

## Testing
- `pnpm --filter @prism-apex-tool/ui-consistency typecheck` (fails: None of the selected packages has a "typecheck" script)
- `pnpm --filter @prism-apex-tool/ui-consistency test` (no output; script missing)


------
https://chatgpt.com/codex/tasks/task_b_68b1cdcb6e10832cad3536bd65115f20