### PR TITLE
fix(ui-consistency): add React typings for tsc

### DIFF
--- a/packages/ui-consistency/package.json
+++ b/packages/ui-consistency/package.json
@@ -14,5 +14,11 @@
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --reporter=verbose"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "5.4.5",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/ui-consistency/tsconfig.json
+++ b/packages/ui-consistency/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["ES2022", "DOM"]
+    "lib": ["ES2022", "DOM"],
+    "types": ["vitest/globals", "react", "react-dom"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "__tests__/**/*.ts", "__tests__/**/*.tsx"],
   "exclude": ["node_modules", "dist", "build"]


### PR DESCRIPTION
## Summary
- add React, TypeScript, and Vitest typings for ui-consistency package
- expose Vitest and React type definitions in tsconfig

## Testing
- `pnpm --filter @prism-apex-tool/ui-consistency install`
- `pnpm --filter @prism-apex-tool/ui-consistency typecheck`
- `pnpm --filter @prism-apex-tool/ui-consistency test`


------
https://chatgpt.com/codex/tasks/task_b_68b1de0b08f8832cb4fc6af312b7c117